### PR TITLE
fix: make snapshot imports durable and convergent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,14 +62,15 @@ jobs:
 
       - name: Enforce coverage gate
         shell: bash
+        env:
+          MINIMUM_COVERAGE: '100.0'
         run: |
           set -euo pipefail
           total="$(
             go tool cover -func=coverage.out |
               awk '/^total:/ { gsub("%", "", $3); print $3 }'
           )"
-          awk -v total="$total" 'BEGIN {
-            minimum = 65.0
+          awk -v total="$total" -v minimum="$MINIMUM_COVERAGE" 'BEGIN {
             if (total + 0 < minimum) {
               printf "coverage %.1f%% is below %.1f%%\n", total, minimum
               exit 1

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ go test -run '^$' -bench 'IDSetLoadMillion' -benchmem ./src/cache
 ```
 
 Pull requests run formatting, module consistency, vet, race detection, unit and
-PostgreSQL integration tests, and a coverage gate. The separate E2E workflow
+PostgreSQL integration tests, and a 100% statement coverage gate. The separate E2E workflow
 uses deterministic fixtures on GitHub-hosted `ubuntu-latest`; it does not depend
 on live Discogs availability.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ dump: missing relations are deleted, changed mutable values are updated, and
 unchanged relation rows retain their identifiers. Root artist, label, master,
 and release rows are upserted; roots absent from a later dump are not currently
 deleted. The importer assumes official dump root identifiers are unique.
+The v1 schema still identifies several relation values with a 32-bit Java hash;
+a collision within one root can merge distinct values. The measured, online
+migration to collision-resistant identity is tracked in
+[`open-discogs-model#43`](https://github.com/dsub-io/open-discogs-model/issues/43).
 
 Atomicity is per chunk, not per monthly snapshot. Permanent full-dump staging is
 intentionally avoided because it would duplicate a catalog exceeding 200

--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ Discogs. The Discogs name identifies only the public data source.
   independently unless an exact `--dump-month` is requested.
 - Every run records the selected dump dates, SHA-256 checksums, source URIs,
   sizes, and stable identifiers as one immutable manifest.
-- A manifest that already succeeded is skipped. `--force` reruns that same
-  manifest without changing the idempotent database result.
+- A successful manifest is admitted and skipped before dump files are downloaded
+  or checksummed only while all of its entity dumps are still the current
+  checkpoints and no later failed or abandoned run has dirtied those entities.
+  `--force` reruns that same manifest without changing the normalized database
+  result.
+- A failed or abandoned run resumes only when the manifest, processor name and
+  version, entity/dump identity, and chunk size all match exactly. A different
+  manifest or `--force` starts at zero.
+- Each tracked convergence chunk writes its canonical roots, exact relations,
+  committed-chunk ledger, and item counter in one PostgreSQL transaction. A
+  retry skips only source ranges represented by valid committed chunk rows.
 - An older entity dump is rejected unless `--allow-downgrade` is supplied; the
   override is recorded in import history.
 - PostgreSQL advisory locks prevent concurrent runs from updating an overlapping
@@ -27,6 +36,46 @@ Discogs. The Discogs name identifies only the public data source.
 
 If the upstream catalog refresh fails, the importer tries the catalog already
 stored in PostgreSQL. It fails if that catalog cannot satisfy the request.
+
+### Durability and idempotency boundaries
+
+`SIGINT` and `SIGTERM` cancel download, parsing, and database work. The active
+chunk transaction rolls back, while run failure is recorded with a separate
+bounded completion context. `SIGKILL`, host loss, or a database disconnect can
+leave a run marked `running`; the next process acquires the entity locks, marks
+that abandoned run failed, and transfers its valid ledger in one transaction.
+If ledger transfer fails, the new run and copied rows roll back together and the
+source ledger remains authoritative.
+
+Every canonical and tracked chunk fences against the owning run row before it
+can commit. Once an abandoned run is marked failed, a delayed worker can no
+longer commit canonical data, progress, or entity completion. If an in-flight
+chunk obtains the fence first, abandonment waits for that atomic commit and the
+next run transfers the resulting ledger entry.
+
+An entity is complete only when chunk indexes cover the parsed stream without
+gaps, overlaps, or out-of-range indexes and both chunk and item totals match.
+The whole run becomes successful only after every selected entity is complete.
+Failed ledgers are retained until the current successful checkpoints, produced
+by the same processor version, supersede every entity/dump pair in the failed
+run. Historical success rows alone never authorize pruning. A failed ledger is
+also not resumed when a newer successful checkpoint with different dump or
+processor identity has overwritten one of its entity ranges. These rules
+prevent an Artist-only run from deleting the only valid resume state for a
+failed Artist+Release run or mixing ranges from different snapshots.
+
+Relations owned by each imported root are reconciled to the exact set in the
+dump: missing relations are deleted, changed mutable values are updated, and
+unchanged relation rows retain their identifiers. Root artist, label, master,
+and release rows are upserted; roots absent from a later dump are not currently
+deleted. The importer assumes official dump root identifiers are unique.
+
+Atomicity is per chunk, not per monthly snapshot. Permanent full-dump staging is
+intentionally avoided because it would duplicate a catalog exceeding 200
+million records. Readers can therefore observe already committed chunks while
+an import is running. Deployments that require an all-at-once snapshot switch
+must put a separate versioned database or replica promotion boundary around the
+import.
 
 ## Requirements
 
@@ -104,6 +153,55 @@ release-to-master update also changes up to 5,000 row-by-row SQL statements at
 the default chunk size into one set-based statement. These figures isolate the
 measured operations; end-to-end import throughput still depends on dump shape,
 PostgreSQL, storage, and runtime limits.
+
+### Measured durable-import cost and skip improvement
+
+The tracked production path was measured before and after the recovery fixes
+against commit `2a1ddbd` on the same Apple M2 Pro, PostgreSQL 18.4 Alpine tmpfs
+container, four 3-record fixture dumps, `chunk-size=5`, `max-workers=2`, one
+import per sample, and 20 samples. Output was suppressed identically. Initial
+import latency changed from p50/p95/p99 `48.509/54.527/80.881 ms` to
+`73.922/77.397/88.551 ms` (`52.4%/41.9%/9.5%` higher). Median throughput changed
+from `0.167` to `0.109 MB/s` (`34.4%` lower), allocated bytes from 2,327,712 to
+2,454,276 B/op (`5.4%` higher), and allocations from 43,524 to 44,333/op (`1.9%`
+higher).
+
+Forced-repeat latency changed from p50/p95/p99 `38.864/43.826/44.841 ms` to
+`72.822/74.057/74.204 ms` (`87.4%/69.0%/65.5%` higher). Median throughput changed
+from `0.208` to `0.111 MB/s` (`46.6%` lower), allocated bytes from 2,340,796 to
+2,466,576 B/op (`5.4%` higher), and allocations from 44,597 to 45,990/op (`3.1%`
+higher). The added cost buys current-checkpoint validation and a database fence
+that prevents delayed workers from committing after abandonment. This tiny
+12-record fixture exaggerates fixed transaction cost and is not a full-dataset
+throughput estimate.
+
+Fresh tracked relation chunks use one SQL statement for the active-run fence,
+ledger insert, and summary update. Resumed chunks add one exact-ledger lookup.
+The Artist and Label canonical pre-seed phase adds one active-run fence per
+chunk because those roots must exist before forward relations are reconciled.
+
+The production no-op path was measured separately with the same successful
+manifest and a cached 64 MiB sparse file. Checksum-before-admission latency was
+p50/p95/p99 `38.917/50.768/58.719 ms`; admission-before-checksum was
+`1.776/2.728/3.038 ms`, a `95.4%/94.6%/94.8%` reduction and `21.9x` median
+speedup. Median allocations changed from 40,008 to 6,800 B/op (`83.0%` lower)
+and 113 to 106 allocations/op (`6.2%` lower), while 64 MiB of file I/O was
+avoided per invocation.
+
+Peak RSS was not reported from these microbenchmarks because it would include
+the test process and container lifecycle while the 12-record fixture is too
+small to represent production heap pressure. Allocation counts are reported
+instead; production sizing still requires a heap/RSS profile from a
+representative large dump under the intended `chunk-size` and `max-workers`.
+
+Reproduce the focused measurements with:
+
+```shell
+go test ./src/batch -run '^$' \
+  -bench '^BenchmarkDurableBatchImport$' -benchtime=1x -count=20 -benchmem
+go test ./src/batch -run '^$' \
+  -bench '^BenchmarkCompletedManifestPreflight$' -benchtime=1x -count=20 -benchmem
+```
 
 ## Container
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Discogs. The Discogs name identifies only the public data source.
   retry skips only source ranges represented by valid committed chunk rows.
 - An older entity dump is rejected unless `--allow-downgrade` is supplied; the
   override is recorded in import history.
-- PostgreSQL advisory locks prevent concurrent runs from updating an overlapping
-  entity set. Runs with disjoint entity sets may proceed together.
+- PostgreSQL advisory locks cover both selected entities and their reference
+  dependencies. Master locks Artist and Master; Release locks Artist, Label,
+  Master, and Release because it also updates `master.main_release_id`.
+  Independent sets such as Artist and Label may still proceed together.
 - Downloads are retained by default. `--cleanup` deletes only the selected dump
   files after a successful import or successful-manifest skip. Failed imports
   retain their files for retry.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,20 @@ const versionPrintPrefix = "go-open-discogs-batch"
 
 var version string
 var conf = koanf.New(".")
+var runBatch = func(ctx context.Context, config *koanf.Koanf, releaseVersion string) error {
+	return (&batch.Runner{Version: releaseVersion}).Run(ctx, config)
+}
+var loadEnvironmentConfig = loadEnvironment
+var loadFlagConfig = func(flags *pflag.FlagSet, k *koanf.Koanf) error {
+	return k.Load(posflag.Provider(flags, ".", k), nil)
+}
+var normalizeEntityConfig = func(k *koanf.Koanf) error { return normalizeEntities(k) }
+var setEntityListConfig = func(k *koanf.Koanf, entities []string) error {
+	return k.Set("entities", entities)
+}
+var setEntitySelectionConfig = func(k *koanf.Koanf, key string, selected bool) error {
+	return k.Set(key, selected)
+}
 
 var environmentOptionNames = map[string]string{
 	"DATABASE_URL":    "database-url",
@@ -87,7 +101,7 @@ var getMainFunc = func() func(cmd *cobra.Command, args []string) error {
 		if err := new(validator).Validate(conf); err != nil {
 			return err
 		}
-		return (&batch.Runner{Version: version}).Run(cmd.Context(), conf)
+		return runBatch(cmd.Context(), conf, version)
 	}
 }
 
@@ -102,13 +116,13 @@ func load(flags *pflag.FlagSet, k *koanf.Koanf) error {
 	if ok, _ := flags.GetBool("version"); ok {
 		return nil
 	}
-	if err := loadEnvironment(k); err != nil {
+	if err := loadEnvironmentConfig(k); err != nil {
 		return err
 	}
-	if err := k.Load(posflag.Provider(flags, ".", k), nil); err != nil {
+	if err := loadFlagConfig(flags, k); err != nil {
 		return err
 	}
-	return normalizeEntities(k)
+	return normalizeEntityConfig(k)
 }
 
 func loadEnvironment(k *koanf.Koanf) error {
@@ -149,11 +163,11 @@ func normalizeEntities(k *koanf.Koanf) error {
 		selected[normalized] = true
 		entities = append(entities, normalized)
 	}
-	if err := k.Set("entities", entities); err != nil {
+	if err := setEntityListConfig(k, entities); err != nil {
 		return err
 	}
 	for _, entity := range []string{"artist", "label", "master", "release"} {
-		if err := k.Set(entity+"s", selected[entity]); err != nil {
+		if err := setEntitySelectionConfig(k, entity+"s", selected[entity]); err != nil {
 			return err
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/dsub-io/go-open-discogs-batch/src/batch"
 	"github.com/knadh/koanf"
@@ -42,7 +44,9 @@ var booleanEnvironmentOptions = map[string]struct{}{
 }
 
 func Execute() error {
-	return NewRootCommand().Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return NewRootCommand().ExecuteContext(ctx)
 }
 
 func NewRootCommand() *cobra.Command {
@@ -83,7 +87,7 @@ var getMainFunc = func() func(cmd *cobra.Command, args []string) error {
 		if err := new(validator).Validate(conf); err != nil {
 			return err
 		}
-		return (&batch.Runner{Version: version}).Run(context.Background(), conf)
+		return (&batch.Runner{Version: version}).Run(cmd.Context(), conf)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/knadh/koanf"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,4 +93,117 @@ func (failingHomeDirSupplier) HomeUserDir() (string, error) {
 
 func TestGetHomeDirPanics(t *testing.T) {
 	require.Panics(t, func() { getHomeDir(failingHomeDirSupplier{}) })
+}
+
+func TestExecuteUsesProcessArguments(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"go-open-discogs-batch", "--version"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	require.NoError(t, Execute())
+}
+
+func TestMainFunctionValidatesAndDelegates(t *testing.T) {
+	originalRunBatch := runBatch
+	t.Cleanup(func() { runBatch = originalRunBatch })
+	invalidConfig := koanf.New(".")
+	require.NoError(t, invalidConfig.Set("database-url", "://invalid"))
+	require.Error(t, originalRunBatch(context.Background(), invalidConfig, "test"))
+
+	called := false
+	runBatch = func(ctx context.Context, config *koanf.Koanf, releaseVersion string) error {
+		called = true
+		require.NotNil(t, ctx)
+		return nil
+	}
+
+	command := NewRootCommand()
+	command.SetArgs([]string{
+		"--database-url", "postgresql://user:pass@db:5432/discogs",
+		"--entities", "artist",
+	})
+	require.NoError(t, command.Execute())
+	require.True(t, called)
+
+	command = NewRootCommand()
+	command.SetArgs([]string{"--entities", "artist"})
+	require.ErrorContains(t, command.Execute(), "database-url")
+}
+
+func TestPrintableVersion(t *testing.T) {
+	originalVersion := version
+	t.Cleanup(func() { version = originalVersion })
+	version = "  "
+	require.Equal(t, "development", printableVersion())
+	version = "1.2.3"
+	require.Equal(t, "1.2.3", printableVersion())
+}
+
+func TestLoadPropagatesEachStageFailure(t *testing.T) {
+	originalEnvironment := loadEnvironmentConfig
+	originalFlags := loadFlagConfig
+	originalNormalize := normalizeEntityConfig
+	t.Cleanup(func() {
+		loadEnvironmentConfig = originalEnvironment
+		loadFlagConfig = originalFlags
+		normalizeEntityConfig = originalNormalize
+	})
+	flags := pflag.NewFlagSet("fixture", pflag.ContinueOnError)
+	flags.Bool("version", false, "")
+	config := koanf.New(".")
+	expected := errors.New("fixture")
+
+	loadEnvironmentConfig = func(*koanf.Koanf) error { return expected }
+	require.ErrorIs(t, load(flags, config), expected)
+
+	loadEnvironmentConfig = originalEnvironment
+	loadFlagConfig = func(*pflag.FlagSet, *koanf.Koanf) error { return expected }
+	require.ErrorIs(t, load(flags, config), expected)
+
+	loadFlagConfig = originalFlags
+	normalizeEntityConfig = func(*koanf.Koanf) error { return expected }
+	require.ErrorIs(t, load(flags, config), expected)
+}
+
+func TestNormalizeEntitiesPropagatesSetFailures(t *testing.T) {
+	originalList := setEntityListConfig
+	originalSelection := setEntitySelectionConfig
+	t.Cleanup(func() {
+		setEntityListConfig = originalList
+		setEntitySelectionConfig = originalSelection
+	})
+	config := koanf.New(".")
+	require.NoError(t, config.Set("entities", []string{"artist"}))
+	expected := errors.New("set failure")
+
+	setEntityListConfig = func(*koanf.Koanf, []string) error { return expected }
+	require.ErrorIs(t, normalizeEntities(config), expected)
+
+	setEntityListConfig = originalList
+	setEntitySelectionConfig = func(*koanf.Koanf, string, bool) error { return expected }
+	require.ErrorIs(t, normalizeEntities(config), expected)
+}
+
+func TestLoadEnvironmentHandlesUnknownAndBooleanSpellings(t *testing.T) {
+	t.Setenv(Prefix+"UNKNOWN", "ignored")
+	t.Setenv(Prefix+"CLEANUP", "off")
+	t.Setenv(Prefix+"FORCE", "1")
+	t.Setenv(Prefix+"ALLOW_DOWNGRADE", "invalid")
+	config := koanf.New(".")
+
+	require.NoError(t, loadEnvironment(config))
+	require.False(t, config.Exists("unknown"))
+	require.False(t, config.Bool("cleanup"))
+	require.True(t, config.Bool("force"))
+	require.Equal(t, "invalid", config.String("allow-downgrade"))
+}
+
+func TestNormalizeEntitiesDropsBlankAndDuplicateValues(t *testing.T) {
+	config := koanf.New(".")
+	require.NoError(t, config.Set("entities", []string{"", "Artists", "artist", " RELEASES "}))
+
+	require.NoError(t, normalizeEntities(config))
+	require.Equal(t, []string{"artist", "release"}, config.Strings("entities"))
+	require.True(t, config.Bool("artists"))
+	require.True(t, config.Bool("releases"))
 }

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -70,3 +70,40 @@ func TestValidator(t *testing.T) {
 	require.NoError(t, config.Set("entities", []string{"unknown"}))
 	require.ErrorContains(t, new(validator).Validate(config), "unknown entities")
 }
+
+func TestValidatorReportsEveryConfigurationBoundary(t *testing.T) {
+	valid := func() *koanf.Koanf {
+		config := koanf.New(".")
+		require.NoError(t, config.Set("database-url", "postgresql://user:pass@db:5432/discogs"))
+		require.NoError(t, config.Set("entities", []string{"artist"}))
+		require.NoError(t, config.Set("chunk-size", 5000))
+		require.NoError(t, config.Set("max-workers", 4))
+		return config
+	}
+
+	config := valid()
+	require.NoError(t, config.Set("cleanup", "invalid"))
+	require.ErrorContains(t, new(validator).Validate(config), "must be a boolean")
+
+	config = valid()
+	require.NoError(t, config.Set("dump-month", "invalid"))
+	require.ErrorContains(t, new(validator).Validate(config), "dump-month")
+
+	config = valid()
+	require.NoError(t, config.Set("database-url", "mysql://user:pass@db/catalog"))
+	require.ErrorContains(t, new(validator).Validate(config), "database-url")
+
+	config = valid()
+	require.NoError(t, config.Set("chunk-size", 0))
+	require.ErrorContains(t, new(validator).Validate(config), "chunk-size")
+
+	config = valid()
+	require.NoError(t, config.Set("max-workers", 0))
+	require.ErrorContains(t, new(validator).Validate(config), "max-workers")
+}
+
+func TestValidDatabaseURLRequiresPasswordHostAndDatabase(t *testing.T) {
+	require.ErrorContains(t, ValidDatabaseURL("postgresql://user@db/catalog"), "username and password")
+	require.ErrorContains(t, ValidDatabaseURL("postgresql://user:pass@/catalog"), "host and database")
+	require.ErrorContains(t, ValidDatabaseURL("postgresql://user:pass@db"), "host and database")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/knadh/koanf v1.5.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
+	github.com/moby/moby/api v1.55.0
 	github.com/reactivex/rxgo/v2 v2.5.0
 	github.com/schollz/progressbar/v3 v3.19.1
 	github.com/sirupsen/logrus v1.9.4
@@ -25,7 +26,6 @@ require (
 	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.3.0 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dsub-io/go-open-discogs-batch
 go 1.26
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/knadh/koanf v1.5.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsub-io/open-discogs-model v0.2.0
+	github.com/dsub-io/open-discogs-model v0.2.1
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsub-io/open-discogs-model v0.1.2
+	github.com/dsub-io/open-discogs-model v0.2.0
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -54,7 +54,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.10.0 // indirect
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -210,6 +212,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/knadh/koanf v1.5.0 h1:q2TSd/3Pyc/5yP9ldIrSdIz26MCcyNQzW0pEAugLPNs=

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dsub-io/open-discogs-model v0.2.0 h1:J89ZdKkY0/z6ZFCCK81MmZ3M+B4czdGA9GJJRkcg3s8=
 github.com/dsub-io/open-discogs-model v0.2.0/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
+github.com/dsub-io/open-discogs-model v0.2.1 h1:v5Yis29dv3P9ImXBrYm8TJrI53SGcLjpvJ7ZrMYS63k=
+github.com/dsub-io/open-discogs-model v0.2.1/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dsub-io/open-discogs-model v0.2.0 h1:J89ZdKkY0/z6ZFCCK81MmZ3M+B4czdGA9GJJRkcg3s8=
-github.com/dsub-io/open-discogs-model v0.2.0/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dsub-io/open-discogs-model v0.2.1 h1:v5Yis29dv3P9ImXBrYm8TJrI53SGcLjpvJ7ZrMYS63k=
 github.com/dsub-io/open-discogs-model v0.2.1/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dsub-io/open-discogs-model v0.1.2 h1:LTC5fmdLKtOsMfTa/QLeEyqglWaCfQjuOa0SH21EdvI=
-github.com/dsub-io/open-discogs-model v0.1.2/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
+github.com/dsub-io/open-discogs-model v0.2.0 h1:J89ZdKkY0/z6ZFCCK81MmZ3M+B4czdGA9GJJRkcg3s8=
+github.com/dsub-io/open-discogs-model v0.2.0/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=

--- a/internal/test/resource/resource_test.go
+++ b/internal/test/resource/resource_test.go
@@ -1,0 +1,17 @@
+package resource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadReturnsBytesAndPanicsOnFilesystemErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fixture")
+	require.NoError(t, os.WriteFile(path, []byte("payload"), 0o600))
+	require.Equal(t, []byte("payload"), Read(path))
+	require.Panics(t, func() { Read(filepath.Join(t.TempDir(), "missing")) })
+	require.Panics(t, func() { Read(t.TempDir()) })
+}

--- a/internal/testserver/testserver_test.go
+++ b/internal/testserver/testserver_test.go
@@ -1,0 +1,32 @@
+package testserver
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticAndCustomServersRecordRequests(t *testing.T) {
+	static := NewServerWithStaticResponse("payload")
+	t.Cleanup(static.Close)
+	response, err := http.Get(static.URL)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, "payload", string(body))
+	require.Len(t, static.Requests(), 1)
+	require.False(t, static.Requests()[0].GetTime().IsZero())
+
+	custom := NewServer(func(requests []*HttpRequest, writer http.ResponseWriter, request *http.Request) {
+		require.Len(t, requests, 1)
+		writer.WriteHeader(http.StatusCreated)
+	})
+	t.Cleanup(custom.Close)
+	response, err = http.Get(custom.URL)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, http.StatusCreated, response.StatusCode)
+}

--- a/internal/testutils/schema.go
+++ b/internal/testutils/schema.go
@@ -9,15 +9,18 @@ import (
 	"gorm.io/gorm"
 )
 
+var loadSharedMigrations = opendiscogsschema.Migrations
+
 func ApplySharedSchema(db *gorm.DB) error {
-	migrations, err := opendiscogsschema.Migrations()
+	migrations, err := loadSharedMigrations()
 	if err != nil {
 		return err
 	}
-	names, err := fs.Glob(migrations, "*.sql")
-	if err != nil {
-		return err
-	}
+	return applySharedMigrations(db, migrations)
+}
+
+func applySharedMigrations(db *gorm.DB, migrations fs.FS) error {
+	names, _ := fs.Glob(migrations, "*.sql")
 	sort.Strings(names)
 	for _, name := range names {
 		contents, readErr := fs.ReadFile(migrations, name)

--- a/internal/testutils/testcontainer.go
+++ b/internal/testutils/testcontainer.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	containerapi "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/network"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -38,6 +40,35 @@ type Database struct {
 	Port     string
 }
 
+type testReporter interface {
+	Helper()
+	Cleanup(func())
+	Fatalf(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+type postgresContainer interface {
+	Terminate(context.Context, ...testcontainers.TerminateOption) error
+	Inspect(context.Context) (*containerapi.InspectResponse, error)
+	Host(context.Context) (string, error)
+	MappedPort(context.Context, string) (network.Port, error)
+}
+
+var createPostgresContainer = startPostgresContainer
+
+func startPostgresContainer(
+	ctx context.Context,
+	req testcontainers.ContainerRequest,
+) (postgresContainer, error) {
+	return testcontainers.GenericContainer(
+		ctx,
+		testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		},
+	)
+}
+
 func GetDsn(dt DatabaseType, db Database) string {
 	if dt != Postgres {
 		panic("unsupported database type")
@@ -60,7 +91,7 @@ func GetDatabase(t testing.TB, db DatabaseType) Database {
 	panic("unsupported database type")
 }
 
-func setupPostgres(t testing.TB) Database {
+func setupPostgres(t testReporter) Database {
 	t.Helper()
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
@@ -85,38 +116,51 @@ func setupPostgres(t testing.TB) Database {
 			wait.ForListeningPort(postgresPort).WithStartupTimeout(10*time.Second),
 		).WithDeadline(time.Second * 120),
 	}
-	dbContainer, err := testcontainers.GenericContainer(
-		ctx,
-		testcontainers.GenericContainerRequest{
-			ContainerRequest: req,
-			Started:          true,
-		})
+	dbContainer, err := createPostgresContainer(ctx, req)
 	if err != nil {
 		t.Fatalf("start PostgreSQL test container: %v", err)
+		return Database{}
 	}
 	t.Cleanup(func() {
-		if terminateErr := dbContainer.Terminate(context.Background()); terminateErr != nil {
-			t.Errorf("terminate PostgreSQL test container: %v", terminateErr)
-		}
+		reportPostgresTermination(t, dbContainer)
 	})
 
+	database, err := databaseFromContainer(ctx, dbContainer)
+	if err != nil {
+		t.Fatalf("resolve PostgreSQL test container: %v", err)
+		return Database{}
+	}
+	return database
+}
+
+func reportPostgresTermination(t testReporter, dbContainer postgresContainer) {
+	if err := dbContainer.Terminate(context.Background()); err != nil {
+		t.Errorf("terminate PostgreSQL test container: %v", err)
+	}
+}
+
+func databaseFromContainer(ctx context.Context, dbContainer postgresContainer) (Database, error) {
 	inspection, err := dbContainer.Inspect(ctx)
 	if err != nil {
-		t.Fatalf("inspect PostgreSQL test container: %v", err)
+		return Database{}, fmt.Errorf("inspect PostgreSQL test container: %w", err)
 	}
 	for _, mounted := range inspection.Mounts {
 		if mounted.Type == mount.TypeVolume {
-			t.Fatalf("PostgreSQL test container must not create volume %q at %q", mounted.Name, mounted.Destination)
+			return Database{}, fmt.Errorf(
+				"PostgreSQL test container must not create volume %q at %q",
+				mounted.Name,
+				mounted.Destination,
+			)
 		}
 	}
 
 	host, err := dbContainer.Host(ctx)
 	if err != nil {
-		t.Fatalf("resolve PostgreSQL test container host: %v", err)
+		return Database{}, fmt.Errorf("resolve PostgreSQL test container host: %w", err)
 	}
 	port, err := dbContainer.MappedPort(ctx, postgresPort)
 	if err != nil {
-		t.Fatalf("resolve PostgreSQL test container port: %v", err)
+		return Database{}, fmt.Errorf("resolve PostgreSQL test container port: %w", err)
 	}
 	return Database{
 		Username: postgresUsername,
@@ -125,5 +169,5 @@ func setupPostgres(t testing.TB) Database {
 		DBName:   postgresDatabase,
 		Type:     Postgres,
 		Port:     port.Port(),
-	}
+	}, nil
 }

--- a/internal/testutils/testcontainer.go
+++ b/internal/testutils/testcontainer.go
@@ -3,10 +3,12 @@ package testutils
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
 
+	"github.com/moby/moby/api/types/mount"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"time"
 )
 
 type DatabaseType int
@@ -15,16 +17,25 @@ const (
 	Postgres DatabaseType = iota + 1
 )
 
-const postgresWaitLog = `database system is ready to accept connections`
+const (
+	postgresDatabase      = "test_db"
+	postgresImage         = "postgres:18.4-alpine"
+	postgresPassword      = "postgres"
+	postgresPort          = "5432/tcp"
+	postgresUsername      = "postgres"
+	postgresWaitLog       = `database system is ready to accept connections`
+	testOwnerLabelKey     = "io.dsub.test-owner"
+	testOwnerLabelValue   = "go-open-discogs-batch"
+	postgresDataDirectory = "/var/lib/postgresql"
+)
 
 type Database struct {
-	Username  string
-	Password  string
-	Hostname  string
-	DBName    string
-	Type      DatabaseType
-	Port      string
-	Container testcontainers.Container
+	Username string
+	Password string
+	Hostname string
+	DBName   string
+	Type     DatabaseType
+	Port     string
 }
 
 func GetDsn(dt DatabaseType, db Database) string {
@@ -41,50 +52,78 @@ func GetDsn(dt DatabaseType, db Database) string {
 	)
 }
 
-func GetDatabase(db DatabaseType) Database {
+func GetDatabase(t testing.TB, db DatabaseType) Database {
+	t.Helper()
 	if db == Postgres {
-		return setupPostgres()
+		return setupPostgres(t)
 	}
 	panic("unsupported database type")
 }
 
-func setupPostgres() Database {
+func setupPostgres(t testing.TB) Database {
+	t.Helper()
+	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{},
-		Image:          "postgres:latest",
+		Image:          postgresImage,
 		Entrypoint:     nil,
 		Env: map[string]string{
-			"POSTGRES_DB":       "test_db",
-			"POSTGRES_PASSWORD": "postgres",
-			"POSTGRES_USER":     "postgres",
+			"POSTGRES_DB":       postgresDatabase,
+			"POSTGRES_PASSWORD": postgresPassword,
+			"POSTGRES_USER":     postgresUsername,
 		},
-		ExposedPorts: []string{"5432/tcp"},
+		ExposedPorts: []string{postgresPort},
+		Labels: map[string]string{
+			testOwnerLabelKey: testOwnerLabelValue,
+		},
+		Tmpfs: map[string]string{
+			postgresDataDirectory: "rw,noexec,nosuid,size=512m",
+		},
 		WaitingFor: wait.ForAll(
 			wait.ForLog(postgresWaitLog),
 			wait.ForExposedPort().WithStartupTimeout(time.Second*180),
-			wait.ForListeningPort("5432/tcp").WithStartupTimeout(10*time.Second),
+			wait.ForListeningPort(postgresPort).WithStartupTimeout(10*time.Second),
 		).WithDeadline(time.Second * 120),
 	}
 	dbContainer, err := testcontainers.GenericContainer(
-		context.Background(),
+		ctx,
 		testcontainers.GenericContainerRequest{
 			ContainerRequest: req,
 			Started:          true,
 		})
-
 	if err != nil {
-		panic(err)
+		t.Fatalf("start PostgreSQL test container: %v", err)
+	}
+	t.Cleanup(func() {
+		if terminateErr := dbContainer.Terminate(context.Background()); terminateErr != nil {
+			t.Errorf("terminate PostgreSQL test container: %v", terminateErr)
+		}
+	})
+
+	inspection, err := dbContainer.Inspect(ctx)
+	if err != nil {
+		t.Fatalf("inspect PostgreSQL test container: %v", err)
+	}
+	for _, mounted := range inspection.Mounts {
+		if mounted.Type == mount.TypeVolume {
+			t.Fatalf("PostgreSQL test container must not create volume %q at %q", mounted.Name, mounted.Destination)
+		}
 	}
 
-	host, _ := dbContainer.Host(context.Background())
-	port, _ := dbContainer.MappedPort(context.Background(), "5432")
+	host, err := dbContainer.Host(ctx)
+	if err != nil {
+		t.Fatalf("resolve PostgreSQL test container host: %v", err)
+	}
+	port, err := dbContainer.MappedPort(ctx, postgresPort)
+	if err != nil {
+		t.Fatalf("resolve PostgreSQL test container port: %v", err)
+	}
 	return Database{
-		Username:  "postgres",
-		Password:  "postgres",
-		Hostname:  host,
-		DBName:    "test_db",
-		Type:      Postgres,
-		Port:      port.Port(),
-		Container: dbContainer,
+		Username: postgresUsername,
+		Password: postgresPassword,
+		Hostname: host,
+		DBName:   postgresDatabase,
+		Type:     Postgres,
+		Port:     port.Port(),
 	}
 }

--- a/internal/testutils/testcontainer_test.go
+++ b/internal/testutils/testcontainer_test.go
@@ -1,0 +1,168 @@
+package testutils
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	containerapi "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/network"
+	"github.com/stretchr/testify/require"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+)
+
+func TestDatabaseHelpers(t *testing.T) {
+	databaseConfig := GetDatabase(t, Postgres)
+	dsn := GetDsn(Postgres, databaseConfig)
+
+	require.Contains(t, dsn, "host="+databaseConfig.Hostname)
+	require.Contains(t, dsn, "dbname="+databaseConfig.DBName)
+	require.Panics(t, func() { GetDsn(DatabaseType(99), databaseConfig) })
+	require.Panics(t, func() { GetDatabase(t, DatabaseType(99)) })
+
+	db, err := database.GetConnect(dsn)
+	require.NoError(t, err)
+	require.NoError(t, ApplySharedSchema(db))
+}
+
+type reporterStub struct {
+	cleanups []func()
+	fatals   []string
+	errors   []string
+}
+
+func (*reporterStub) Helper()                  {}
+func (r *reporterStub) Cleanup(cleanup func()) { r.cleanups = append(r.cleanups, cleanup) }
+func (r *reporterStub) Fatalf(format string, args ...interface{}) {
+	r.fatals = append(r.fatals, format)
+}
+func (r *reporterStub) Errorf(format string, args ...interface{}) {
+	r.errors = append(r.errors, format)
+}
+
+type postgresContainerStub struct {
+	inspection   *containerapi.InspectResponse
+	inspectErr   error
+	host         string
+	hostErr      error
+	port         network.Port
+	portErr      error
+	terminateErr error
+}
+
+func (c *postgresContainerStub) Terminate(context.Context, ...testcontainers.TerminateOption) error {
+	return c.terminateErr
+}
+func (c *postgresContainerStub) Inspect(context.Context) (*containerapi.InspectResponse, error) {
+	return c.inspection, c.inspectErr
+}
+func (c *postgresContainerStub) Host(context.Context) (string, error) {
+	return c.host, c.hostErr
+}
+func (c *postgresContainerStub) MappedPort(context.Context, string) (network.Port, error) {
+	return c.port, c.portErr
+}
+
+func validPostgresContainerStub() *postgresContainerStub {
+	return &postgresContainerStub{
+		inspection: &containerapi.InspectResponse{},
+		host:       "127.0.0.1",
+		port:       network.MustParsePort("15432/tcp"),
+	}
+}
+
+func TestSetupPostgresReportsStartAndResolutionFailures(t *testing.T) {
+	originalCreate := createPostgresContainer
+	t.Cleanup(func() { createPostgresContainer = originalCreate })
+	reporter := &reporterStub{}
+	expected := errors.New("fixture")
+
+	createPostgresContainer = func(context.Context, testcontainers.ContainerRequest) (postgresContainer, error) {
+		return nil, expected
+	}
+	require.Equal(t, Database{}, setupPostgres(reporter))
+	require.Len(t, reporter.fatals, 1)
+
+	reporter = &reporterStub{}
+	container := validPostgresContainerStub()
+	container.inspectErr = expected
+	createPostgresContainer = func(context.Context, testcontainers.ContainerRequest) (postgresContainer, error) {
+		return container, nil
+	}
+	require.Equal(t, Database{}, setupPostgres(reporter))
+	require.Len(t, reporter.fatals, 1)
+	require.Len(t, reporter.cleanups, 1)
+	reporter.cleanups[0]()
+}
+
+func TestDatabaseFromContainerErrorBoundaries(t *testing.T) {
+	ctx := context.Background()
+	expected := errors.New("fixture")
+
+	container := validPostgresContainerStub()
+	container.inspectErr = expected
+	_, err := databaseFromContainer(ctx, container)
+	require.ErrorContains(t, err, "inspect")
+
+	container = validPostgresContainerStub()
+	container.inspection.Mounts = []containerapi.MountPoint{{
+		Type:        mount.TypeVolume,
+		Name:        "unexpected",
+		Destination: postgresDataDirectory,
+	}}
+	_, err = databaseFromContainer(ctx, container)
+	require.ErrorContains(t, err, "must not create volume")
+
+	container = validPostgresContainerStub()
+	container.hostErr = expected
+	_, err = databaseFromContainer(ctx, container)
+	require.ErrorContains(t, err, "host")
+
+	container = validPostgresContainerStub()
+	container.portErr = expected
+	_, err = databaseFromContainer(ctx, container)
+	require.ErrorContains(t, err, "port")
+
+	container = validPostgresContainerStub()
+	actual, err := databaseFromContainer(ctx, container)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", actual.Hostname)
+	require.Equal(t, "15432", actual.Port)
+}
+
+func TestReportPostgresTermination(t *testing.T) {
+	reporter := &reporterStub{}
+	reportPostgresTermination(reporter, validPostgresContainerStub())
+	require.Empty(t, reporter.errors)
+
+	container := validPostgresContainerStub()
+	container.terminateErr = errors.New("fixture")
+	reportPostgresTermination(reporter, container)
+	require.Len(t, reporter.errors, 1)
+}
+
+func TestApplySharedSchemaErrorBoundaries(t *testing.T) {
+	originalLoad := loadSharedMigrations
+	t.Cleanup(func() { loadSharedMigrations = originalLoad })
+	expected := errors.New("fixture")
+	loadSharedMigrations = func() (fs.FS, error) { return nil, expected }
+	require.ErrorIs(t, ApplySharedSchema(nil), expected)
+
+	databaseConfig := GetDatabase(t, Postgres)
+	db, err := database.GetConnect(GetDsn(Postgres, databaseConfig))
+	require.NoError(t, err)
+
+	readFailure := fstest.MapFS{
+		"001-broken.sql": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+	require.Error(t, applySharedMigrations(db, readFailure))
+
+	invalidSQL := fstest.MapFS{
+		"001-invalid.sql": &fstest.MapFile{Data: []byte("invalid SQL")},
+	}
+	require.ErrorContains(t, applySharedMigrations(db, invalidSQL), "apply 001-invalid.sql")
+}

--- a/main.go
+++ b/main.go
@@ -27,9 +27,12 @@ import (
 	"os"
 )
 
+var execute = cmd.Execute
+var exit = os.Exit
+
 func main() {
-	if err := cmd.Execute(); err != nil {
+	if err := execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "critical error:", err)
-		os.Exit(1)
+		exit(1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainHandlesSuccessAndFailure(t *testing.T) {
+	originalExecute, originalExit := execute, exit
+	t.Cleanup(func() {
+		execute = originalExecute
+		exit = originalExit
+	})
+
+	exitCode := 0
+	execute = func() error { return nil }
+	exit = func(code int) { exitCode = code }
+	main()
+	require.Zero(t, exitCode)
+
+	execute = func() error { return errors.New("fixture") }
+	main()
+	require.Equal(t, 1, exitCode)
+}

--- a/src/batch/artist.go
+++ b/src/batch/artist.go
@@ -2,7 +2,26 @@ package batch
 
 import (
 	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	"github.com/dsub-io/go-open-discogs-batch/src/unique"
 	"github.com/dsub-io/open-discogs-model/model"
+)
+
+var (
+	artistAliasRelation = integerRelation{
+		table: "artist_alias", parentColumn: "artist_id", keyColumn: "alias_id",
+	}
+	artistGroupRelation = integerRelation{
+		table: "artist_group", parentColumn: "artist_id", keyColumn: "group_id",
+	}
+	artistMemberRelation = integerRelation{
+		table: "artist_member", parentColumn: "artist_id", keyColumn: "member_id",
+	}
+	artistNameVariationRelation = integerRelation{
+		table: "artist_name_variation", parentColumn: "artist_id", keyColumn: "hash",
+	}
+	artistURLRelation = integerRelation{
+		table: "artist_url", parentColumn: "artist_id", keyColumn: "hash",
+	}
 )
 
 func GetArtistStep(order Order) Step {
@@ -27,27 +46,122 @@ func insertArtists(order Order) result.Result {
 }
 
 func insertArtistRelations(order Order) result.Result {
+	deleteStale, err := relationTablesContainRows(
+		order,
+		artistAliasRelation.table,
+		artistGroupRelation.table,
+		artistMemberRelation.table,
+		artistNameVariationRelation.table,
+		artistURLRelation.table,
+	)
+	if err != nil {
+		return result.NewResult(0, err)
+	}
 	return processRelationChunks(
 		order,
 		"artist relations",
 		"artist",
 		"updating artist relations...",
-		writeArtistRelationChunk,
+		func(order Order, chunk ChunkMetadata, items []*XmlArtistRelation) result.Result {
+			return writeArtistRelationChunk(order, chunk, items, deleteStale)
+		},
 	)
 }
 
-func writeArtistRelationChunk(order Order, items []*XmlArtistRelation) result.Result {
-	n := make([]*model.ArtistNameVariation, 0)
-	a := make([]*model.ArtistAlias, 0)
-	g := make([]*model.ArtistGroup, 0)
-	m := make([]*model.ArtistMember, 0)
-	u := make([]*model.ArtistURL, 0)
-	for _, item := range items {
-		a = append(a, item.GetAliases()...)
-		g = append(g, item.GetGroups()...)
-		m = append(m, item.GetMembers()...)
-		n = append(n, item.GetNameVars()...)
-		u = append(u, item.GetUrls()...)
-	}
-	return writeChunk(order, a, g, m, n, u)
+func writeArtistRelationChunk(
+	order Order,
+	chunk ChunkMetadata,
+	items []*XmlArtistRelation,
+	deleteStale bool,
+) result.Result {
+	return executeChunk(order, chunk, func(transactionOrder Order) result.Result {
+		rootIDs := make([]int32, 0, len(items))
+		artists := make([]*model.Artist, 0, len(items))
+		nameVariations := make([]*model.ArtistNameVariation, 0)
+		aliases := make([]*model.ArtistAlias, 0)
+		groups := make([]*model.ArtistGroup, 0)
+		members := make([]*model.ArtistMember, 0)
+		urls := make([]*model.ArtistURL, 0)
+		for _, item := range items {
+			if item == nil {
+				continue
+			}
+			rootIDs = append(rootIDs, item.ID)
+			artists = append(artists, item.GetArtist())
+			aliases = append(aliases, item.GetAliases()...)
+			groups = append(groups, item.GetGroups()...)
+			members = append(members, item.GetMembers()...)
+			nameVariations = append(nameVariations, item.GetNameVars()...)
+			urls = append(urls, item.GetUrls()...)
+		}
+		rootIDs = unique.Slice(rootIDs)
+		written := writeChunk(transactionOrder, artists)
+		if written.IsErr() {
+			return written
+		}
+		reconcile := []func() result.Result{
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					artistAliasRelation,
+					deleteStale,
+					rootIDs,
+					aliases,
+					func(item *model.ArtistAlias) int32 { return item.ArtistID },
+					func(item *model.ArtistAlias) int32 { return item.AliasID },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					artistGroupRelation,
+					deleteStale,
+					rootIDs,
+					groups,
+					func(item *model.ArtistGroup) int32 { return item.ArtistID },
+					func(item *model.ArtistGroup) int32 { return item.GroupID },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					artistMemberRelation,
+					deleteStale,
+					rootIDs,
+					members,
+					func(item *model.ArtistMember) int32 { return item.ArtistID },
+					func(item *model.ArtistMember) int32 { return item.MemberID },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					artistNameVariationRelation,
+					deleteStale,
+					rootIDs,
+					nameVariations,
+					func(item *model.ArtistNameVariation) int32 { return item.ArtistID },
+					func(item *model.ArtistNameVariation) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					artistURLRelation,
+					deleteStale,
+					rootIDs,
+					urls,
+					func(item *model.ArtistURL) int32 { return item.ArtistID },
+					func(item *model.ArtistURL) int32 { return item.Hash },
+				)
+			},
+		}
+		for _, reconcileRelation := range reconcile {
+			written = written.Sum(reconcileRelation())
+			if written.IsErr() {
+				return written
+			}
+		}
+		return written
+	})
 }

--- a/src/batch/batch_test.go
+++ b/src/batch/batch_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestBatch(t *testing.T) {
@@ -100,16 +101,57 @@ func TestBatch(t *testing.T) {
 	after := snapshotBusinessTables(t, db)
 	require.Equal(t, before, after)
 
-	normalized := normalizedBusinessState(t, db)
+	canonical := normalizedBusinessState(t, db)
+	var preservedURL model.ArtistURL
+	require.NoError(t, db.Where("artist_id = ?", 1).First(&preservedURL).Error)
+	const staleArtistURLHash int32 = 2_147_483_000
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&model.ArtistURL{
+		ArtistID:       1,
+		Hash:           staleArtistURLHash,
+		URL:            "https://stale.invalid/artist",
+		CreatedAt:      now,
+		LastModifiedAt: now,
+	}).Error)
+	require.NoError(t, db.Model(&model.LabelReleaseItem{}).
+		Where("release_item_id = ? and label_id = ?", 1, 1).
+		Update("category_notation", "stale-category").Error)
+
+	for _, fixture := range []struct {
+		path string
+		step func(Order) Step
+	}{
+		{"testdata/artist.xml.gz", newBatch().UpdateArtist},
+		{"testdata/label.xml.gz", newBatch().UpdateLabel},
+		{"testdata/master.xml.gz", newBatch().UpdateMaster},
+		{"testdata/release.xml.gz", newBatch().UpdateRelease},
+	} {
+		converged := fixture.step(NewOrder(ctx, chunk, maxWorkers, fixture.path, db))()
+		require.NoError(t, converged.Err())
+	}
+	var staleURLCount int64
+	require.NoError(t, db.Model(&model.ArtistURL{}).
+		Where("artist_id = ? and hash = ?", 1, staleArtistURLHash).
+		Count(&staleURLCount).Error)
+	require.Zero(t, staleURLCount)
+	var retainedURL model.ArtistURL
+	require.NoError(t, db.Where(
+		"artist_id = ? and hash = ?",
+		preservedURL.ArtistID,
+		preservedURL.Hash,
+	).First(&retainedURL).Error)
+	require.Equal(t, preservedURL.ID, retainedURL.ID)
+	require.Equal(t, canonical, normalizedBusinessState(t, db))
+
 	goldenPath := filepath.Join("testdata", "cross-language-state.json")
 	if os.Getenv("UPDATE_CROSS_LANGUAGE_GOLDEN") == "1" {
-		encoded, err := json.MarshalIndent(normalized, "", "  ")
+		encoded, err := json.MarshalIndent(canonical, "", "  ")
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(goldenPath, append(encoded, '\n'), 0o644))
 	}
 	expected, err := os.ReadFile(goldenPath)
 	require.NoError(t, err)
-	actual, err := json.Marshal(normalized)
+	actual, err := json.Marshal(canonical)
 	require.NoError(t, err)
 	require.JSONEq(t, string(expected), string(actual))
 }

--- a/src/batch/batch_test.go
+++ b/src/batch/batch_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBatch(t *testing.T) {
-	pg := testutils.GetDatabase(testutils.Postgres)
+	pg := testutils.GetDatabase(t, testutils.Postgres)
 	dsn := testutils.GetDsn(testutils.Postgres, pg)
 	db, err := database.GetConnect(dsn)
 	require.NoError(t, err)

--- a/src/batch/convergence.go
+++ b/src/batch/convergence.go
@@ -1,0 +1,192 @@
+package batch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type integerRelation struct {
+	table        string
+	parentColumn string
+	keyColumn    string
+}
+
+type textRelation struct {
+	table        string
+	parentColumn string
+	keyColumn    string
+}
+
+type twoIntegerKeyRelation struct {
+	table           string
+	parentColumn    string
+	firstKeyColumn  string
+	secondKeyColumn string
+}
+
+func reconcileIntegerRelation[T comparable](
+	order Order,
+	relation integerRelation,
+	deleteStale bool,
+	rootIDs []int32,
+	incoming []T,
+	parentID func(T) int32,
+	key func(T) int32,
+) result.Result {
+	if !deleteStale {
+		return doWrite(incoming, order.getChunkSize(), order.getDB())
+	}
+	parents := make([]int32, 0, len(incoming))
+	keys := make([]int32, 0, len(incoming))
+	for _, item := range incoming {
+		parents = append(parents, parentID(item))
+		keys = append(keys, key(item))
+	}
+	deleted := order.getDB().Exec(
+		fmt.Sprintf(
+			`delete from public.%s current
+			  where current.%s = any(?::integer[])
+			    and not exists (
+			        select 1
+			          from unnest(?::integer[], ?::integer[]) incoming(parent_id, relation_key)
+			         where incoming.parent_id = current.%s
+			           and incoming.relation_key = current.%s
+			    )`,
+			relation.table,
+			relation.parentColumn,
+			relation.parentColumn,
+			relation.keyColumn,
+		),
+		postgresArray(rootIDs),
+		postgresArray(parents),
+		postgresArray(keys),
+	)
+	if deleted.Error != nil {
+		return result.NewResult(0, fmt.Errorf("delete stale %s rows: %w", relation.table, deleted.Error))
+	}
+	written := doWrite(incoming, order.getChunkSize(), order.getDB())
+	return result.NewResult(int(deleted.RowsAffected), nil).Sum(written)
+}
+
+func reconcileTextRelation[T comparable](
+	order Order,
+	relation textRelation,
+	deleteStale bool,
+	rootIDs []int32,
+	incoming []T,
+	parentID func(T) int32,
+	key func(T) string,
+) result.Result {
+	if !deleteStale {
+		return doWrite(incoming, order.getChunkSize(), order.getDB())
+	}
+	parents := make([]int32, 0, len(incoming))
+	keys := make([]string, 0, len(incoming))
+	for _, item := range incoming {
+		parents = append(parents, parentID(item))
+		keys = append(keys, key(item))
+	}
+	deleted := order.getDB().Exec(
+		fmt.Sprintf(
+			`delete from public.%s current
+			  where current.%s = any(?::integer[])
+			    and not exists (
+			        select 1
+			          from unnest(?::integer[], ?::text[]) incoming(parent_id, relation_key)
+			         where incoming.parent_id = current.%s
+			           and incoming.relation_key = current.%s
+			    )`,
+			relation.table,
+			relation.parentColumn,
+			relation.parentColumn,
+			relation.keyColumn,
+		),
+		postgresArray(rootIDs),
+		postgresArray(parents),
+		postgresArray(keys),
+	)
+	if deleted.Error != nil {
+		return result.NewResult(0, fmt.Errorf("delete stale %s rows: %w", relation.table, deleted.Error))
+	}
+	written := doWrite(incoming, order.getChunkSize(), order.getDB())
+	return result.NewResult(int(deleted.RowsAffected), nil).Sum(written)
+}
+
+func reconcileTwoIntegerKeyRelation[T comparable](
+	order Order,
+	relation twoIntegerKeyRelation,
+	deleteStale bool,
+	rootIDs []int32,
+	incoming []T,
+	parentID func(T) int32,
+	firstKey func(T) int32,
+	secondKey func(T) int32,
+) result.Result {
+	if !deleteStale {
+		return doWrite(incoming, order.getChunkSize(), order.getDB())
+	}
+	parents := make([]int32, 0, len(incoming))
+	firstKeys := make([]int32, 0, len(incoming))
+	secondKeys := make([]int32, 0, len(incoming))
+	for _, item := range incoming {
+		parents = append(parents, parentID(item))
+		firstKeys = append(firstKeys, firstKey(item))
+		secondKeys = append(secondKeys, secondKey(item))
+	}
+	deleted := order.getDB().Exec(
+		fmt.Sprintf(
+			`delete from public.%s current
+			  where current.%s = any(?::integer[])
+			    and not exists (
+			        select 1
+			          from unnest(?::integer[], ?::integer[], ?::integer[])
+			               incoming(parent_id, first_key, second_key)
+			         where incoming.parent_id = current.%s
+			           and incoming.first_key = current.%s
+			           and incoming.second_key = current.%s
+			    )`,
+			relation.table,
+			relation.parentColumn,
+			relation.parentColumn,
+			relation.firstKeyColumn,
+			relation.secondKeyColumn,
+		),
+		postgresArray(rootIDs),
+		postgresArray(parents),
+		postgresArray(firstKeys),
+		postgresArray(secondKeys),
+	)
+	if deleted.Error != nil {
+		return result.NewResult(0, fmt.Errorf("delete stale %s rows: %w", relation.table, deleted.Error))
+	}
+	written := doWrite(incoming, order.getChunkSize(), order.getDB())
+	return result.NewResult(int(deleted.RowsAffected), nil).Sum(written)
+}
+
+func postgresArray[T comparable](values []T) pgtype.Array[T] {
+	return pgtype.Array[T]{
+		Elements: values,
+		Dims: []pgtype.ArrayDimension{
+			{Length: int32(len(values)), LowerBound: 1},
+		},
+		Valid: true,
+	}
+}
+
+func relationTablesContainRows(order Order, tables ...string) (bool, error) {
+	checks := make([]string, len(tables))
+	for index, table := range tables {
+		checks[index] = fmt.Sprintf("exists (select 1 from public.%s limit 1)", table)
+	}
+	var containsRows bool
+	query := order.getDB().Raw(
+		"select " + strings.Join(checks, " or "),
+	).Scan(&containsRows)
+	if query.Error != nil {
+		return false, fmt.Errorf("check relation table state: %w", query.Error)
+	}
+	return containsRows, nil
+}

--- a/src/batch/coverage_test.go
+++ b/src/batch/coverage_test.go
@@ -1,0 +1,517 @@
+package batch
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dsub-io/go-open-discogs-batch/src/cache"
+	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+	"github.com/reactivex/rxgo/v2"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func testString(value string) *string { return &value }
+
+func TestBatchConstructor(t *testing.T) {
+	require.NotNil(t, New())
+}
+
+func TestLegacyCoreTransforms(t *testing.T) {
+	master := &XmlMaster{ID: 1, Title: testString("master")}
+	masterResult := <-master.Transform().Observe()
+	require.NoError(t, masterResult.E)
+	require.Equal(t, int32(1), masterResult.V.(*opendiscogsmodel.Master).ID)
+
+	release := &XmlRelease{ID: 2, Title: testString("release")}
+	releaseResult := <-release.Transform().Observe()
+	require.NoError(t, releaseResult.E)
+	require.Equal(t, int32(2), releaseResult.V.(*opendiscogsmodel.ReleaseItem).ID)
+}
+
+func TestXMLRelationFiltersInvalidValues(t *testing.T) {
+	cache.ResetIDs()
+	t.Cleanup(cache.ResetIDs)
+	cache.ArtistIDs.Add(1)
+	cache.LabelIDs.Add(2)
+	cache.MasterIDs.Add(3)
+
+	artist := &XmlArtistRelation{
+		ID:       10,
+		URLs:     []string{" ", "https://example.test"},
+		NameVars: []string{" ", "Name"},
+		Aliases:  []XmlRef{{ID: 99}, {ID: 1}},
+		Members:  []XmlRef{{ID: 99}, {ID: 1}},
+	}
+	require.Len(t, artist.GetUrls(), 1)
+	require.Len(t, artist.GetNameVars(), 1)
+	require.Len(t, artist.GetAliases(), 1)
+	require.Len(t, artist.GetMembers(), 1)
+
+	label := &XmlLabelRelation{
+		ID:        11,
+		URLs:      []string{" ", "https://example.test"},
+		SubLabels: []XmlRef{{ID: 99}, {ID: 2}},
+	}
+	require.Len(t, label.GetUrls(), 1)
+	require.Len(t, label.GetSubLabels(), 1)
+
+	master := &XmlMasterRelation{
+		ID:      12,
+		Styles:  []string{" ", "Rock"},
+		Genres:  []string{" ", "Electronic"},
+		Artists: []int32{99, 1},
+		Videos:  []XmlVideo{{}, {URL: "https://example.test"}},
+	}
+	require.Len(t, master.GetMasterStyles(), 1)
+	require.Len(t, master.GetMasterGenres(), 1)
+	require.Len(t, master.GetMasterArtists(), 1)
+	require.Len(t, master.GetMasterVideos(), 1)
+
+	release := &XmlReleaseRelation{
+		ID: 13,
+		Works: []XmlWork{
+			{LabelID: 2, Work: " "},
+			{LabelID: 99, Work: "Company"},
+			{LabelID: 2, Work: "Company"},
+		},
+		Videos:          []XmlVideo{{}, {URL: "https://example.test"}},
+		Identifiers:     []XmlIdentifier{{}, {Type: "Barcode", Value: "1"}},
+		Tracks:          []XmlTrack{{}, {Position: "A1", Title: "Track"}},
+		Formats:         []XmlFormat{{}, {Name: testString("LP")}},
+		CreditedArtists: []XmlCreditedArtist{{ArtistID: 99, Role: "Role"}, {ArtistID: 1}, {ArtistID: 1, Role: "Role"}},
+		Artists:         []int32{99, 1},
+		Labels:          []XmlLabelRelease{{LabelID: 99}, {LabelID: 2}},
+		Styles:          []string{" ", "Rock"},
+		Genres:          []string{" ", "Electronic"},
+	}
+	require.Len(t, release.GetWorks(), 1)
+	require.Len(t, release.GetVideos(), 1)
+	require.Len(t, release.GetIdentifiers(), 1)
+	require.Len(t, release.GetTracks(), 1)
+	require.Len(t, release.GetFormats(), 1)
+	require.Len(t, release.GetCreditedArtists(), 1)
+	require.Len(t, release.GetReleaseArtists(), 1)
+	require.Len(t, release.GetLabels(), 1)
+	require.Len(t, release.GetReleaseStyles(), 1)
+	require.Len(t, release.GetReleaseGenres(), 1)
+}
+
+func TestXMLValueBoundaries(t *testing.T) {
+	require.Nil(t, releaseItem(1, nil, nil, nil, nil, nil, XmlReleaseMasterInfo{}, nil).MasterID)
+	unknownMaster := int32(99)
+	require.Nil(t, releaseItem(
+		1,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		XmlReleaseMasterInfo{MasterID: &unknownMaster},
+		nil,
+	).MasterID)
+
+	invalidDate := "invalid"
+	parsed, validYear, validMonth, validDay := parsedReleaseDate(&invalidDate)
+	require.Nil(t, parsed)
+	require.False(t, validYear)
+	require.False(t, validMonth)
+	require.False(t, validDay)
+
+	yearOnly := "2026"
+	parsed, validYear, validMonth, validDay = parsedReleaseDate(&yearOnly)
+	require.NotNil(t, parsed)
+	require.True(t, validYear)
+	require.False(t, validMonth)
+	require.False(t, validDay)
+
+	require.Nil(t, reducedDescription([]string{" "}))
+	require.Empty(t, stringValue(nil))
+}
+
+func TestWriterDispatchesEverySupportedType(t *testing.T) {
+	writer := gormWriter{}
+	result := writer.Write(1,
+		[]*opendiscogsmodel.Artist{},
+		[]*opendiscogsmodel.ArtistURL{},
+		[]*opendiscogsmodel.ArtistAlias{},
+		[]*opendiscogsmodel.ArtistGroup{},
+		[]*opendiscogsmodel.ArtistMember{},
+		[]*opendiscogsmodel.ArtistNameVariation{},
+		[]*opendiscogsmodel.Label{},
+		[]*opendiscogsmodel.LabelURL{},
+		[]*opendiscogsmodel.LabelSubLabel{},
+		[]*opendiscogsmodel.LabelReleaseItem{},
+		[]*opendiscogsmodel.Master{},
+		[]*opendiscogsmodel.MasterArtist{},
+		[]*opendiscogsmodel.MasterGenre{},
+		[]*opendiscogsmodel.MasterStyle{},
+		[]*opendiscogsmodel.MasterVideo{},
+		[]*opendiscogsmodel.ReleaseItem{},
+		[]*opendiscogsmodel.ReleaseItemArtist{},
+		[]*opendiscogsmodel.ReleaseItemWork{},
+		[]*opendiscogsmodel.ReleaseItemFormat{},
+		[]*opendiscogsmodel.ReleaseItemCreditedArtist{},
+		[]*opendiscogsmodel.ReleaseItemGenre{},
+		[]*opendiscogsmodel.ReleaseItemStyle{},
+		[]*opendiscogsmodel.ReleaseItemIdentifier{},
+		[]*opendiscogsmodel.ReleaseItemImage{},
+		[]*opendiscogsmodel.ReleaseItemTrack{},
+		[]*opendiscogsmodel.ReleaseItemVideo{},
+		[]*opendiscogsmodel.Style{},
+		[]*opendiscogsmodel.Genre{},
+		struct{}{},
+	)
+	require.NoError(t, result.Err())
+	require.Zero(t, result.Count())
+}
+
+func TestExtractClauseRemainingTypes(t *testing.T) {
+	for _, item := range []interface{}{
+		&opendiscogsmodel.LabelReleaseItem{},
+		&opendiscogsmodel.ReleaseItemFormat{},
+		&opendiscogsmodel.LabelSubLabel{},
+		&opendiscogsmodel.ReleaseItemImage{},
+		&opendiscogsmodel.Style{},
+		struct{}{},
+	} {
+		_ = ExtractClause(item)
+	}
+}
+
+func TestRegisterCacheBoundaries(t *testing.T) {
+	cache.ResetIDs()
+	t.Cleanup(cache.ResetIDs)
+	for _, item := range []interface{}{
+		nil,
+		&opendiscogsmodel.Artist{ID: 1},
+		&opendiscogsmodel.Label{ID: 2},
+		&opendiscogsmodel.Master{ID: 3},
+		struct{}{},
+	} {
+		actual, err := registerCache(context.Background(), item)
+		require.NoError(t, err)
+		require.Equal(t, item, actual)
+	}
+	require.True(t, cache.ArtistIDs.Contains(1))
+	require.True(t, cache.LabelIDs.Contains(2))
+	require.True(t, cache.MasterIDs.Contains(3))
+}
+
+func TestOrderValidationAndCancellation(t *testing.T) {
+	require.Panics(t, func() { NewTrackedOrder(context.Background(), 1, 1, "", nil, 0, "artist", false) })
+	require.Panics(t, func() { NewTrackedOrder(context.Background(), 1, 1, "", nil, 1, "", false) })
+	require.Panics(t, func() { newOrder(context.Background(), 0, 1, "", nil, 0, "", false) })
+	require.Panics(t, func() { newOrder(context.Background(), 1, 0, "", nil, 0, "", false) })
+
+	order := newOrder(nil, 1, 1, "", nil, 0, "", false).(*orderImpl)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, order.submitWorker(ctx, func() { t.Fatal("must not run") }))
+
+	order.workers <- struct{}{}
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.False(t, order.submitWorker(ctx, func() { t.Fatal("must not run") }))
+	<-order.workers
+
+	done := make(chan struct{})
+	require.True(t, order.submitWorker(nil, func() { close(done) }))
+	<-done
+}
+
+func TestSourceErrorRecorder(t *testing.T) {
+	recorder := new(sourceErrorRecorder)
+	recorder.record(nil)
+	require.NoError(t, recorder.get())
+	first := errors.New("first")
+	recorder.record(first)
+	recorder.record(errors.New("second"))
+	require.ErrorIs(t, recorder.get(), first)
+}
+
+func TestNewReadCloserErrors(t *testing.T) {
+	_, err := newReadCloser(filepath.Join(t.TempDir(), "missing.gz"), "fixture")
+	require.ErrorContains(t, err, "open import file")
+
+	invalid := filepath.Join(t.TempDir(), "invalid.gz")
+	require.NoError(t, os.WriteFile(invalid, []byte("not gzip"), 0600))
+	_, err = newReadCloser(invalid, "fixture")
+	require.ErrorContains(t, err, "open gzip import file")
+}
+
+type writerStub struct {
+	result result.Result
+}
+
+func (w writerStub) Write(int, ...interface{}) result.Result { return w.result }
+
+type rejectingOrder struct {
+	Order
+}
+
+func (o rejectingOrder) submitWorker(context.Context, func()) bool { return false }
+
+func TestSimpleAndRelationPipelineErrorBoundaries(t *testing.T) {
+	missingOrder := NewOrder(context.Background(), 1, 1, filepath.Join(t.TempDir(), "missing.gz"), nil)
+	require.Error(t, GetArtistStep(missingOrder)().Err())
+	require.Error(t, GetLabelStep(missingOrder)().Err())
+	require.Error(t, InsertSimple[XmlArtist, opendiscogsmodel.Artist](missingOrder, "artist", "artist").Err())
+	require.Error(t, processRelationChunks[XmlArtistRelation](
+		missingOrder,
+		"artist",
+		"artist",
+		"fixture",
+		func(Order, ChunkMetadata, []*XmlArtistRelation) result.Result {
+			return result.NewResult(0, nil)
+		},
+	).Err())
+
+	expected := errors.New("fixture")
+	require.ErrorIs(t, simpleInsertResult("artist", rxgo.Error(expected)).Err(), expected)
+	require.Error(t, simpleInsertResult("artist", rxgo.Of("invalid")).Err())
+	require.NoError(t, simpleInsertResult("artist", rxgo.Of(2)).Err())
+}
+
+func TestEntityStepRelationFailures(t *testing.T) {
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	originalWriter := NewWriter
+	t.Cleanup(func() { NewWriter = originalWriter })
+	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(1, nil)} }
+
+	artistOrder := NewOrder(context.Background(), 2, 1, "testdata/artist.xml.gz", db)
+	require.ErrorIs(t, GetArtistStep(artistOrder)().Err(), expected)
+	labelOrder := NewOrder(context.Background(), 2, 1, "testdata/label.xml.gz", db)
+	require.ErrorIs(t, GetLabelStep(labelOrder)().Err(), expected)
+	require.ErrorIs(t, InsertMasterRelations(NewOrder(
+		context.Background(), 1, 1, "testdata/master.xml.gz", db,
+	)).Err(), expected)
+	require.ErrorIs(t, insertReleases(NewOrder(
+		context.Background(), 1, 1, "testdata/release.xml.gz", db,
+	)).Err(), expected)
+}
+
+func TestProcessRelationChunksWorkerAndProgressFailures(t *testing.T) {
+	base := NewOrder(context.Background(), 1, 1, "testdata/artist.xml.gz", nil)
+	resultValue := processRelationChunks[XmlArtistRelation](
+		rejectingOrder{Order: base},
+		"artist",
+		"artist",
+		"fixture",
+		func(Order, ChunkMetadata, []*XmlArtistRelation) result.Result {
+			return result.NewResult(0, nil)
+		},
+	)
+	require.NoError(t, resultValue.Err())
+
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	tracked := NewTrackedOrder(context.Background(), 100, 1, "testdata/artist.xml.gz", db, 1, "artist", false)
+	resultValue = processRelationChunks[XmlArtistRelation](
+		tracked,
+		"artist",
+		"artist",
+		"fixture",
+		func(Order, ChunkMetadata, []*XmlArtistRelation) result.Result {
+			return result.NewResult(0, nil)
+		},
+	)
+	require.ErrorIs(t, resultValue.Err(), expected)
+
+	require.NoError(t, mergeSourceError(result.NewResult(1, nil), nil).Err())
+	require.ErrorIs(t, mergeSourceError(result.NewResult(1, nil), expected).Err(), expected)
+}
+
+func TestWriteRelationChunkControlFlow(t *testing.T) {
+	originalWriter := NewWriter
+	t.Cleanup(func() { NewWriter = originalWriter })
+
+	run := func(t *testing.T, wantError bool, write func(Order) result.Result) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		if wantError {
+			mock.ExpectRollback()
+		} else {
+			mock.ExpectCommit()
+		}
+		actual := write(NewOrder(context.Background(), 1, 1, "unused", db))
+		require.Equal(t, wantError, actual.IsErr())
+	}
+
+	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, nil)} }
+	run(t, false, func(order Order) result.Result {
+		return writeArtistRelationChunk(order, ChunkMetadata{}, []*XmlArtistRelation{nil}, false)
+	})
+	run(t, false, func(order Order) result.Result {
+		return writeLabelRelationChunk(order, ChunkMetadata{}, []*XmlLabelRelation{nil}, false)
+	})
+	run(t, false, func(order Order) result.Result {
+		return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{nil}, false)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{nil}, false)
+	})
+
+	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, errors.New("writer"))} }
+	run(t, true, func(order Order) result.Result {
+		return writeArtistRelationChunk(order, ChunkMetadata{}, []*XmlArtistRelation{{ID: 1}}, false)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeLabelRelationChunk(order, ChunkMetadata{}, []*XmlLabelRelation{{ID: 1}}, false)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{{ID: 1}}, false)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{{ID: 1}}, false)
+	})
+
+	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, nil)} }
+	run(t, true, func(order Order) result.Result {
+		return writeArtistRelationChunk(order, ChunkMetadata{}, []*XmlArtistRelation{{ID: 1}}, true)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeLabelRelationChunk(order, ChunkMetadata{}, []*XmlLabelRelation{{ID: 1}}, true)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{{ID: 1}}, true)
+	})
+	run(t, true, func(order Order) result.Result {
+		return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{{ID: 1}}, true)
+	})
+}
+
+func TestWriterErrorControlFlow(t *testing.T) {
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	actual := gormWriter{db: db}.Write(
+		1,
+		[]*opendiscogsmodel.Genre{{Name: "genre"}},
+		[]*opendiscogsmodel.Style{{Name: "style"}},
+	)
+	require.ErrorIs(t, actual.Err(), expected)
+
+	mockDB, _, _ := newMockGorm(t)
+	type invalidSchema struct {
+		Channel chan int
+	}
+	require.ErrorContains(t, doWrite([]invalidSchema{{}}, 1, mockDB).Err(), "parse insert schema")
+	require.ErrorContains(t, doWrite([]*opendiscogsmodel.Artist{{ID: 1}}, 0, mockDB).Err(), "chunk size")
+}
+
+func TestReleaseUpdateAndReferenceFilters(t *testing.T) {
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	actual := updateMasterMainReleases(
+		NewOrder(context.Background(), 1, 1, "unused", db),
+		[]*XmlReleaseRelation{nil},
+	)
+	require.ErrorIs(t, actual.Err(), expected)
+	require.Empty(t, filterGenres([]*opendiscogsmodel.Genre{{Name: " "}}))
+	require.Empty(t, filterStyles([]*opendiscogsmodel.Style{{Name: " "}}))
+
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectExec("update public.master").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE public.master AS target").
+		WillReturnError(expected)
+	masterID := int32(1)
+	actual = updateMasterMainReleases(
+		NewOrder(context.Background(), 1, 1, "unused", db),
+		[]*XmlReleaseRelation{{
+			ID:         2,
+			MasterInfo: XmlReleaseMasterInfo{MasterID: &masterID, IsMaster: true},
+		}},
+	)
+	require.ErrorIs(t, actual.Err(), expected)
+}
+
+func TestReferenceWriteFailuresInRelationChunks(t *testing.T) {
+	originalWriter := NewWriter
+	t.Cleanup(func() { NewWriter = originalWriter })
+	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, nil)} }
+	expected := errors.New("fixture")
+
+	for _, write := range []func(Order) result.Result{
+		func(order Order) result.Result {
+			return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{{
+				ID:     1,
+				Genres: []string{"genre"},
+			}}, false)
+		},
+		func(order Order) result.Result {
+			return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{{
+				ID:     1,
+				Genres: []string{"genre"},
+			}}, false)
+		},
+	} {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectExec(`INSERT INTO .*genre`).WithArgs("genre").WillReturnError(expected)
+		mock.ExpectRollback()
+		require.ErrorIs(t, write(NewOrder(context.Background(), 1, 1, "unused", db)).Err(), expected)
+	}
+}
+
+func TestLabelSubLabelReconcileAccessors(t *testing.T) {
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	order := NewOrder(context.Background(), 1, 1, "unused", db)
+	actual := reconcileIntegerRelation(
+		order,
+		labelSubLabelRelation,
+		true,
+		[]int32{1},
+		[]*opendiscogsmodel.LabelSubLabel{{ParentLabelID: 1, SubLabelID: 2}},
+		func(item *opendiscogsmodel.LabelSubLabel) int32 { return item.ParentLabelID },
+		func(item *opendiscogsmodel.LabelSubLabel) int32 { return item.SubLabelID },
+	)
+	require.ErrorIs(t, actual.Err(), expected)
+}
+
+func TestLabelChunkUsesSubLabelKeys(t *testing.T) {
+	originalWriter := NewWriter
+	t.Cleanup(func() { NewWriter = originalWriter })
+	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, nil)} }
+	cache.LabelIDs.Add(2)
+	t.Cleanup(cache.ResetIDs)
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectBegin()
+	mock.ExpectExec("delete from public.label_url").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("delete from public.label_sub_label").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(errors.New("fixture"))
+	mock.ExpectRollback()
+
+	actual := writeLabelRelationChunk(
+		NewOrder(context.Background(), 1, 1, "unused", db),
+		ChunkMetadata{},
+		[]*XmlLabelRelation{{ID: 1, SubLabels: []XmlRef{{ID: 2}}}},
+		true,
+	)
+	require.Error(t, actual.Err())
+}
+
+func createGzipFixture(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.xml.gz")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	compressed := gzip.NewWriter(file)
+	_, err = compressed.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, compressed.Close())
+	require.NoError(t, file.Close())
+	return path
+}

--- a/src/batch/database_error_test.go
+++ b/src/batch/database_error_test.go
@@ -1,0 +1,960 @@
+package batch
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io/fs"
+	"regexp"
+	"testing"
+	"testing/fstest"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	opendiscogsmanifest "github.com/dsub-io/open-discogs-model/manifest"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/knadh/koanf"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type postgresArrayValueConverter struct{}
+
+func (postgresArrayValueConverter) ConvertValue(value interface{}) (driver.Value, error) {
+	switch value.(type) {
+	case pgtype.Array[int32], pgtype.Array[string]:
+		return "array", nil
+	default:
+		return driver.DefaultParameterConverter.ConvertValue(value)
+	}
+}
+
+func newMockGorm(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New(
+		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp),
+		sqlmock.ValueConverterOption(postgresArrayValueConverter{}),
+	)
+	require.NoError(t, err)
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		DisableAutomaticPing:   true,
+		SkipDefaultTransaction: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, sqlDB.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+	return db, mock, sqlDB
+}
+
+func TestRunDDLErrorBoundaries(t *testing.T) {
+	originalLoad := loadSchemaMigrations
+	t.Cleanup(func() { loadSchemaMigrations = originalLoad })
+	expected := errors.New("fixture")
+	loadSchemaMigrations = func() (fs.FS, error) { return nil, expected }
+	require.ErrorContains(t, RunDDL(nil), "load shared schema migrations")
+	loadSchemaMigrations = originalLoad
+
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectExec("create table if not exists public.open_discogs_schema_migration").
+		WillReturnError(expected)
+	require.ErrorContains(t, runDDL(db, fstest.MapFS{}), "create schema migration ledger")
+}
+
+func TestRunDDLReadFailure(t *testing.T) {
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectExec("create table if not exists public.open_discogs_schema_migration").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	migrations := fstest.MapFS{
+		"001-broken.sql": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+	require.ErrorContains(t, runDDL(db, migrations), "read shared migration")
+}
+
+func TestRunDDLPropagatesMigrationFailure(t *testing.T) {
+	db, mock, _ := newMockGorm(t)
+	expected := errors.New("fixture")
+	mock.ExpectExec("create table if not exists public.open_discogs_schema_migration").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectBegin()
+	mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").WillReturnError(expected)
+	mock.ExpectRollback()
+	require.ErrorContains(t, runDDL(db, fstest.MapFS{
+		"001.sql": &fstest.MapFile{Data: []byte("select 1")},
+	}), "read migration ledger")
+}
+
+func TestApplyMigrationErrorBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+	tests := []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+		want  string
+	}{
+		{
+			name: "ledger query failure",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "read migration ledger",
+		},
+		{
+			name: "changed checksum",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("old"))
+				mock.ExpectRollback()
+			},
+			want: "checksum changed",
+		},
+		{
+			name: "migration execution failure",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
+				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "apply shared migration",
+		},
+		{
+			name: "ledger insert failure",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
+				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into public.open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "record shared migration",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, _ := newMockGorm(t)
+			test.setup(mock)
+			require.ErrorContains(t, applyMigration(db, "001.sql", "new", "invalid SQL"), test.want)
+		})
+	}
+
+	t.Run("already applied checksum", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+			WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("same"))
+		mock.ExpectCommit()
+		require.NoError(t, applyMigration(db, "001.sql", "same", "unused"))
+	})
+}
+
+func poisonedGorm(t *testing.T, expected error) *gorm.DB {
+	t.Helper()
+	db, _, _ := newMockGorm(t)
+	db.AddError(expected)
+	return db
+}
+
+func TestGormErrorPropagationBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	order := NewOrder(context.Background(), 1, 1, "unused", db)
+
+	require.ErrorIs(t, writeReferenceEntities(order, []*opendiscogsmodel.Genre{}, nil).Err(), expected)
+	require.ErrorIs(t, reconcileIntegerRelation(
+		order,
+		integerRelation{table: "fixture", parentColumn: "parent", keyColumn: "key"},
+		true,
+		[]int32{1},
+		[]*opendiscogsmodel.ArtistAlias{},
+		func(item *opendiscogsmodel.ArtistAlias) int32 { return item.ArtistID },
+		func(item *opendiscogsmodel.ArtistAlias) int32 { return item.AliasID },
+	).Err(), expected)
+	require.ErrorIs(t, reconcileTextRelation(
+		order,
+		textRelation{table: "fixture", parentColumn: "parent", keyColumn: "key"},
+		true,
+		[]int32{1},
+		[]*opendiscogsmodel.MasterGenre{},
+		func(item *opendiscogsmodel.MasterGenre) int32 { return item.MasterID },
+		func(item *opendiscogsmodel.MasterGenre) string { return item.Genre },
+	).Err(), expected)
+	require.ErrorIs(t, reconcileTwoIntegerKeyRelation(
+		order,
+		twoIntegerKeyRelation{table: "fixture", parentColumn: "parent", firstKeyColumn: "first", secondKeyColumn: "second"},
+		true,
+		[]int32{1},
+		[]*opendiscogsmodel.ReleaseItemWork{},
+		func(item *opendiscogsmodel.ReleaseItemWork) int32 { return item.ReleaseItemID },
+		func(item *opendiscogsmodel.ReleaseItemWork) int32 { return item.LabelID },
+		func(item *opendiscogsmodel.ReleaseItemWork) int32 { return item.Hash },
+	).Err(), expected)
+	_, err := relationTablesContainRows(order, "fixture")
+	require.ErrorIs(t, err, expected)
+	require.ErrorIs(t, recordCompletedChunk(db, NewTrackedOrder(
+		context.Background(), 1, 1, "unused", db, 1, "artist", false,
+	), ChunkMetadata{}), expected)
+	require.ErrorIs(t, completeEntityProgress(NewTrackedOrder(
+		context.Background(), 1, 1, "unused", db, 1, "artist", false,
+	), 0, 0), expected)
+}
+
+func TestProgressTransactionErrorBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+
+	t.Run("active write failure", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+		order := NewTrackedOrder(context.Background(), 1, 1, "unused", db, 1, "artist", false)
+		actual := executeActiveRunTransaction(order, func(Order) result.Result {
+			return result.NewResult(0, expected)
+		})
+		require.ErrorIs(t, actual.Err(), expected)
+	})
+
+	t.Run("active fence query failure", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectQuery("select id.*discogs_import_run").WillReturnError(expected)
+		mock.ExpectRollback()
+		order := NewTrackedOrder(context.Background(), 1, 1, "unused", db, 1, "artist", false)
+		actual := executeActiveRunTransaction(order, func(Order) result.Result {
+			return result.NewResult(1, nil)
+		})
+		require.ErrorContains(t, actual.Err(), "fence active import run")
+	})
+
+	t.Run("active fence misses run", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectQuery("select id.*discogs_import_run").
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		mock.ExpectRollback()
+		order := NewTrackedOrder(context.Background(), 1, 1, "unused", db, 1, "artist", false)
+		actual := executeActiveRunTransaction(order, func(Order) result.Result {
+			return result.NewResult(1, nil)
+		})
+		require.ErrorContains(t, actual.Err(), "run is not active")
+	})
+
+	t.Run("resume query failure", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectQuery("select first_item_index, item_count").WillReturnError(expected)
+		mock.ExpectRollback()
+		order := NewTrackedOrder(context.Background(), 1, 1, "unused", db, 1, "artist", true)
+		actual := executeChunk(order, ChunkMetadata{}, func(Order) result.Result {
+			return result.NewResult(1, nil)
+		})
+		require.ErrorContains(t, actual.Err(), "check artist chunk")
+	})
+
+	t.Run("chunk write failure", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+		order := NewOrder(context.Background(), 1, 1, "unused", db)
+		actual := executeChunk(order, ChunkMetadata{}, func(Order) result.Result {
+			return result.NewResult(0, expected)
+		})
+		require.ErrorIs(t, actual.Err(), expected)
+	})
+
+	t.Run("resume range mismatch", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("select first_item_index, item_count").
+			WillReturnRows(sqlmock.NewRows([]string{"first_item_index", "item_count"}).AddRow(9, 9))
+		order := NewTrackedOrder(context.Background(), 1, 1, "unused", db, 1, "artist", true)
+		completed, err := chunkAlreadyCompleted(db, order, ChunkMetadata{Index: 1, FirstItemIndex: 1, ItemCount: 1})
+		require.False(t, completed)
+		require.ErrorContains(t, err, "does not match source range")
+	})
+}
+
+func newMockTransaction(t *testing.T) (sqlmock.Sqlmock, *sql.Tx) {
+	t.Helper()
+	_, mock, sqlDB := newMockGorm(t)
+	mock.ExpectBegin()
+	tx, err := sqlDB.Begin()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		mock.ExpectRollback()
+		require.NoError(t, tx.Rollback())
+	})
+	return mock, tx
+}
+
+func TestExecutionQueryHelpersPropagateErrors(t *testing.T) {
+	expected := errors.New("fixture")
+	dump := importDump("artist", "2026-07-01", "a")
+
+	t.Run("mark abandoned", func(t *testing.T) {
+		_, tx := newMockTransaction(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.ErrorContains(t, markAbandonedRuns(ctx, tx, []string{"artist"}), "recover abandoned")
+	})
+
+	t.Run("read checkpoint", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("select dump_date.*discogs_import_checkpoint").WithArgs("artist").WillReturnError(expected)
+		require.ErrorContains(t, assertNotDowngrade(context.Background(), tx, []*opendiscogsmodel.DiscogsDump{dump}, false), "read artist")
+	})
+
+	t.Run("find successful", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("select candidate_run.id").WithArgs("fingerprint").WillReturnError(expected)
+		_, err := findSuccessfulRun(context.Background(), tx, "fingerprint")
+		require.ErrorContains(t, err, "find successful")
+	})
+
+	t.Run("find resumable", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("select import_run.id").WithArgs("fingerprint", processorName, "version", 1, 1).WillReturnError(expected)
+		_, err := findResumableRun(context.Background(), tx, "fingerprint", "version", 1, 1)
+		require.ErrorContains(t, err, "find resumable")
+	})
+
+	t.Run("prune superseded", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectExec("delete from public.discogs_import_run_chunk run_chunk").WillReturnError(expected)
+		require.ErrorContains(t, pruneSupersededFailedProgress(context.Background(), tx), "prune superseded")
+	})
+
+	t.Run("record dump", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+			dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
+		).WillReturnError(expected)
+		_, err := findOrInsertDump(context.Background(), tx, dump)
+		require.ErrorContains(t, err, "record artist dump provenance")
+	})
+
+	t.Run("resolve existing dump", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+			dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
+		).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		mock.ExpectQuery("select id.*from public.discogs_dump").WithArgs(
+			dump.DumpDate, dump.EntityType, dump.ChecksumSHA256,
+		).WillReturnError(expected)
+		_, err := findOrInsertDump(context.Background(), tx, dump)
+		require.ErrorContains(t, err, "resolve artist dump provenance")
+	})
+
+	t.Run("insert run", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("insert into public.discogs_import_run").WithArgs(
+			"fingerprint", false, false, processorName, "version", sqlmock.AnyArg(),
+		).WillReturnError(expected)
+		_, err := insertImportRun(context.Background(), tx, "fingerprint", false, false, "version", 7)
+		require.ErrorContains(t, err, "start import run")
+	})
+}
+
+func TestCopyResumeProgressErrorBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+	tests := []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+		want  string
+	}{
+		{
+			name: "summary execution",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnError(expected)
+			},
+			want: "copy import run 1 summaries",
+		},
+		{
+			name: "summary count",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewErrorResult(expected))
+			},
+			want: "count copied import run 1 summaries",
+		},
+		{
+			name: "summary mismatch",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 0))
+			},
+			want: "copied 0 of 1 entities",
+		},
+		{
+			name: "chunk execution",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnError(expected)
+			},
+			want: "copy import run 1 chunks",
+		},
+		{
+			name: "chunk count",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewErrorResult(expected))
+			},
+			want: "count copied import run 1 chunks",
+		},
+		{
+			name: "prune execution",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("delete from public.discogs_import_run_chunk").WithArgs(1).WillReturnError(expected)
+			},
+			want: "prune resumed import run 1 chunks",
+		},
+		{
+			name: "prune count",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("delete from public.discogs_import_run_chunk").WithArgs(1).WillReturnResult(sqlmock.NewErrorResult(expected))
+			},
+			want: "count pruned import run 1 chunks",
+		},
+		{
+			name: "transfer mismatch",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectExec("delete from public.discogs_import_run_chunk").WithArgs(1).WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+			want: "copied 2 but pruned 1",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			test.setup(mock)
+			require.ErrorContains(t, copyResumeProgress(context.Background(), tx, 1, 2, 1), test.want)
+		})
+	}
+}
+
+func preloadConfig(t *testing.T) *koanf.Koanf {
+	t.Helper()
+	config := koanf.New(".")
+	require.NoError(t, config.Set("masters", true))
+	require.NoError(t, config.Set("artists", false))
+	return config
+}
+
+func TestPreloadReferenceIDErrorBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+
+	t.Run("query", func(t *testing.T) {
+		_, mock, sqlDB := newMockGorm(t)
+		mock.ExpectQuery("SELECT id FROM public.artist").WillReturnError(expected)
+		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "stream artist")
+	})
+
+	t.Run("scan", func(t *testing.T) {
+		_, mock, sqlDB := newMockGorm(t)
+		mock.ExpectQuery("SELECT id FROM public.artist").
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("not-an-integer"))
+		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "scan artist")
+	})
+
+	t.Run("row iteration", func(t *testing.T) {
+		_, mock, sqlDB := newMockGorm(t)
+		mock.ExpectQuery("SELECT id FROM public.artist").WillReturnRows(
+			sqlmock.NewRows([]string{"id"}).AddRow(1).RowError(0, expected),
+		)
+		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "read artist")
+	})
+
+	t.Run("close", func(t *testing.T) {
+		originalClose := closeIdentifierRows
+		t.Cleanup(func() { closeIdentifierRows = originalClose })
+		closeIdentifierRows = func(*sql.Rows) error { return expected }
+		_, mock, sqlDB := newMockGorm(t)
+		mock.ExpectQuery("SELECT id FROM public.artist").
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "close artist")
+	})
+}
+
+func expectEntityLock(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("select pg_try_advisory_lock").
+		WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"acquired"}).AddRow(true))
+}
+
+func expectEntityUnlock(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("select pg_advisory_unlock").
+		WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func expectMarkAbandoned(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("update public.discogs_import_run import_run").
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func expectNoCheckpoint(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("select dump_date.*discogs_import_checkpoint").
+		WithArgs("artist").
+		WillReturnRows(sqlmock.NewRows([]string{"dump_date"}))
+}
+
+func expectNoSuccessfulRun(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("select candidate_run.id").
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+}
+
+func expectInsertedDump(mock sqlmock.Sqlmock, dump *opendiscogsmodel.DiscogsDump) {
+	mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+		dump.ETag,
+		dump.DumpDate,
+		dump.EntityType,
+		dump.ChecksumSHA256,
+		dump.SizeBytes,
+		dump.URI,
+	).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+}
+
+func expectNoResumableRun(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("select import_run.id").
+		WithArgs(sqlmock.AnyArg(), processorName, "version", 1, 5).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+}
+
+func expectInsertedRun(mock sqlmock.Sqlmock, resumedFrom interface{}) {
+	mock.ExpectQuery("insert into public.discogs_import_run").WithArgs(
+		sqlmock.AnyArg(),
+		false,
+		false,
+		processorName,
+		"version",
+		resumedFrom,
+	).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(2))
+}
+
+func expectInsertedRunDump(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("insert into public.discogs_import_run_dump").
+		WithArgs(int64(2), "artist", int64(1), 5).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func TestImportCoordinatorValidationBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+	coordinator := NewImportExecutionCoordinator(nil, " ")
+	require.Equal(t, "development", coordinator.processorVersion)
+	require.NoError(t, coordinator.Complete(context.Background(), nil))
+	require.ErrorContains(t, func() error {
+		_, err := coordinator.Prepare(context.Background(), nil, 1, false, false)
+		return err
+	}(), "at least one dump")
+	require.ErrorContains(t, func() error {
+		_, err := coordinator.Prepare(context.Background(), []*opendiscogsmodel.DiscogsDump{importDump("artist", "2026-07-01", "a")}, 0, false, false)
+		return err
+	}(), "chunk size")
+	require.ErrorContains(t, func() error {
+		_, err := coordinator.Prepare(context.Background(), []*opendiscogsmodel.DiscogsDump{nil}, 1, false, false)
+		return err
+	}(), "nil dump")
+
+	originalFingerprint := fingerprintImportManifest
+	originalOrder := orderImportEntityTypes
+	originalLocks := requiredImportLockTypes
+	t.Cleanup(func() {
+		fingerprintImportManifest = originalFingerprint
+		orderImportEntityTypes = originalOrder
+		requiredImportLockTypes = originalLocks
+	})
+	dump := importDump("artist", "2026-07-01", "a")
+	fingerprintImportManifest = func([]opendiscogsmanifest.Dump) (string, error) { return "", expected }
+	_, err := coordinator.Prepare(context.Background(), []*opendiscogsmodel.DiscogsDump{dump}, 1, false, false)
+	require.ErrorContains(t, err, "fingerprint import manifest")
+
+	fingerprintImportManifest = originalFingerprint
+	orderImportEntityTypes = func([]string) ([]string, error) { return nil, expected }
+	_, err = coordinator.Prepare(context.Background(), []*opendiscogsmodel.DiscogsDump{dump}, 1, false, false)
+	require.ErrorIs(t, err, expected)
+
+	orderImportEntityTypes = originalOrder
+	requiredImportLockTypes = func([]string) ([]string, error) { return nil, expected }
+	_, err = coordinator.Prepare(context.Background(), []*opendiscogsmodel.DiscogsDump{dump}, 1, false, false)
+	require.ErrorIs(t, err, expected)
+
+	_, mock, sqlDB := newMockGorm(t)
+	conn, err := sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+	prepared := NewImportExecutionCoordinator(sqlDB, "version")
+	prepared.conn = conn
+	_, err = prepared.Prepare(context.Background(), []*opendiscogsmodel.DiscogsDump{dump}, 1, false, false)
+	require.ErrorContains(t, err, "already been prepared")
+	prepared.release(context.Background())
+	prepared.release(context.Background())
+
+	conn, err = sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+	prepared.conn = conn
+	require.Error(t, prepared.acquireEntityLocks(context.Background(), []string{"invalid"}))
+	prepared.release(context.Background())
+
+	conn, err = sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+	prepared.conn = conn
+	mock.ExpectQuery("select pg_try_advisory_lock").WithArgs(
+		opendiscogsmanifest.AdvisoryLockNamespace,
+		sqlmock.AnyArg(),
+	).WillReturnError(expected)
+	require.ErrorContains(t, prepared.acquireEntityLocks(context.Background(), []string{"artist"}), "acquire artist import lock")
+	prepared.release(context.Background())
+}
+
+func TestImportCoordinatorReserveConnectionFailure(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	mock.ExpectClose()
+	require.NoError(t, sqlDB.Close())
+	_, err = NewImportExecutionCoordinator(sqlDB, "version").Prepare(
+		context.Background(),
+		[]*opendiscogsmodel.DiscogsDump{importDump("artist", "2026-07-01", "a")},
+		5,
+		false,
+		false,
+	)
+	require.ErrorContains(t, err, "reserve import lock connection")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestImportCoordinatorAdmissionFailures(t *testing.T) {
+	expected := errors.New("fixture")
+	dump := importDump("artist", "2026-07-01", "a")
+	tests := []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+		want  string
+	}{
+		{
+			name: "begin",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin().WillReturnError(expected)
+				expectEntityUnlock(mock)
+			},
+			want: "begin import admission",
+		},
+		{
+			name: "mark abandoned",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				mock.ExpectExec("update public.discogs_import_run import_run").WithArgs(sqlmock.AnyArg()).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "recover abandoned",
+		},
+		{
+			name: "checkpoint",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				mock.ExpectQuery("select dump_date.*discogs_import_checkpoint").WithArgs("artist").WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "read artist import checkpoint",
+		},
+		{
+			name: "successful lookup",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				mock.ExpectQuery("select candidate_run.id").WithArgs(sqlmock.AnyArg()).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "find successful import manifest",
+		},
+		{
+			name: "skip commit",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				mock.ExpectQuery("select candidate_run.id").WithArgs(sqlmock.AnyArg()).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(9))
+				mock.ExpectCommit().WillReturnError(expected)
+				expectEntityUnlock(mock)
+			},
+			want: "commit skipped import admission",
+		},
+		{
+			name: "dump provenance",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				expectNoSuccessfulRun(mock)
+				mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+					dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
+				).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "record artist dump provenance",
+		},
+		{
+			name: "resume lookup",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				expectNoSuccessfulRun(mock)
+				expectInsertedDump(mock, dump)
+				mock.ExpectQuery("select import_run.id").WithArgs(sqlmock.AnyArg(), processorName, "version", 1, 5).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "find resumable import run",
+		},
+		{
+			name: "insert run",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				expectNoSuccessfulRun(mock)
+				expectInsertedDump(mock, dump)
+				expectNoResumableRun(mock)
+				mock.ExpectQuery("insert into public.discogs_import_run").WithArgs(
+					sqlmock.AnyArg(), false, false, processorName, "version", sqlmock.AnyArg(),
+				).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "start import run",
+		},
+		{
+			name: "insert run dump",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				expectNoSuccessfulRun(mock)
+				expectInsertedDump(mock, dump)
+				expectNoResumableRun(mock)
+				expectInsertedRun(mock, sqlmock.AnyArg())
+				mock.ExpectExec("insert into public.discogs_import_run_dump").WithArgs(int64(2), "artist", int64(1), 5).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "record import run dump artist",
+		},
+		{
+			name: "resume copy",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				expectNoSuccessfulRun(mock)
+				expectInsertedDump(mock, dump)
+				mock.ExpectQuery("select import_run.id").WithArgs(sqlmock.AnyArg(), processorName, "version", 1, 5).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(7))
+				expectInsertedRun(mock, sqlmock.AnyArg())
+				expectInsertedRunDump(mock)
+				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(int64(2), int64(7)).WillReturnError(expected)
+				mock.ExpectRollback()
+				expectEntityUnlock(mock)
+			},
+			want: "copy import run 7 summaries",
+		},
+		{
+			name: "commit",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectEntityLock(mock)
+				mock.ExpectBegin()
+				expectMarkAbandoned(mock)
+				expectNoCheckpoint(mock)
+				expectNoSuccessfulRun(mock)
+				expectInsertedDump(mock, dump)
+				expectNoResumableRun(mock)
+				expectInsertedRun(mock, sqlmock.AnyArg())
+				expectInsertedRunDump(mock)
+				mock.ExpectCommit().WillReturnError(expected)
+				expectEntityUnlock(mock)
+			},
+			want: "commit import admission",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, mock, sqlDB := newMockGorm(t)
+			test.setup(mock)
+			_, err := NewImportExecutionCoordinator(sqlDB, "version").Prepare(
+				context.Background(),
+				[]*opendiscogsmodel.DiscogsDump{dump},
+				5,
+				false,
+				false,
+			)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func preparedMockCoordinator(t *testing.T) (sqlmock.Sqlmock, *ImportExecutionCoordinator) {
+	t.Helper()
+	_, mock, sqlDB := newMockGorm(t)
+	conn, err := sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+	return mock, &ImportExecutionCoordinator{
+		db:               sqlDB,
+		processorVersion: "version",
+		conn:             conn,
+		runID:            1,
+	}
+}
+
+func expectCompletionValidation(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("select count.*discogs_import_run_dump").
+		WithArgs(int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+}
+
+func expectCompletedRunUpdate(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("update public.discogs_import_run").
+		WithArgs("success", sqlmock.AnyArg(), int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func expectPrunedSupersededProgress(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("delete from public.discogs_import_run_chunk run_chunk").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func TestImportCoordinatorCompletionFailures(t *testing.T) {
+	expected := errors.New("fixture")
+	tests := []struct {
+		name   string
+		setup  func(sqlmock.Sqlmock)
+		runErr error
+		want   string
+	}{
+		{
+			name: "begin",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin().WillReturnError(expected)
+			},
+			want: "begin import completion",
+		},
+		{
+			name: "validation query",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery("select count.*discogs_import_run_dump").WithArgs(int64(1)).WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "validate import run 1 completion",
+		},
+		{
+			name: "status update",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("update public.discogs_import_run").
+					WithArgs("failed", sqlmock.AnyArg(), int64(1)).
+					WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			runErr: expected,
+			want:   "complete import run 1",
+		},
+		{
+			name: "status result",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("update public.discogs_import_run").
+					WithArgs("failed", sqlmock.AnyArg(), int64(1)).
+					WillReturnResult(sqlmock.NewErrorResult(expected))
+				mock.ExpectRollback()
+			},
+			runErr: expected,
+			want:   "read import completion result",
+		},
+		{
+			name: "run no longer active",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("update public.discogs_import_run").
+					WithArgs("failed", sqlmock.AnyArg(), int64(1)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectRollback()
+			},
+			runErr: expected,
+			want:   "was not running",
+		},
+		{
+			name: "prune superseded",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				expectCompletionValidation(mock)
+				expectCompletedRunUpdate(mock)
+				mock.ExpectExec("delete from public.discogs_import_run_chunk run_chunk").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "prune superseded failed import progress",
+		},
+		{
+			name: "prune completed chunks",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				expectCompletionValidation(mock)
+				expectCompletedRunUpdate(mock)
+				expectPrunedSupersededProgress(mock)
+				mock.ExpectExec("delete from public.discogs_import_run_chunk where import_run_id").
+					WithArgs(int64(1)).
+					WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "prune completed import run 1 chunks",
+		},
+		{
+			name: "commit",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				expectCompletionValidation(mock)
+				expectCompletedRunUpdate(mock)
+				expectPrunedSupersededProgress(mock)
+				mock.ExpectExec("delete from public.discogs_import_run_chunk where import_run_id").
+					WithArgs(int64(1)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectCommit().WillReturnError(expected)
+			},
+			want: "commit import completion",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock, coordinator := preparedMockCoordinator(t)
+			test.setup(mock)
+			require.ErrorContains(t, coordinator.Complete(context.Background(), test.runErr), test.want)
+		})
+	}
+}

--- a/src/batch/ddl.go
+++ b/src/batch/ddl.go
@@ -14,18 +14,20 @@ import (
 
 const migrationTable = "open_discogs_schema_migration"
 
+var loadSchemaMigrations = opendiscogsschema.Migrations
+
 // RunDDL applies the versioned PostgreSQL migrations embedded in open-discogs-model.
 // Applied checksums are persisted so a released migration can never change silently.
 func RunDDL(db *gorm.DB) error {
-	migrations, err := opendiscogsschema.Migrations()
+	migrations, err := loadSchemaMigrations()
 	if err != nil {
 		return fmt.Errorf("load shared schema migrations: %w", err)
 	}
+	return runDDL(db, migrations)
+}
 
-	names, err := fs.Glob(migrations, "*.sql")
-	if err != nil {
-		return fmt.Errorf("list shared schema migrations: %w", err)
-	}
+func runDDL(db *gorm.DB, migrations fs.FS) error {
+	names, _ := fs.Glob(migrations, "*.sql")
 	sort.Strings(names)
 
 	if err := db.Exec(`

--- a/src/batch/execution.go
+++ b/src/batch/execution.go
@@ -15,9 +15,10 @@ import (
 const processorName = "go-open-discogs-batch"
 
 type ImportPreparation struct {
-	ManifestSHA256 string
-	RunID          int64
-	Skipped        bool
+	ManifestSHA256   string
+	RunID            int64
+	ResumedFromRunID int64
+	Skipped          bool
 }
 
 type ImportExecutionCoordinator struct {
@@ -46,6 +47,7 @@ func NewImportExecutionCoordinator(
 func (c *ImportExecutionCoordinator) Prepare(
 	ctx context.Context,
 	dumps []*opendiscogsmodel.DiscogsDump,
+	chunkSize int,
 	force bool,
 	allowDowngrade bool,
 ) (*ImportPreparation, error) {
@@ -57,6 +59,9 @@ func (c *ImportExecutionCoordinator) Prepare(
 	}
 	if len(dumps) == 0 {
 		return nil, errors.New("import plan must contain at least one dump")
+	}
+	if chunkSize <= 0 {
+		return nil, errors.New("chunk size must be a positive integer")
 	}
 
 	manifestDumps := make([]opendiscogsmanifest.Dump, 0, len(dumps))
@@ -146,6 +151,23 @@ func (c *ImportExecutionCoordinator) Prepare(
 		}
 	}
 
+	resumedFromRunID := int64(0)
+	if !force {
+		resumedFromRunID, err = findResumableRun(
+			ctx,
+			tx,
+			fingerprint,
+			c.processorVersion,
+			chunkSize,
+			len(dumps),
+		)
+		if err != nil {
+			_ = tx.Rollback()
+			c.release(ctx)
+			return nil, err
+		}
+	}
+
 	runID, err := insertImportRun(
 		ctx,
 		tx,
@@ -153,6 +175,7 @@ func (c *ImportExecutionCoordinator) Prepare(
 		force,
 		allowDowngrade,
 		c.processorVersion,
+		resumedFromRunID,
 	)
 	if err != nil {
 		_ = tx.Rollback()
@@ -163,16 +186,35 @@ func (c *ImportExecutionCoordinator) Prepare(
 		if _, err := tx.ExecContext(
 			ctx,
 			`insert into public.discogs_import_run_dump
-			    (import_run_id, entity_type, dump_id)
-			 values ($1, $2, $3)`,
+			    (import_run_id, entity_type, dump_id, chunk_size)
+			 values ($1, $2, $3, $4)`,
 			runID,
 			dump.EntityType,
 			dumpIDs[index],
+			chunkSize,
 		); err != nil {
 			_ = tx.Rollback()
 			c.release(ctx)
 			return nil, fmt.Errorf("record import run dump %s: %w", dump.EntityType, err)
 		}
+	}
+	if resumedFromRunID != 0 {
+		if err := copyResumeProgress(
+			ctx,
+			tx,
+			resumedFromRunID,
+			runID,
+			len(dumps),
+		); err != nil {
+			_ = tx.Rollback()
+			c.release(ctx)
+			return nil, err
+		}
+	}
+	if err := pruneObsoleteFailedProgress(ctx, tx, orderedTypes); err != nil {
+		_ = tx.Rollback()
+		c.release(ctx)
+		return nil, err
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -183,8 +225,9 @@ func (c *ImportExecutionCoordinator) Prepare(
 	committed = true
 	c.runID = runID
 	return &ImportPreparation{
-		ManifestSHA256: fingerprint,
-		RunID:          runID,
+		ManifestSHA256:   fingerprint,
+		RunID:            runID,
+		ResumedFromRunID: resumedFromRunID,
 	}, nil
 }
 
@@ -201,11 +244,39 @@ func (c *ImportExecutionCoordinator) Complete(ctx context.Context, runErr error)
 	if err != nil {
 		return fmt.Errorf("begin import completion transaction: %w", err)
 	}
+	statusReason := runErr
+	var completionErr error
+	if statusReason == nil {
+		var incompleteEntities int64
+		if scanErr := tx.QueryRowContext(
+			ctx,
+			`select count(*)
+			   from public.discogs_import_run_dump
+			  where import_run_id = $1
+			    and (completed_at is null
+			         or total_items is null
+			         or total_chunks is null
+			         or processed_items <> total_items)`,
+			c.runID,
+		).Scan(&incompleteEntities); scanErr != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("validate import run %d completion: %w", c.runID, scanErr)
+		}
+		if incompleteEntities != 0 {
+			completionErr = fmt.Errorf(
+				"import run %d has %d incomplete entities",
+				c.runID,
+				incompleteEntities,
+			)
+			statusReason = completionErr
+		}
+	}
+
 	status := "success"
-	var failure any
-	if runErr != nil {
+	failure := sql.NullString{}
+	if statusReason != nil {
 		status = "failed"
-		failure = runErr.Error()
+		failure = sql.NullString{String: statusReason.Error(), Valid: true}
 	}
 	result, err := tx.ExecContext(
 		ctx,
@@ -232,11 +303,21 @@ func (c *ImportExecutionCoordinator) Complete(ctx context.Context, runErr error)
 		_ = tx.Rollback()
 		return fmt.Errorf("import run %d was not running", c.runID)
 	}
+	if statusReason == nil {
+		if _, err := tx.ExecContext(
+			ctx,
+			"delete from public.discogs_import_run_chunk where import_run_id = $1",
+			c.runID,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("prune completed import run %d chunks: %w", c.runID, err)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit import completion: %w", err)
 	}
 	c.runID = 0
-	return nil
+	return completionErr
 }
 
 func (c *ImportExecutionCoordinator) acquireEntityLocks(
@@ -288,13 +369,7 @@ func markAbandonedRuns(
 	tx *sql.Tx,
 	entityTypes []string,
 ) error {
-	placeholders := make([]string, len(entityTypes))
-	args := make([]any, len(entityTypes))
-	for index, entityType := range entityTypes {
-		placeholders[index] = fmt.Sprintf("$%d", index+1)
-		args[index] = entityType
-	}
-	query := fmt.Sprintf(`
+	if _, err := tx.ExecContext(ctx, `
 		update public.discogs_import_run import_run
 		   set status = 'failed',
 		       completed_at = now(),
@@ -304,9 +379,8 @@ func markAbandonedRuns(
 		       select 1
 		         from public.discogs_import_run_dump run_dump
 		        where run_dump.import_run_id = import_run.id
-		          and run_dump.entity_type in (%s)
-		   )`, strings.Join(placeholders, ", "))
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		          and run_dump.entity_type = any($1::text[])
+		   )`, postgresArray(entityTypes)); err != nil {
 		return fmt.Errorf("recover abandoned import runs: %w", err)
 	}
 	return nil
@@ -374,6 +448,174 @@ func findSuccessfulRun(
 	return runID, nil
 }
 
+func findResumableRun(
+	ctx context.Context,
+	tx *sql.Tx,
+	fingerprint string,
+	processorVersion string,
+	chunkSize int,
+	entityCount int,
+) (int64, error) {
+	var runID int64
+	err := tx.QueryRowContext(
+		ctx,
+		`select import_run.id
+		   from public.discogs_import_run import_run
+		  where import_run.manifest_sha256 = $1
+		    and import_run.status = 'failed'
+		    and import_run.processor = $2
+		    and import_run.processor_version = $3
+		    and not import_run.force_requested
+		    and (select count(*)
+		           from public.discogs_import_run_dump run_dump
+		          where run_dump.import_run_id = import_run.id) = $4
+		    and not exists (
+		        select 1
+		          from public.discogs_import_run_dump run_dump
+		         where run_dump.import_run_id = import_run.id
+		           and run_dump.chunk_size is distinct from $5
+		    )
+		    and not exists (
+		        select 1
+		          from public.discogs_import_run_dump run_dump
+		         where run_dump.import_run_id = import_run.id
+		           and run_dump.processed_items <> (
+		               select coalesce(sum(run_chunk.item_count), 0)
+		                 from public.discogs_import_run_chunk run_chunk
+		                where run_chunk.import_run_id = run_dump.import_run_id
+		                  and run_chunk.entity_type = run_dump.entity_type
+		           )
+		    )
+		    and not exists (
+		        select 1
+		          from public.discogs_import_run_chunk run_chunk
+		          join public.discogs_import_run_dump run_dump
+		            on run_dump.import_run_id = run_chunk.import_run_id
+		           and run_dump.entity_type = run_chunk.entity_type
+		         where run_chunk.import_run_id = import_run.id
+		           and (run_chunk.first_item_index <> run_chunk.chunk_index * run_dump.chunk_size
+		                or run_chunk.item_count > run_dump.chunk_size)
+		    )
+		  order by import_run.completed_at desc, import_run.id desc
+		  limit 1`,
+		fingerprint,
+		processorName,
+		processorVersion,
+		entityCount,
+		chunkSize,
+	).Scan(&runID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("find resumable import run: %w", err)
+	}
+	return runID, nil
+}
+
+func copyResumeProgress(
+	ctx context.Context,
+	tx *sql.Tx,
+	fromRunID int64,
+	toRunID int64,
+	expectedEntityCount int,
+) error {
+	summaryResult, err := tx.ExecContext(
+		ctx,
+		`update public.discogs_import_run_dump target
+		    set processed_items = source.processed_items,
+		        total_items = source.total_items,
+		        total_chunks = source.total_chunks,
+		        last_progress_at = source.last_progress_at,
+		        completed_at = source.completed_at
+		   from public.discogs_import_run_dump source
+		  where target.import_run_id = $1
+		    and source.import_run_id = $2
+		    and target.entity_type = source.entity_type
+		    and target.dump_id = source.dump_id
+		    and target.chunk_size = source.chunk_size`,
+		toRunID,
+		fromRunID,
+	)
+	if err != nil {
+		return fmt.Errorf("copy import run %d summaries: %w", fromRunID, err)
+	}
+	copiedSummaries, err := summaryResult.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count copied import run %d summaries: %w", fromRunID, err)
+	}
+	if copiedSummaries != int64(expectedEntityCount) {
+		return fmt.Errorf(
+			"copy import run %d summaries: copied %d of %d entities",
+			fromRunID,
+			copiedSummaries,
+			expectedEntityCount,
+		)
+	}
+
+	chunkResult, err := tx.ExecContext(
+		ctx,
+		`insert into public.discogs_import_run_chunk
+		    (import_run_id, entity_type, chunk_index, first_item_index, item_count, completed_at)
+		 select $1, entity_type, chunk_index, first_item_index, item_count, completed_at
+		   from public.discogs_import_run_chunk
+		  where import_run_id = $2`,
+		toRunID,
+		fromRunID,
+	)
+	if err != nil {
+		return fmt.Errorf("copy import run %d chunks: %w", fromRunID, err)
+	}
+	copiedChunks, err := chunkResult.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count copied import run %d chunks: %w", fromRunID, err)
+	}
+	deleteResult, err := tx.ExecContext(
+		ctx,
+		"delete from public.discogs_import_run_chunk where import_run_id = $1",
+		fromRunID,
+	)
+	if err != nil {
+		return fmt.Errorf("prune resumed import run %d chunks: %w", fromRunID, err)
+	}
+	deletedChunks, err := deleteResult.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count pruned import run %d chunks: %w", fromRunID, err)
+	}
+	if deletedChunks != copiedChunks {
+		return fmt.Errorf(
+			"transfer import run %d chunks: copied %d but pruned %d",
+			fromRunID,
+			copiedChunks,
+			deletedChunks,
+		)
+	}
+	return nil
+}
+
+func pruneObsoleteFailedProgress(
+	ctx context.Context,
+	tx *sql.Tx,
+	entityTypes []string,
+) error {
+	if _, err := tx.ExecContext(
+		ctx,
+		`delete from public.discogs_import_run_chunk run_chunk
+		  where run_chunk.import_run_id in (
+		      select distinct import_run.id
+		        from public.discogs_import_run import_run
+		        join public.discogs_import_run_dump run_dump
+		          on run_dump.import_run_id = import_run.id
+		       where import_run.status = 'failed'
+		         and run_dump.entity_type = any($1::text[])
+		  )`,
+		postgresArray(entityTypes),
+	); err != nil {
+		return fmt.Errorf("prune obsolete failed import progress: %w", err)
+	}
+	return nil
+}
+
 func findOrInsertDump(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -424,20 +666,26 @@ func insertImportRun(
 	force bool,
 	allowDowngrade bool,
 	processorVersion string,
+	resumedFromRunID int64,
 ) (int64, error) {
 	var runID int64
+	resumedFrom := sql.NullInt64{}
+	if resumedFromRunID != 0 {
+		resumedFrom = sql.NullInt64{Int64: resumedFromRunID, Valid: true}
+	}
 	err := tx.QueryRowContext(
 		ctx,
 		`insert into public.discogs_import_run
 		    (manifest_sha256, status, force_requested,
-		     allow_downgrade_requested, processor, processor_version)
-		 values ($1, 'running', $2, $3, $4, $5)
+		     allow_downgrade_requested, processor, processor_version, resumed_from_run_id)
+		 values ($1, 'running', $2, $3, $4, $5, $6)
 		 returning id`,
 		fingerprint,
 		force,
 		allowDowngrade,
 		processorName,
 		processorVersion,
+		resumedFrom,
 	).Scan(&runID)
 	if err != nil {
 		return 0, fmt.Errorf("start import run: %w", err)

--- a/src/batch/execution.go
+++ b/src/batch/execution.go
@@ -86,13 +86,17 @@ func (c *ImportExecutionCoordinator) Prepare(
 	if err != nil {
 		return nil, err
 	}
+	lockTypes, err := opendiscogsmanifest.RequiredLockEntityTypes(orderedTypes)
+	if err != nil {
+		return nil, err
+	}
 
 	conn, err := c.db.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reserve import lock connection: %w", err)
 	}
 	c.conn = conn
-	if err := c.acquireEntityLocks(ctx, orderedTypes); err != nil {
+	if err := c.acquireEntityLocks(ctx, lockTypes); err != nil {
 		c.release(ctx)
 		return nil, err
 	}

--- a/src/batch/execution.go
+++ b/src/batch/execution.go
@@ -211,12 +211,6 @@ func (c *ImportExecutionCoordinator) Prepare(
 			return nil, err
 		}
 	}
-	if err := pruneObsoleteFailedProgress(ctx, tx, orderedTypes); err != nil {
-		_ = tx.Rollback()
-		c.release(ctx)
-		return nil, err
-	}
-
 	if err := tx.Commit(); err != nil {
 		_ = tx.Rollback()
 		c.release(ctx)
@@ -304,6 +298,10 @@ func (c *ImportExecutionCoordinator) Complete(ctx context.Context, runErr error)
 		return fmt.Errorf("import run %d was not running", c.runID)
 	}
 	if statusReason == nil {
+		if err := pruneSupersededFailedProgress(ctx, tx); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
 		if _, err := tx.ExecContext(
 			ctx,
 			"delete from public.discogs_import_run_chunk where import_run_id = $1",
@@ -431,11 +429,37 @@ func findSuccessfulRun(
 	var runID int64
 	err := tx.QueryRowContext(
 		ctx,
-		`select id
-		   from public.discogs_import_run
-		  where manifest_sha256 = $1
-		    and status = 'success'
-		  order by completed_at desc, id desc
+		`select candidate_run.id
+		   from public.discogs_import_run candidate_run
+		  where candidate_run.manifest_sha256 = $1
+		    and candidate_run.status = 'success'
+		    and not exists (
+		        select 1
+		          from public.discogs_import_run_dump candidate_dump
+		          left join public.discogs_import_checkpoint checkpoint
+		            on checkpoint.entity_type = candidate_dump.entity_type
+		          left join public.discogs_import_run_dump current_dump
+		            on current_dump.import_run_id = checkpoint.import_run_id
+		           and current_dump.entity_type = checkpoint.entity_type
+		         where candidate_dump.import_run_id = candidate_run.id
+		           and current_dump.dump_id is distinct from candidate_dump.dump_id
+		    )
+		    and not exists (
+		        select 1
+		          from public.discogs_import_run_dump candidate_dump
+		          join public.discogs_import_checkpoint checkpoint
+		            on checkpoint.entity_type = candidate_dump.entity_type
+		          join public.discogs_import_run_dump failed_dump
+		            on failed_dump.entity_type = candidate_dump.entity_type
+		          join public.discogs_import_run failed_run
+		            on failed_run.id = failed_dump.import_run_id
+		         where candidate_dump.import_run_id = candidate_run.id
+		           and failed_run.status = 'failed'
+		           and (failed_run.completed_at > checkpoint.applied_at
+		                or (failed_run.completed_at = checkpoint.applied_at
+		                    and failed_run.id > checkpoint.import_run_id))
+		    )
+		  order by candidate_run.completed_at desc, candidate_run.id desc
 		  limit 1`,
 		fingerprint,
 	).Scan(&runID)
@@ -495,6 +519,24 @@ func findResumableRun(
 		         where run_chunk.import_run_id = import_run.id
 		           and (run_chunk.first_item_index <> run_chunk.chunk_index * run_dump.chunk_size
 		                or run_chunk.item_count > run_dump.chunk_size)
+		    )
+		    and not exists (
+		        select 1
+		          from public.discogs_import_run_dump failed_dump
+		          join public.discogs_import_checkpoint checkpoint
+		            on checkpoint.entity_type = failed_dump.entity_type
+		          join public.discogs_import_run_dump current_dump
+		            on current_dump.import_run_id = checkpoint.import_run_id
+		           and current_dump.entity_type = checkpoint.entity_type
+		          join public.discogs_import_run current_run
+		            on current_run.id = checkpoint.import_run_id
+		         where failed_dump.import_run_id = import_run.id
+		           and (current_dump.dump_id <> failed_dump.dump_id
+		                or current_run.processor <> import_run.processor
+		                or current_run.processor_version <> import_run.processor_version)
+		           and (checkpoint.applied_at > import_run.completed_at
+		                or (checkpoint.applied_at = import_run.completed_at
+		                    and checkpoint.import_run_id > import_run.id))
 		    )
 		  order by import_run.completed_at desc, import_run.id desc
 		  limit 1`,
@@ -593,25 +635,32 @@ func copyResumeProgress(
 	return nil
 }
 
-func pruneObsoleteFailedProgress(
-	ctx context.Context,
-	tx *sql.Tx,
-	entityTypes []string,
-) error {
+func pruneSupersededFailedProgress(ctx context.Context, tx *sql.Tx) error {
 	if _, err := tx.ExecContext(
 		ctx,
 		`delete from public.discogs_import_run_chunk run_chunk
 		  where run_chunk.import_run_id in (
-		      select distinct import_run.id
-		        from public.discogs_import_run import_run
-		        join public.discogs_import_run_dump run_dump
-		          on run_dump.import_run_id = import_run.id
-		       where import_run.status = 'failed'
-		         and run_dump.entity_type = any($1::text[])
+		      select failed_run.id
+		        from public.discogs_import_run failed_run
+		       where failed_run.status = 'failed'
+		         and not exists (
+		             select 1
+		               from public.discogs_import_run_dump failed_dump
+		               left join public.discogs_import_checkpoint checkpoint
+		                 on checkpoint.entity_type = failed_dump.entity_type
+		               left join public.discogs_import_run current_run
+		                 on current_run.id = checkpoint.import_run_id
+		               left join public.discogs_import_run_dump current_dump
+		                 on current_dump.import_run_id = checkpoint.import_run_id
+		                and current_dump.entity_type = checkpoint.entity_type
+		              where failed_dump.import_run_id = failed_run.id
+		                and (current_dump.dump_id is distinct from failed_dump.dump_id
+		                     or current_run.processor is distinct from failed_run.processor
+		                     or current_run.processor_version is distinct from failed_run.processor_version)
+		         )
 		  )`,
-		postgresArray(entityTypes),
 	); err != nil {
-		return fmt.Errorf("prune obsolete failed import progress: %w", err)
+		return fmt.Errorf("prune superseded failed import progress: %w", err)
 	}
 	return nil
 }

--- a/src/batch/execution.go
+++ b/src/batch/execution.go
@@ -14,6 +14,10 @@ import (
 
 const processorName = "go-open-discogs-batch"
 
+var fingerprintImportManifest = opendiscogsmanifest.Fingerprint
+var orderImportEntityTypes = opendiscogsmanifest.OrderedEntityTypes
+var requiredImportLockTypes = opendiscogsmanifest.RequiredLockEntityTypes
+
 type ImportPreparation struct {
 	ManifestSHA256   string
 	RunID            int64
@@ -78,15 +82,15 @@ func (c *ImportExecutionCoordinator) Prepare(
 		entityTypes = append(entityTypes, dump.EntityType)
 	}
 
-	fingerprint, err := opendiscogsmanifest.Fingerprint(manifestDumps)
+	fingerprint, err := fingerprintImportManifest(manifestDumps)
 	if err != nil {
 		return nil, fmt.Errorf("fingerprint import manifest: %w", err)
 	}
-	orderedTypes, err := opendiscogsmanifest.OrderedEntityTypes(entityTypes)
+	orderedTypes, err := orderImportEntityTypes(entityTypes)
 	if err != nil {
 		return nil, err
 	}
-	lockTypes, err := opendiscogsmanifest.RequiredLockEntityTypes(orderedTypes)
+	lockTypes, err := requiredImportLockTypes(orderedTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/src/batch/execution_test.go
+++ b/src/batch/execution_test.go
@@ -218,35 +218,69 @@ func TestImportExecutionCoordinator(t *testing.T) {
 		require.NoError(t, repairJuly.Complete(ctx, nil))
 	})
 
-	t.Run("allows disjoint entities and rejects overlap", func(t *testing.T) {
+	t.Run("locks reference dependencies while allowing independent entities", func(t *testing.T) {
 		reset(t)
-		artistRelease := NewImportExecutionCoordinator(sqlDB, "test")
-		artistReleaseDumps := []*opendiscogsmodel.DiscogsDump{
+		artist := NewImportExecutionCoordinator(sqlDB, "test")
+		artistDumps := []*opendiscogsmodel.DiscogsDump{
 			importDump("artist", "2026-07-01", "b"),
-			importDump("release", "2026-07-01", "c"),
 		}
-		artistReleasePrepared, err := artistRelease.Prepare(
-			ctx, artistReleaseDumps, testChunkSize, false, false,
+		artistPrepared, err := artist.Prepare(
+			ctx, artistDumps, testChunkSize, false, false,
 		)
+		require.NoError(t, err)
+
+		label := NewImportExecutionCoordinator(sqlDB, "test")
+		labelDumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("label", "2026-07-01", "c"),
+		}
+		labelPrepared, err := label.Prepare(ctx, labelDumps, testChunkSize, false, false)
 		require.NoError(t, err)
 
 		master := NewImportExecutionCoordinator(sqlDB, "test")
 		masterDumps := []*opendiscogsmodel.DiscogsDump{
 			importDump("master", "2026-07-01", "d"),
 		}
-		masterPrepared, err := master.Prepare(ctx, masterDumps, testChunkSize, false, false)
-		require.NoError(t, err)
+		_, err = master.Prepare(ctx, masterDumps, testChunkSize, false, false)
+		require.ErrorContains(t, err, "already updating artist")
 
-		overlapping := NewImportExecutionCoordinator(sqlDB, "test")
-		_, err = overlapping.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
-			importDump("artist", "2026-07-01", "e"),
+		release := NewImportExecutionCoordinator(sqlDB, "test")
+		_, err = release.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
+			importDump("release", "2026-07-01", "e"),
 		}, testChunkSize, false, false)
 		require.ErrorContains(t, err, "already updating artist")
 
-		complete(t, masterPrepared, masterDumps)
-		require.NoError(t, master.Complete(ctx, nil))
-		complete(t, artistReleasePrepared, artistReleaseDumps)
-		require.NoError(t, artistRelease.Complete(ctx, nil))
+		complete(t, labelPrepared, labelDumps)
+		require.NoError(t, label.Complete(ctx, nil))
+		complete(t, artistPrepared, artistDumps)
+		require.NoError(t, artist.Complete(ctx, nil))
+	})
+
+	t.Run("release locks every referenced entity and master write target", func(t *testing.T) {
+		reset(t)
+		release := NewImportExecutionCoordinator(sqlDB, "test")
+		releaseDumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("release", "2026-07-01", "e"),
+		}
+		releasePrepared, err := release.Prepare(
+			ctx, releaseDumps, testChunkSize, false, false,
+		)
+		require.NoError(t, err)
+
+		for entityType, blockedLock := range map[string]string{
+			"artist":  "artist",
+			"label":   "label",
+			"master":  "artist",
+			"release": "artist",
+		} {
+			competing := NewImportExecutionCoordinator(sqlDB, "test")
+			_, err = competing.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
+				importDump(entityType, "2026-07-01", "f"),
+			}, testChunkSize, false, false)
+			require.ErrorContains(t, err, "already updating "+blockedLock)
+		}
+
+		complete(t, releasePrepared, releaseDumps)
+		require.NoError(t, release.Complete(ctx, nil))
 	})
 
 	t.Run("rejects downgrades unless separately authorized", func(t *testing.T) {

--- a/src/batch/execution_test.go
+++ b/src/batch/execution_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/data"
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
 	"github.com/stretchr/testify/require"
@@ -49,6 +52,7 @@ func TestImportExecutionCoordinator(t *testing.T) {
 				db,
 				prepared.RunID,
 				dump.EntityType,
+				false,
 			)
 			require.NoError(t, completeEntityProgress(order, 0, 0))
 		}
@@ -86,6 +90,132 @@ func TestImportExecutionCoordinator(t *testing.T) {
 			 where status = 'success'
 			   and force_requested`).Scan(&forcedRuns).Error)
 		require.Equal(t, int64(1), forcedRuns)
+	})
+
+	t.Run("reapplies a historical manifest when the current checkpoint changed", func(t *testing.T) {
+		reset(t)
+		julyDump := importDump("artist", "2026-07-01", "b")
+		augustDump := importDump("artist", "2026-08-01", "c")
+
+		july := NewImportExecutionCoordinator(sqlDB, "test")
+		julyPreparation, err := july.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, julyPreparation, []*opendiscogsmodel.DiscogsDump{julyDump})
+		require.NoError(t, july.Complete(ctx, nil))
+
+		august := NewImportExecutionCoordinator(sqlDB, "test")
+		augustPreparation, err := august.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{augustDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, augustPreparation, []*opendiscogsmodel.DiscogsDump{augustDump})
+		require.NoError(t, august.Complete(ctx, nil))
+
+		reapplyJuly := NewImportExecutionCoordinator(sqlDB, "test")
+		reappliedJuly, err := reapplyJuly.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			true,
+		)
+		require.NoError(t, err)
+		require.False(t, reappliedJuly.Skipped)
+		complete(t, reappliedJuly, []*opendiscogsmodel.DiscogsDump{julyDump})
+		require.NoError(t, reapplyJuly.Complete(ctx, nil))
+
+		reapplyAugust := NewImportExecutionCoordinator(sqlDB, "test")
+		reappliedAugust, err := reapplyAugust.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{augustDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.False(t, reappliedAugust.Skipped)
+		complete(t, reappliedAugust, []*opendiscogsmodel.DiscogsDump{augustDump})
+		require.NoError(t, reapplyAugust.Complete(ctx, nil))
+
+		currentAugust := NewImportExecutionCoordinator(sqlDB, "test")
+		currentPreparation, err := currentAugust.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{augustDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.True(t, currentPreparation.Skipped)
+	})
+
+	t.Run("does not skip a checkpoint dirtied by a later failed run", func(t *testing.T) {
+		reset(t)
+		julyDump := importDump("master", "2026-07-01", "d")
+		july := NewImportExecutionCoordinator(sqlDB, "test")
+		julyPreparation, err := july.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, julyPreparation, []*opendiscogsmodel.DiscogsDump{julyDump})
+		require.NoError(t, july.Complete(ctx, nil))
+
+		augustDump := importDump("master", "2026-08-01", "e")
+		failedAugust := NewImportExecutionCoordinator(sqlDB, "test")
+		failedPreparation, err := failedAugust.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{augustDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+			if insertErr := tx.Exec(
+				`insert into public.discogs_import_run_chunk
+				    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+				 values (?, 'master', 0, 0, 1)`,
+				failedPreparation.RunID,
+			).Error; insertErr != nil {
+				return insertErr
+			}
+			return tx.Exec(
+				`update public.discogs_import_run_dump
+				    set processed_items = 1,
+				        last_progress_at = now()
+				  where import_run_id = ?
+				    and entity_type = 'master'`,
+				failedPreparation.RunID,
+			).Error
+		}))
+		require.NoError(t, failedAugust.Complete(ctx, errors.New("fixture failure")))
+
+		repairJuly := NewImportExecutionCoordinator(sqlDB, "test")
+		repairPreparation, err := repairJuly.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.False(t, repairPreparation.Skipped)
+		complete(t, repairPreparation, []*opendiscogsmodel.DiscogsDump{julyDump})
+		require.NoError(t, repairJuly.Complete(ctx, nil))
 	})
 
 	t.Run("allows disjoint entities and rejects overlap", func(t *testing.T) {
@@ -245,6 +375,70 @@ func TestImportExecutionCoordinator(t *testing.T) {
 		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
 	})
 
+	t.Run("does not resume progress overwritten by a newer successful dump", func(t *testing.T) {
+		reset(t)
+		julyDump := importDump("master", "2026-07-01", "6")
+		failed := NewImportExecutionCoordinator(sqlDB, "test")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+			if insertErr := tx.Exec(
+				`insert into public.discogs_import_run_chunk
+				    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+				 values (?, 'master', 0, 0, 1)`,
+				failedPreparation.RunID,
+			).Error; insertErr != nil {
+				return insertErr
+			}
+			return tx.Exec(
+				`update public.discogs_import_run_dump
+				    set processed_items = 1,
+				        last_progress_at = now()
+				  where import_run_id = ?
+				    and entity_type = 'master'`,
+				failedPreparation.RunID,
+			).Error
+		}))
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		augustDump := importDump("master", "2026-08-01", "7")
+		august := NewImportExecutionCoordinator(sqlDB, "test")
+		augustPreparation, err := august.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{augustDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, augustPreparation, []*opendiscogsmodel.DiscogsDump{augustDump})
+		require.NoError(t, august.Complete(ctx, nil))
+
+		retryJuly := NewImportExecutionCoordinator(sqlDB, "test")
+		retryPreparation, err := retryJuly.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			true,
+		)
+		require.NoError(t, err)
+		require.Zero(t, retryPreparation.ResumedFromRunID)
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"master",
+		))
+		require.NoError(t, retryJuly.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
 	t.Run("rejects structurally invalid progress", func(t *testing.T) {
 		reset(t)
 		dumps := []*opendiscogsmodel.DiscogsDump{
@@ -283,13 +477,346 @@ func TestImportExecutionCoordinator(t *testing.T) {
 		prepared, err := retry.Prepare(ctx, dumps, testChunkSize, false, false)
 		require.NoError(t, err)
 		require.Zero(t, prepared.ResumedFromRunID)
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"label",
+		))
+		complete(t, prepared, dumps)
+		require.NoError(t, retry.Complete(ctx, nil))
 		require.Empty(t, completedChunkIndexes(
 			t,
 			db,
 			failedPreparation.RunID,
 			"label",
 		))
-		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("preserves a failed multi-entity ledger until every dump is superseded", func(t *testing.T) {
+		reset(t)
+		artistDump := importDump("artist", "2026-07-01", "7")
+		releaseDump := importDump("release", "2026-07-01", "8")
+		failed := NewImportExecutionCoordinator(sqlDB, "test")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{artistDump, releaseDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		for _, entityType := range []string{"artist", "release"} {
+			require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Exec(
+					`insert into public.discogs_import_run_chunk
+					    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+					 values (?, ?, 0, 0, 1)`,
+					failedPreparation.RunID,
+					entityType,
+				).Error; err != nil {
+					return err
+				}
+				return tx.Exec(
+					`update public.discogs_import_run_dump
+					    set processed_items = 1,
+					        last_progress_at = now()
+					  where import_run_id = ?
+					    and entity_type = ?`,
+					failedPreparation.RunID,
+					entityType,
+				).Error
+			}))
+		}
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		artist := NewImportExecutionCoordinator(sqlDB, "test")
+		artistPreparation, err := artist.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{artistDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.Zero(t, artistPreparation.ResumedFromRunID)
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"artist",
+		))
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"release",
+		))
+		complete(t, artistPreparation, []*opendiscogsmodel.DiscogsDump{artistDump})
+		require.NoError(t, artist.Complete(ctx, nil))
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"artist",
+		))
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"release",
+		))
+
+		release := NewImportExecutionCoordinator(sqlDB, "test")
+		releasePreparation, err := release.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{releaseDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.Zero(t, releasePreparation.ResumedFromRunID)
+		complete(t, releasePreparation, []*opendiscogsmodel.DiscogsDump{releaseDump})
+		require.NoError(t, release.Complete(ctx, nil))
+		require.Empty(t, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"artist",
+		))
+		require.Empty(t, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"release",
+		))
+	})
+
+	t.Run("does not prune progress superseded by another processor version", func(t *testing.T) {
+		reset(t)
+		artistDump := importDump("artist", "2026-07-01", "a")
+		releaseDump := importDump("release", "2026-07-01", "b")
+		for _, dump := range []*opendiscogsmodel.DiscogsDump{artistDump, releaseDump} {
+			oldProcessor := NewImportExecutionCoordinator(sqlDB, "old-version")
+			prepared, prepareErr := oldProcessor.Prepare(
+				ctx,
+				[]*opendiscogsmodel.DiscogsDump{dump},
+				testChunkSize,
+				false,
+				false,
+			)
+			require.NoError(t, prepareErr)
+			complete(t, prepared, []*opendiscogsmodel.DiscogsDump{dump})
+			require.NoError(t, oldProcessor.Complete(ctx, nil))
+		}
+
+		failed := NewImportExecutionCoordinator(sqlDB, "new-version")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{artistDump, releaseDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		for _, entityType := range []string{"artist", "release"} {
+			require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+				if insertErr := tx.Exec(
+					`insert into public.discogs_import_run_chunk
+					    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+					 values (?, ?, 0, 0, 1)`,
+					failedPreparation.RunID,
+					entityType,
+				).Error; insertErr != nil {
+					return insertErr
+				}
+				return tx.Exec(
+					`update public.discogs_import_run_dump
+					    set processed_items = 1,
+					        last_progress_at = now()
+					  where import_run_id = ?
+					    and entity_type = ?`,
+					failedPreparation.RunID,
+					entityType,
+				).Error
+			}))
+		}
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		masterDump := importDump("master", "2026-07-01", "c")
+		master := NewImportExecutionCoordinator(sqlDB, "new-version")
+		masterPreparation, err := master.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{masterDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, masterPreparation, []*opendiscogsmodel.DiscogsDump{masterDump})
+		require.NoError(t, master.Complete(ctx, nil))
+
+		for _, entityType := range []string{"artist", "release"} {
+			require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+				t,
+				db,
+				failedPreparation.RunID,
+				entityType,
+			))
+		}
+	})
+
+	t.Run("does not prune failed progress based on a historical checkpoint", func(t *testing.T) {
+		reset(t)
+		julyDump := importDump("artist", "2026-07-01", "d")
+		augustDump := importDump("artist", "2026-08-01", "e")
+		for _, dump := range []*opendiscogsmodel.DiscogsDump{julyDump, augustDump} {
+			coordinator := NewImportExecutionCoordinator(sqlDB, "test")
+			prepared, prepareErr := coordinator.Prepare(
+				ctx,
+				[]*opendiscogsmodel.DiscogsDump{dump},
+				testChunkSize,
+				false,
+				false,
+			)
+			require.NoError(t, prepareErr)
+			complete(t, prepared, []*opendiscogsmodel.DiscogsDump{dump})
+			require.NoError(t, coordinator.Complete(ctx, nil))
+		}
+
+		failedJuly := NewImportExecutionCoordinator(sqlDB, "test")
+		failedPreparation, err := failedJuly.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{julyDump},
+			testChunkSize,
+			false,
+			true,
+		)
+		require.NoError(t, err)
+		require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+			if insertErr := tx.Exec(
+				`insert into public.discogs_import_run_chunk
+				    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+				 values (?, 'artist', 0, 0, 1)`,
+				failedPreparation.RunID,
+			).Error; insertErr != nil {
+				return insertErr
+			}
+			return tx.Exec(
+				`update public.discogs_import_run_dump
+				    set processed_items = 1,
+				        last_progress_at = now()
+				  where import_run_id = ?
+				    and entity_type = 'artist'`,
+				failedPreparation.RunID,
+			).Error
+		}))
+		require.NoError(t, failedJuly.Complete(ctx, errors.New("fixture failure")))
+
+		masterDump := importDump("master", "2026-08-01", "f")
+		master := NewImportExecutionCoordinator(sqlDB, "test")
+		masterPreparation, err := master.Prepare(
+			ctx,
+			[]*opendiscogsmodel.DiscogsDump{masterDump},
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, masterPreparation, []*opendiscogsmodel.DiscogsDump{masterDump})
+		require.NoError(t, master.Complete(ctx, nil))
+		require.ElementsMatch(t, []int64{0}, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"artist",
+		))
+	})
+
+	t.Run("rejects an out-of-range chunk even when counts match", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("master", "2026-07-01", "9"),
+		}
+		coordinator := NewImportExecutionCoordinator(sqlDB, "test")
+		prepared, err := coordinator.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.NoError(t, err)
+		for _, chunkIndex := range []int64{0, 1, 3} {
+			require.NoError(t, db.Exec(
+				`insert into public.discogs_import_run_chunk
+				    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+				 values (?, 'master', ?, ?, ?)`,
+				prepared.RunID,
+				chunkIndex,
+				chunkIndex*testChunkSize,
+				testChunkSize,
+			).Error)
+		}
+		require.NoError(t, db.Exec(
+			`update public.discogs_import_run_dump
+			    set processed_items = 15,
+			        last_progress_at = now()
+			  where import_run_id = ?
+			    and entity_type = 'master'`,
+			prepared.RunID,
+		).Error)
+		order := NewTrackedOrder(
+			ctx,
+			testChunkSize,
+			1,
+			"unused",
+			db,
+			prepared.RunID,
+			"master",
+			false,
+		)
+
+		err = completeEntityProgress(order, 15, 3)
+		require.ErrorContains(t, err, "chunk coverage does not match")
+		require.NoError(t, coordinator.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("keeps success durable when cleanup fails", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("artist", "2026-07-01", "a"),
+		}
+		coordinator := NewImportExecutionCoordinator(sqlDB, "test")
+		prepared, err := coordinator.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.NoError(t, err)
+		complete(t, prepared, dumps)
+		nonEmptyDirectory := filepath.Join(t.TempDir(), "retained-download")
+		require.NoError(t, os.Mkdir(nonEmptyDirectory, 0755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(nonEmptyDirectory, "data"),
+			[]byte("fixture"),
+			0644,
+		))
+		plan := &data.ImportPlan{
+			Resources: map[string]string{"artists": nonEmptyDirectory},
+			Dumps:     dumps,
+		}
+
+		err = finalizeImport(ctx, coordinator, plan, true, nil)
+		require.Error(t, err)
+		var status string
+		require.NoError(t, db.Raw(
+			"select status from public.discogs_import_run where id = ?",
+			prepared.RunID,
+		).Scan(&status).Error)
+		require.Equal(t, "success", status)
+
+		repeated := NewImportExecutionCoordinator(sqlDB, "test")
+		repeatedPreparation, err := repeated.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.True(t, repeatedPreparation.Skipped)
 	})
 }
 

--- a/src/batch/execution_test.go
+++ b/src/batch/execution_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestImportExecutionCoordinator(t *testing.T) {
+	const testChunkSize = 5
 	pg := testutils.GetDatabase(t, testutils.Postgres)
 	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
 	require.NoError(t, err)
@@ -32,6 +34,25 @@ func TestImportExecutionCoordinator(t *testing.T) {
 			    public.discogs_dump
 			restart identity cascade`).Error)
 	}
+	complete := func(
+		t *testing.T,
+		prepared *ImportPreparation,
+		dumps []*opendiscogsmodel.DiscogsDump,
+	) {
+		t.Helper()
+		for _, dump := range dumps {
+			order := NewTrackedOrder(
+				ctx,
+				testChunkSize,
+				1,
+				"unused",
+				db,
+				prepared.RunID,
+				dump.EntityType,
+			)
+			require.NoError(t, completeEntityProgress(order, 0, 0))
+		}
+	}
 
 	t.Run("skips a successful manifest unless forced", func(t *testing.T) {
 		reset(t)
@@ -40,20 +61,22 @@ func TestImportExecutionCoordinator(t *testing.T) {
 		}
 
 		first := NewImportExecutionCoordinator(sqlDB, "test")
-		prepared, err := first.Prepare(ctx, dumps, false, false)
+		prepared, err := first.Prepare(ctx, dumps, testChunkSize, false, false)
 		require.NoError(t, err)
 		require.False(t, prepared.Skipped)
+		complete(t, prepared, dumps)
 		require.NoError(t, first.Complete(ctx, nil))
 
 		repeated := NewImportExecutionCoordinator(sqlDB, "test")
-		prepared, err = repeated.Prepare(ctx, dumps, false, false)
+		prepared, err = repeated.Prepare(ctx, dumps, testChunkSize, false, false)
 		require.NoError(t, err)
 		require.True(t, prepared.Skipped)
 
 		forced := NewImportExecutionCoordinator(sqlDB, "test")
-		prepared, err = forced.Prepare(ctx, dumps, true, false)
+		prepared, err = forced.Prepare(ctx, dumps, testChunkSize, true, false)
 		require.NoError(t, err)
 		require.False(t, prepared.Skipped)
+		complete(t, prepared, dumps)
 		require.NoError(t, forced.Complete(ctx, nil))
 
 		var forcedRuns int64
@@ -68,48 +91,57 @@ func TestImportExecutionCoordinator(t *testing.T) {
 	t.Run("allows disjoint entities and rejects overlap", func(t *testing.T) {
 		reset(t)
 		artistRelease := NewImportExecutionCoordinator(sqlDB, "test")
-		_, err := artistRelease.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
+		artistReleaseDumps := []*opendiscogsmodel.DiscogsDump{
 			importDump("artist", "2026-07-01", "b"),
 			importDump("release", "2026-07-01", "c"),
-		}, false, false)
+		}
+		artistReleasePrepared, err := artistRelease.Prepare(
+			ctx, artistReleaseDumps, testChunkSize, false, false,
+		)
 		require.NoError(t, err)
 
 		master := NewImportExecutionCoordinator(sqlDB, "test")
-		_, err = master.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
+		masterDumps := []*opendiscogsmodel.DiscogsDump{
 			importDump("master", "2026-07-01", "d"),
-		}, false, false)
+		}
+		masterPrepared, err := master.Prepare(ctx, masterDumps, testChunkSize, false, false)
 		require.NoError(t, err)
 
 		overlapping := NewImportExecutionCoordinator(sqlDB, "test")
 		_, err = overlapping.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
 			importDump("artist", "2026-07-01", "e"),
-		}, false, false)
+		}, testChunkSize, false, false)
 		require.ErrorContains(t, err, "already updating artist")
 
+		complete(t, masterPrepared, masterDumps)
 		require.NoError(t, master.Complete(ctx, nil))
+		complete(t, artistReleasePrepared, artistReleaseDumps)
 		require.NoError(t, artistRelease.Complete(ctx, nil))
 	})
 
 	t.Run("rejects downgrades unless separately authorized", func(t *testing.T) {
 		reset(t)
 		newer := NewImportExecutionCoordinator(sqlDB, "test")
-		_, err := newer.Prepare(ctx, []*opendiscogsmodel.DiscogsDump{
+		newerDumps := []*opendiscogsmodel.DiscogsDump{
 			importDump("label", "2026-07-01", "f"),
-		}, false, false)
+		}
+		newerPrepared, err := newer.Prepare(ctx, newerDumps, testChunkSize, false, false)
 		require.NoError(t, err)
+		complete(t, newerPrepared, newerDumps)
 		require.NoError(t, newer.Complete(ctx, nil))
 
 		olderDump := []*opendiscogsmodel.DiscogsDump{
 			importDump("label", "2026-06-01", "1"),
 		}
 		older := NewImportExecutionCoordinator(sqlDB, "test")
-		_, err = older.Prepare(ctx, olderDump, true, false)
+		_, err = older.Prepare(ctx, olderDump, testChunkSize, true, false)
 		require.ErrorContains(t, err, "predates checkpoint")
 
 		authorized := NewImportExecutionCoordinator(sqlDB, "test")
-		prepared, err := authorized.Prepare(ctx, olderDump, false, true)
+		prepared, err := authorized.Prepare(ctx, olderDump, testChunkSize, false, true)
 		require.NoError(t, err)
 		require.False(t, prepared.Skipped)
+		complete(t, prepared, olderDump)
 		require.NoError(t, authorized.Complete(ctx, nil))
 
 		var allowed bool
@@ -126,15 +158,138 @@ func TestImportExecutionCoordinator(t *testing.T) {
 			importDump("master", "2026-07-01", "2"),
 		}
 		failed := NewImportExecutionCoordinator(sqlDB, "test")
-		_, err := failed.Prepare(ctx, dumps, false, false)
+		_, err := failed.Prepare(ctx, dumps, testChunkSize, false, false)
 		require.NoError(t, err)
 		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
 
 		retry := NewImportExecutionCoordinator(sqlDB, "test")
-		prepared, err := retry.Prepare(ctx, dumps, false, false)
+		prepared, err := retry.Prepare(ctx, dumps, testChunkSize, false, false)
 		require.NoError(t, err)
 		require.False(t, prepared.Skipped)
+		require.NotZero(t, prepared.ResumedFromRunID)
+		complete(t, prepared, dumps)
 		require.NoError(t, retry.Complete(ctx, nil))
+	})
+
+	t.Run("marks an incomplete run failed", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("artist", "2026-07-01", "3"),
+		}
+		coordinator := NewImportExecutionCoordinator(sqlDB, "test")
+		prepared, err := coordinator.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.NoError(t, err)
+
+		err = coordinator.Complete(ctx, nil)
+		require.ErrorContains(t, err, "1 incomplete entities")
+
+		var status string
+		require.NoError(t, db.Raw(
+			"select status from public.discogs_import_run where id = ?",
+			prepared.RunID,
+		).Scan(&status).Error)
+		require.Equal(t, "failed", status)
+
+		retry := NewImportExecutionCoordinator(sqlDB, "test")
+		retried, err := retry.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.NoError(t, err)
+		require.Equal(t, prepared.RunID, retried.ResumedFromRunID)
+		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("does not resume progress across processor versions", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("release", "2026-07-01", "4"),
+		}
+		failed := NewImportExecutionCoordinator(sqlDB, "old-version")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		retry := NewImportExecutionCoordinator(sqlDB, "new-version")
+		prepared, err := retry.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.NoError(t, err)
+		require.Zero(t, prepared.ResumedFromRunID)
+		require.NotEqual(t, failedPreparation.RunID, prepared.RunID)
+		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("does not resume progress across chunk sizes", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("master", "2026-07-01", "5"),
+		}
+		failed := NewImportExecutionCoordinator(sqlDB, "test")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		retry := NewImportExecutionCoordinator(sqlDB, "test")
+		prepared, err := retry.Prepare(ctx, dumps, testChunkSize+1, false, false)
+		require.NoError(t, err)
+		require.Zero(t, prepared.ResumedFromRunID)
+		require.NotEqual(t, failedPreparation.RunID, prepared.RunID)
+		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("rejects structurally invalid progress", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("label", "2026-07-01", "6"),
+		}
+		failed := NewImportExecutionCoordinator(sqlDB, "test")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec(
+				`insert into public.discogs_import_run_chunk
+				    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+				 values (?, 'label', 0, 1, 1)`,
+				failedPreparation.RunID,
+			).Error; err != nil {
+				return err
+			}
+			return tx.Exec(
+				`update public.discogs_import_run_dump
+				    set processed_items = 1,
+				        last_progress_at = now()
+				  where import_run_id = ?
+				    and entity_type = 'label'`,
+				failedPreparation.RunID,
+			).Error
+		}))
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		retry := NewImportExecutionCoordinator(sqlDB, "test")
+		prepared, err := retry.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.NoError(t, err)
+		require.Zero(t, prepared.ResumedFromRunID)
+		require.Empty(t, completedChunkIndexes(
+			t,
+			db,
+			failedPreparation.RunID,
+			"label",
+		))
+		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
 	})
 }
 

--- a/src/batch/execution_test.go
+++ b/src/batch/execution_test.go
@@ -15,10 +15,7 @@ import (
 )
 
 func TestImportExecutionCoordinator(t *testing.T) {
-	pg := testutils.GetDatabase(testutils.Postgres)
-	t.Cleanup(func() {
-		require.NoError(t, pg.Container.Terminate(context.Background()))
-	})
+	pg := testutils.GetDatabase(t, testutils.Postgres)
 	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
 	require.NoError(t, err)
 	require.NoError(t, RunDDL(db))

--- a/src/batch/insert.go
+++ b/src/batch/insert.go
@@ -38,7 +38,12 @@ func InsertSimple[F, T any](order Order, topic string, localName string) result.
 
 func insertBySlice[T any](order Order) func(_ context.Context, i interface{}) (interface{}, error) {
 	return func(_ context.Context, i interface{}) (interface{}, error) {
-		res := NewWriter(order.getDB()).Write(order.getChunkSize(), i.([]T))
+		res := executeActiveRunTransaction(order, func(transactionOrder Order) result.Result {
+			return NewWriter(transactionOrder.getDB()).Write(
+				transactionOrder.getChunkSize(),
+				i.([]T),
+			)
+		})
 		return res.Count(), res.Err()
 	}
 }

--- a/src/batch/insert.go
+++ b/src/batch/insert.go
@@ -13,7 +13,10 @@ import (
 )
 
 func InsertSimple[F, T any](order Order, topic string, localName string) result.Result {
-	r := newReadCloser(order.getFilePath(), fmt.Sprintf("updating %+v...", topic))
+	r, err := newReadCloser(order.getFilePath(), fmt.Sprintf("updating %+v...", topic))
+	if err != nil {
+		return result.NewResult(0, err)
+	}
 	res := <-reader.NewReader[F](order.getContext(), r, localName).
 		FlatMap(Transform).
 		Map(registerCache).

--- a/src/batch/insert.go
+++ b/src/batch/insert.go
@@ -25,6 +25,10 @@ func InsertSimple[F, T any](order Order, topic string, localName string) result.
 		Map(insertBySlice[*T](order), rxgo.WithPool(order.getMaxWorkers())).
 		Reduce(helper.MergeCount()).
 		Observe()
+	return simpleInsertResult(topic, res)
+}
+
+func simpleInsertResult(topic string, res rxgo.Item) result.Result {
 	if res.E != nil {
 		return result.NewResult(0, res.E)
 	}

--- a/src/batch/label.go
+++ b/src/batch/label.go
@@ -2,7 +2,17 @@ package batch
 
 import (
 	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	"github.com/dsub-io/go-open-discogs-batch/src/unique"
 	"github.com/dsub-io/open-discogs-model/model"
+)
+
+var (
+	labelSubLabelRelation = integerRelation{
+		table: "label_sub_label", parentColumn: "parent_label_id", keyColumn: "sub_label_id",
+	}
+	labelURLRelation = integerRelation{
+		table: "label_url", parentColumn: "label_id", keyColumn: "hash",
+	}
 )
 
 //TODO: add label release step for future use
@@ -29,21 +39,80 @@ func insertLabels(order Order) result.Result {
 }
 
 func insertLabelRelations(order Order) result.Result {
+	deleteStale, err := relationTablesContainRows(
+		order,
+		labelSubLabelRelation.table,
+		labelURLRelation.table,
+	)
+	if err != nil {
+		return result.NewResult(0, err)
+	}
 	return processRelationChunks(
 		order,
 		"label relations",
 		"label",
 		"updating label relations...",
-		writeLabelRelationChunk,
+		func(order Order, chunk ChunkMetadata, items []*XmlLabelRelation) result.Result {
+			return writeLabelRelationChunk(order, chunk, items, deleteStale)
+		},
 	)
 }
 
-func writeLabelRelationChunk(order Order, items []*XmlLabelRelation) result.Result {
-	u := make([]*model.LabelURL, 0)
-	s := make([]*model.LabelSubLabel, 0)
-	for _, item := range items {
-		u = append(u, item.GetUrls()...)
-		s = append(s, item.GetSubLabels()...)
-	}
-	return writeChunk(order, u, s)
+func writeLabelRelationChunk(
+	order Order,
+	chunk ChunkMetadata,
+	items []*XmlLabelRelation,
+	deleteStale bool,
+) result.Result {
+	return executeChunk(order, chunk, func(transactionOrder Order) result.Result {
+		rootIDs := make([]int32, 0, len(items))
+		labels := make([]*model.Label, 0, len(items))
+		urls := make([]*model.LabelURL, 0)
+		subLabels := make([]*model.LabelSubLabel, 0)
+		for _, item := range items {
+			if item == nil {
+				continue
+			}
+			rootIDs = append(rootIDs, item.ID)
+			labels = append(labels, item.GetLabel())
+			urls = append(urls, item.GetUrls()...)
+			subLabels = append(subLabels, item.GetSubLabels()...)
+		}
+		rootIDs = unique.Slice(rootIDs)
+		written := writeChunk(transactionOrder, labels)
+		if written.IsErr() {
+			return written
+		}
+		reconcile := []func() result.Result{
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					labelURLRelation,
+					deleteStale,
+					rootIDs,
+					urls,
+					func(item *model.LabelURL) int32 { return item.LabelID },
+					func(item *model.LabelURL) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					labelSubLabelRelation,
+					deleteStale,
+					rootIDs,
+					subLabels,
+					func(item *model.LabelSubLabel) int32 { return item.ParentLabelID },
+					func(item *model.LabelSubLabel) int32 { return item.SubLabelID },
+				)
+			},
+		}
+		for _, reconcileRelation := range reconcile {
+			written = written.Sum(reconcileRelation())
+			if written.IsErr() {
+				return written
+			}
+		}
+		return written
+	})
 }

--- a/src/batch/master.go
+++ b/src/batch/master.go
@@ -3,7 +3,23 @@ package batch
 import (
 	"github.com/dsub-io/go-open-discogs-batch/src/cache"
 	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	"github.com/dsub-io/go-open-discogs-batch/src/unique"
 	"github.com/dsub-io/open-discogs-model/model"
+)
+
+var (
+	masterArtistRelation = integerRelation{
+		table: "master_artist", parentColumn: "master_id", keyColumn: "artist_id",
+	}
+	masterGenreRelation = textRelation{
+		table: "master_genre", parentColumn: "master_id", keyColumn: "genre",
+	}
+	masterStyleRelation = textRelation{
+		table: "master_style", parentColumn: "master_id", keyColumn: "style",
+	}
+	masterVideoRelation = integerRelation{
+		table: "master_video", parentColumn: "master_id", keyColumn: "hash",
+	}
 )
 
 //TODO: add master release step for future use
@@ -15,49 +31,125 @@ func GetMasterStep(order Order) Step {
 }
 
 func InsertMasterRelations(order Order) result.Result {
+	deleteStale, err := relationTablesContainRows(
+		order,
+		masterArtistRelation.table,
+		masterGenreRelation.table,
+		masterStyleRelation.table,
+		masterVideoRelation.table,
+	)
+	if err != nil {
+		return result.NewResult(0, err)
+	}
 	return processRelationChunks(
 		order,
 		"master relations",
 		"master",
 		"updating master relations...",
-		writeMasterRelationChunk,
+		func(order Order, chunk ChunkMetadata, items []*XmlMasterRelation) result.Result {
+			return writeMasterRelationChunk(order, chunk, items, deleteStale)
+		},
 	)
 }
 
-func writeMasterRelationChunk(order Order, items []*XmlMasterRelation) result.Result {
-	s := make([]*model.Style, 0)
-	g := make([]*model.Genre, 0)
+func writeMasterRelationChunk(
+	order Order,
+	chunk ChunkMetadata,
+	items []*XmlMasterRelation,
+	deleteStale bool,
+) result.Result {
 	for _, item := range items {
 		if item == nil {
 			continue
 		}
-		g = append(g, item.GetGenres()...)
-		s = append(s, item.GetStyles()...)
+		cache.MasterIDs.Add(item.ID)
 	}
-	s = filterStyles(s)
-	g = filterGenres(g)
-	if referenceResult := writeReferenceEntities(order, g, s); referenceResult.IsErr() {
-		return referenceResult
-	}
-
-	var (
-		m  = make([]*model.Master, 0)
-		mv = make([]*model.MasterVideo, 0)
-		ms = make([]*model.MasterStyle, 0)
-		mg = make([]*model.MasterGenre, 0)
-		ma = make([]*model.MasterArtist, 0)
-	)
-	for _, item := range items {
-		if item == nil {
-			continue
+	return executeChunk(order, chunk, func(transactionOrder Order) result.Result {
+		styles := make([]*model.Style, 0)
+		genres := make([]*model.Genre, 0)
+		rootIDs := make([]int32, 0, len(items))
+		masters := make([]*model.Master, 0, len(items))
+		videos := make([]*model.MasterVideo, 0)
+		masterStyles := make([]*model.MasterStyle, 0)
+		masterGenres := make([]*model.MasterGenre, 0)
+		artists := make([]*model.MasterArtist, 0)
+		for _, item := range items {
+			if item == nil {
+				continue
+			}
+			rootIDs = append(rootIDs, item.ID)
+			genres = append(genres, item.GetGenres()...)
+			styles = append(styles, item.GetStyles()...)
+			masters = append(masters, item.GetMaster())
+			masterStyles = append(masterStyles, item.GetMasterStyles()...)
+			masterGenres = append(masterGenres, item.GetMasterGenres()...)
+			videos = append(videos, item.GetMasterVideos()...)
+			artists = append(artists, item.GetMasterArtists()...)
 		}
-		master := item.GetMaster()
-		m = append(m, master)
-		cache.MasterIDs.Add(master.ID)
-		ms = append(ms, item.GetMasterStyles()...)
-		mg = append(mg, item.GetMasterGenres()...)
-		mv = append(mv, item.GetMasterVideos()...)
-		ma = append(ma, item.GetMasterArtists()...)
-	}
-	return writeChunk(order, m, mv, ms, mg, ma)
+		rootIDs = unique.Slice(rootIDs)
+		if referenceResult := writeReferenceEntities(
+			transactionOrder,
+			filterGenres(genres),
+			filterStyles(styles),
+		); referenceResult.IsErr() {
+			return referenceResult
+		}
+		written := writeChunk(transactionOrder, masters)
+		if written.IsErr() {
+			return written
+		}
+		reconcile := []func() result.Result{
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					masterArtistRelation,
+					deleteStale,
+					rootIDs,
+					artists,
+					func(item *model.MasterArtist) int32 { return item.MasterID },
+					func(item *model.MasterArtist) int32 { return item.ArtistID },
+				)
+			},
+			func() result.Result {
+				return reconcileTextRelation(
+					transactionOrder,
+					masterGenreRelation,
+					deleteStale,
+					rootIDs,
+					masterGenres,
+					func(item *model.MasterGenre) int32 { return item.MasterID },
+					func(item *model.MasterGenre) string { return item.Genre },
+				)
+			},
+			func() result.Result {
+				return reconcileTextRelation(
+					transactionOrder,
+					masterStyleRelation,
+					deleteStale,
+					rootIDs,
+					masterStyles,
+					func(item *model.MasterStyle) int32 { return item.MasterID },
+					func(item *model.MasterStyle) string { return item.Style },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					masterVideoRelation,
+					deleteStale,
+					rootIDs,
+					videos,
+					func(item *model.MasterVideo) int32 { return item.MasterID },
+					func(item *model.MasterVideo) int32 { return item.Hash },
+				)
+			},
+		}
+		for _, reconcileRelation := range reconcile {
+			written = written.Sum(reconcileRelation())
+			if written.IsErr() {
+				return written
+			}
+		}
+		return written
+	})
 }

--- a/src/batch/order.go
+++ b/src/batch/order.go
@@ -9,17 +9,22 @@ import (
 type Order interface {
 	getContext() context.Context
 	getChunkSize() int
+	getEntityType() string
 	getMaxWorkers() int
 	getFilePath() string
+	getRunID() int64
 	getDB() *gorm.DB
 	submitWorker(context.Context, func()) bool
+	withDB(*gorm.DB) Order
 }
 
 type orderImpl struct {
 	ctx        context.Context
 	chunkSize  int
+	entityType string
 	maxWorkers int
 	filepath   string
+	runID      int64
 	db         *gorm.DB
 	workers    chan struct{}
 }
@@ -32,12 +37,20 @@ func (o *orderImpl) getChunkSize() int {
 	return o.chunkSize
 }
 
+func (o *orderImpl) getEntityType() string {
+	return o.entityType
+}
+
 func (o *orderImpl) getMaxWorkers() int {
 	return o.maxWorkers
 }
 
 func (o *orderImpl) getFilePath() string {
 	return o.filepath
+}
+
+func (o *orderImpl) getRunID() int64 {
+	return o.runID
 }
 
 func (o *orderImpl) getDB() *gorm.DB {
@@ -63,7 +76,46 @@ func (o *orderImpl) submitWorker(ctx context.Context, work func()) bool {
 	return true
 }
 
+func (o *orderImpl) withDB(db *gorm.DB) Order {
+	copy := *o
+	copy.db = db
+	return &copy
+}
+
 func NewOrder(ctx context.Context, chunkSize, maxWorkers int, filepath string, db *gorm.DB) Order {
+	return newOrder(ctx, chunkSize, maxWorkers, filepath, db, 0, "")
+}
+
+func NewTrackedOrder(
+	ctx context.Context,
+	chunkSize int,
+	maxWorkers int,
+	filepath string,
+	db *gorm.DB,
+	runID int64,
+	entityType string,
+) Order {
+	if runID <= 0 {
+		panic("runID must be a positive integer")
+	}
+	if entityType == "" {
+		panic("entityType must not be empty")
+	}
+	return newOrder(ctx, chunkSize, maxWorkers, filepath, db, runID, entityType)
+}
+
+func newOrder(
+	ctx context.Context,
+	chunkSize int,
+	maxWorkers int,
+	filepath string,
+	db *gorm.DB,
+	runID int64,
+	entityType string,
+) Order {
+	if chunkSize <= 0 {
+		panic("chunkSize must be a positive integer")
+	}
 	if maxWorkers <= 0 {
 		panic("maxWorkers must be a positive integer")
 	}
@@ -73,8 +125,10 @@ func NewOrder(ctx context.Context, chunkSize, maxWorkers int, filepath string, d
 	return &orderImpl{
 		ctx:        ctx,
 		chunkSize:  chunkSize,
+		entityType: entityType,
 		maxWorkers: maxWorkers,
 		filepath:   filepath,
+		runID:      runID,
 		db:         db,
 		workers:    make(chan struct{}, maxWorkers),
 	}

--- a/src/batch/order.go
+++ b/src/batch/order.go
@@ -13,6 +13,7 @@ type Order interface {
 	getMaxWorkers() int
 	getFilePath() string
 	getRunID() int64
+	shouldResumeProgress() bool
 	getDB() *gorm.DB
 	submitWorker(context.Context, func()) bool
 	withDB(*gorm.DB) Order
@@ -25,6 +26,7 @@ type orderImpl struct {
 	maxWorkers int
 	filepath   string
 	runID      int64
+	resume     bool
 	db         *gorm.DB
 	workers    chan struct{}
 }
@@ -51,6 +53,10 @@ func (o *orderImpl) getFilePath() string {
 
 func (o *orderImpl) getRunID() int64 {
 	return o.runID
+}
+
+func (o *orderImpl) shouldResumeProgress() bool {
+	return o.resume
 }
 
 func (o *orderImpl) getDB() *gorm.DB {
@@ -83,7 +89,7 @@ func (o *orderImpl) withDB(db *gorm.DB) Order {
 }
 
 func NewOrder(ctx context.Context, chunkSize, maxWorkers int, filepath string, db *gorm.DB) Order {
-	return newOrder(ctx, chunkSize, maxWorkers, filepath, db, 0, "")
+	return newOrder(ctx, chunkSize, maxWorkers, filepath, db, 0, "", false)
 }
 
 func NewTrackedOrder(
@@ -94,6 +100,7 @@ func NewTrackedOrder(
 	db *gorm.DB,
 	runID int64,
 	entityType string,
+	resume bool,
 ) Order {
 	if runID <= 0 {
 		panic("runID must be a positive integer")
@@ -101,7 +108,7 @@ func NewTrackedOrder(
 	if entityType == "" {
 		panic("entityType must not be empty")
 	}
-	return newOrder(ctx, chunkSize, maxWorkers, filepath, db, runID, entityType)
+	return newOrder(ctx, chunkSize, maxWorkers, filepath, db, runID, entityType, resume)
 }
 
 func newOrder(
@@ -112,6 +119,7 @@ func newOrder(
 	db *gorm.DB,
 	runID int64,
 	entityType string,
+	resume bool,
 ) Order {
 	if chunkSize <= 0 {
 		panic("chunkSize must be a positive integer")
@@ -129,6 +137,7 @@ func newOrder(
 		maxWorkers: maxWorkers,
 		filepath:   filepath,
 		runID:      runID,
+		resume:     resume,
 		db:         db,
 		workers:    make(chan struct{}, maxWorkers),
 	}

--- a/src/batch/performance_test.go
+++ b/src/batch/performance_test.go
@@ -1,0 +1,104 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/cache"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	"github.com/dsub-io/open-discogs-model/model"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const (
+	benchmarkCheckpointView = "discogs_import_checkpoint"
+	benchmarkChunkSize      = 5
+	benchmarkMaxWorkers     = 2
+)
+
+var benchmarkFixtures = []struct {
+	path string
+	step func(Order) Step
+}{
+	{path: "testdata/artist.xml.gz", step: newBatch().UpdateArtist},
+	{path: "testdata/label.xml.gz", step: newBatch().UpdateLabel},
+	{path: "testdata/master.xml.gz", step: newBatch().UpdateMaster},
+	{path: "testdata/release.xml.gz", step: newBatch().UpdateRelease},
+}
+
+func BenchmarkBatchImport(b *testing.B) {
+	pg := testutils.GetDatabase(b, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(b, err)
+	require.NoError(b, RunDDL(db))
+	fixtureBytes := benchmarkFixtureBytes(b)
+
+	b.Run("initial", func(b *testing.B) {
+		b.SetBytes(fixtureBytes)
+		for range b.N {
+			b.StopTimer()
+			resetBenchmarkDatabase(b, db)
+			b.StartTimer()
+			runBenchmarkImport(b, db)
+		}
+	})
+
+	b.Run("repeat", func(b *testing.B) {
+		b.StopTimer()
+		resetBenchmarkDatabase(b, db)
+		runBenchmarkImport(b, db)
+		b.StartTimer()
+		b.SetBytes(fixtureBytes)
+		for range b.N {
+			runBenchmarkImport(b, db)
+		}
+	})
+}
+
+func benchmarkFixtureBytes(b *testing.B) int64 {
+	b.Helper()
+	var total int64
+	for _, fixture := range benchmarkFixtures {
+		info, err := os.Stat(fixture.path)
+		require.NoError(b, err)
+		total += info.Size()
+	}
+	return total
+}
+
+func resetBenchmarkDatabase(b *testing.B, db *gorm.DB) {
+	b.Helper()
+	tables := make([]string, 0, len(model.TableNames))
+	for _, table := range model.TableNames {
+		if table == benchmarkCheckpointView {
+			continue
+		}
+		tables = append(tables, fmt.Sprintf(`public."%s"`, table))
+	}
+	statement := fmt.Sprintf(
+		"truncate table %s restart identity cascade",
+		strings.Join(tables, ", "),
+	)
+	require.NoError(b, db.Exec(statement).Error)
+	cache.ResetIDs()
+}
+
+func runBenchmarkImport(b *testing.B, db *gorm.DB) {
+	b.Helper()
+	ctx := context.Background()
+	for _, fixture := range benchmarkFixtures {
+		result := fixture.step(NewOrder(
+			ctx,
+			benchmarkChunkSize,
+			benchmarkMaxWorkers,
+			fixture.path,
+			db,
+		))()
+		require.NoError(b, result.Err())
+	}
+}

--- a/src/batch/performance_test.go
+++ b/src/batch/performance_test.go
@@ -2,7 +2,11 @@ package batch
 
 import (
 	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -10,6 +14,7 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
 	"github.com/dsub-io/go-open-discogs-batch/src/cache"
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	fileutil "github.com/dsub-io/go-open-discogs-batch/src/file"
 	"github.com/dsub-io/open-discogs-model/model"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -19,19 +24,111 @@ const (
 	benchmarkCheckpointView = "discogs_import_checkpoint"
 	benchmarkChunkSize      = 5
 	benchmarkMaxWorkers     = 2
+	benchmarkPreflightBytes = 64 << 20
 )
 
 var benchmarkFixtures = []struct {
-	path string
-	step func(Order) Step
+	entityType string
+	path       string
+	step       func(Order) Step
 }{
-	{path: "testdata/artist.xml.gz", step: newBatch().UpdateArtist},
-	{path: "testdata/label.xml.gz", step: newBatch().UpdateLabel},
-	{path: "testdata/master.xml.gz", step: newBatch().UpdateMaster},
-	{path: "testdata/release.xml.gz", step: newBatch().UpdateRelease},
+	{entityType: "artist", path: "testdata/artist.xml.gz", step: newBatch().UpdateArtist},
+	{entityType: "label", path: "testdata/label.xml.gz", step: newBatch().UpdateLabel},
+	{entityType: "master", path: "testdata/master.xml.gz", step: newBatch().UpdateMaster},
+	{entityType: "release", path: "testdata/release.xml.gz", step: newBatch().UpdateRelease},
+}
+
+func BenchmarkCompletedManifestPreflight(b *testing.B) {
+	restoreOutput := silenceBenchmarkOutput(b)
+	defer restoreOutput()
+	ctx := context.Background()
+	pg := testutils.GetDatabase(b, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(b, err)
+	require.NoError(b, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(b, err)
+	dumps := []*model.DiscogsDump{
+		importDump("artist", "2026-07-01", "c"),
+	}
+	completed := NewImportExecutionCoordinator(sqlDB, "preflight-benchmark")
+	preparation, err := completed.Prepare(
+		ctx,
+		dumps,
+		benchmarkChunkSize,
+		false,
+		false,
+	)
+	require.NoError(b, err)
+	order := NewTrackedOrder(
+		ctx,
+		benchmarkChunkSize,
+		benchmarkMaxWorkers,
+		"unused",
+		db,
+		preparation.RunID,
+		"artist",
+		false,
+	)
+	require.NoError(b, completeEntityProgress(order, 0, 0))
+	require.NoError(b, completed.Complete(ctx, nil))
+
+	resourcePath, checksum := benchmarkPreflightResource(b)
+	handler := fileutil.NewHandler()
+	b.SetBytes(benchmarkPreflightBytes)
+
+	b.Run("checksum_before_admission", func(b *testing.B) {
+		b.SetBytes(benchmarkPreflightBytes)
+		for range b.N {
+			require.NoError(b, handler.Checksum(resourcePath, checksum))
+			prepareCompletedManifest(b, ctx, sqlDB, dumps)
+		}
+	})
+
+	b.Run("admission_before_checksum", func(b *testing.B) {
+		b.SetBytes(benchmarkPreflightBytes)
+		for range b.N {
+			prepareCompletedManifest(b, ctx, sqlDB, dumps)
+		}
+	})
+}
+
+func benchmarkPreflightResource(b *testing.B) (string, string) {
+	b.Helper()
+	resource, err := os.CreateTemp(b.TempDir(), "completed-manifest-*.xml.gz")
+	require.NoError(b, err)
+	require.NoError(b, resource.Truncate(benchmarkPreflightBytes))
+	_, err = resource.Seek(0, io.SeekStart)
+	require.NoError(b, err)
+	hash := sha256.New()
+	_, err = io.Copy(hash, resource)
+	require.NoError(b, err)
+	require.NoError(b, resource.Close())
+	return resource.Name(), hex.EncodeToString(hash.Sum(nil))
+}
+
+func prepareCompletedManifest(
+	b *testing.B,
+	ctx context.Context,
+	db *sql.DB,
+	dumps []*model.DiscogsDump,
+) {
+	b.Helper()
+	coordinator := NewImportExecutionCoordinator(db, "preflight-benchmark")
+	preparation, err := coordinator.Prepare(
+		ctx,
+		dumps,
+		benchmarkChunkSize,
+		false,
+		false,
+	)
+	require.NoError(b, err)
+	require.True(b, preparation.Skipped)
 }
 
 func BenchmarkBatchImport(b *testing.B) {
+	restoreOutput := silenceBenchmarkOutput(b)
+	defer restoreOutput()
 	pg := testutils.GetDatabase(b, testutils.Postgres)
 	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
 	require.NoError(b, err)
@@ -58,6 +155,101 @@ func BenchmarkBatchImport(b *testing.B) {
 			runBenchmarkImport(b, db)
 		}
 	})
+}
+
+func BenchmarkDurableBatchImport(b *testing.B) {
+	restoreOutput := silenceBenchmarkOutput(b)
+	defer restoreOutput()
+	pg := testutils.GetDatabase(b, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(b, err)
+	require.NoError(b, RunDDL(db))
+	fixtureBytes := benchmarkFixtureBytes(b)
+	dumps := benchmarkImportDumps()
+
+	b.Run("initial", func(b *testing.B) {
+		b.SetBytes(fixtureBytes)
+		for range b.N {
+			b.StopTimer()
+			resetBenchmarkDatabase(b, db)
+			b.StartTimer()
+			runDurableBenchmarkImport(b, db, dumps, false)
+		}
+	})
+
+	b.Run("forced_repeat", func(b *testing.B) {
+		b.StopTimer()
+		resetBenchmarkDatabase(b, db)
+		runDurableBenchmarkImport(b, db, dumps, false)
+		b.StartTimer()
+		b.SetBytes(fixtureBytes)
+		for range b.N {
+			runDurableBenchmarkImport(b, db, dumps, true)
+		}
+	})
+}
+
+func benchmarkImportDumps() []*model.DiscogsDump {
+	dumps := make([]*model.DiscogsDump, 0, len(benchmarkFixtures))
+	for index, fixture := range benchmarkFixtures {
+		dumps = append(dumps, importDump(
+			fixture.entityType,
+			"2026-07-01",
+			fmt.Sprintf("%x", index+1),
+		))
+	}
+	return dumps
+}
+
+func runDurableBenchmarkImport(
+	b *testing.B,
+	db *gorm.DB,
+	dumps []*model.DiscogsDump,
+	force bool,
+) {
+	b.Helper()
+	ctx := context.Background()
+	sqlDB, err := db.DB()
+	require.NoError(b, err)
+	coordinator := NewImportExecutionCoordinator(sqlDB, "durable-benchmark")
+	preparation, err := coordinator.Prepare(
+		ctx,
+		dumps,
+		benchmarkChunkSize,
+		force,
+		false,
+	)
+	require.NoError(b, err)
+	require.False(b, preparation.Skipped)
+	for _, fixture := range benchmarkFixtures {
+		result := fixture.step(NewTrackedOrder(
+			ctx,
+			benchmarkChunkSize,
+			benchmarkMaxWorkers,
+			fixture.path,
+			db,
+			preparation.RunID,
+			fixture.entityType,
+			false,
+		))()
+		require.NoError(b, result.Err())
+	}
+	require.NoError(b, coordinator.Complete(ctx, nil))
+}
+
+func silenceBenchmarkOutput(b *testing.B) func() {
+	b.Helper()
+	output, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(b, err)
+	standardOutput := os.Stdout
+	standardError := os.Stderr
+	os.Stdout = output
+	os.Stderr = output
+	return func() {
+		os.Stdout = standardOutput
+		os.Stderr = standardError
+		require.NoError(b, output.Close())
+	}
 }
 
 func benchmarkFixtureBytes(b *testing.B) int64 {

--- a/src/batch/progress.go
+++ b/src/batch/progress.go
@@ -13,6 +13,45 @@ type ChunkMetadata struct {
 	ItemCount      int
 }
 
+func executeActiveRunTransaction(
+	order Order,
+	write func(Order) result.Result,
+) result.Result {
+	if order.getRunID() == 0 {
+		return write(order)
+	}
+	written := result.NewResult(0, nil)
+	err := order.getDB().WithContext(order.getContext()).Transaction(func(tx *gorm.DB) error {
+		written = write(order.withDB(tx))
+		if written.IsErr() {
+			return written.Err()
+		}
+		type activeImportRun struct {
+			ID int64
+		}
+		var active activeImportRun
+		fenced := tx.Raw(
+			`select id
+			   from public.discogs_import_run
+			  where id = ?
+			    and status = 'running'
+			  for update`,
+			order.getRunID(),
+		).Scan(&active)
+		if fenced.Error != nil {
+			return fmt.Errorf("fence active import run %d: %w", order.getRunID(), fenced.Error)
+		}
+		if fenced.RowsAffected != 1 || active.ID != order.getRunID() {
+			return fmt.Errorf("fence active import run %d: run is not active", order.getRunID())
+		}
+		return nil
+	})
+	if err != nil {
+		return result.NewResult(0, err)
+	}
+	return written
+}
+
 func executeChunk(
 	order Order,
 	chunk ChunkMetadata,
@@ -21,7 +60,7 @@ func executeChunk(
 	db := order.getDB().WithContext(order.getContext())
 	written := result.NewResult(0, nil)
 	err := db.Transaction(func(tx *gorm.DB) error {
-		if order.getRunID() != 0 {
+		if order.shouldResumeProgress() {
 			completed, checkErr := chunkAlreadyCompleted(tx, order, chunk)
 			if checkErr != nil {
 				return checkErr
@@ -96,41 +135,34 @@ func recordCompletedChunk(
 	order Order,
 	chunk ChunkMetadata,
 ) error {
-	inserted := tx.Exec(
-		`insert into public.discogs_import_run_chunk
-		    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
-		 values (?, ?, ?, ?, ?)
-		 on conflict do nothing`,
+	updated := tx.Exec(
+		`with active_run as (
+		    select id
+		      from public.discogs_import_run
+		     where id = ?
+		       and status = 'running'
+		     for update
+		),
+		inserted as (
+		    insert into public.discogs_import_run_chunk
+		        (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+		    select active_run.id, ?, ?, ?, ?
+		      from active_run
+		    on conflict do nothing
+		    returning item_count
+		)
+		update public.discogs_import_run_dump run_dump
+		   set processed_items = run_dump.processed_items + inserted.item_count,
+		       last_progress_at = now()
+		  from inserted
+		 where run_dump.import_run_id = ?
+		   and run_dump.entity_type = ?
+		   and run_dump.chunk_size = ?
+		   and run_dump.completed_at is null`,
 		order.getRunID(),
 		order.getEntityType(),
 		chunk.Index,
 		chunk.FirstItemIndex,
-		chunk.ItemCount,
-	)
-	if inserted.Error != nil {
-		return fmt.Errorf(
-			"record %s chunk %d progress: %w",
-			order.getEntityType(),
-			chunk.Index,
-			inserted.Error,
-		)
-	}
-	if inserted.RowsAffected != 1 {
-		return fmt.Errorf(
-			"record %s chunk %d progress: completion already exists",
-			order.getEntityType(),
-			chunk.Index,
-		)
-	}
-
-	updated := tx.Exec(
-		`update public.discogs_import_run_dump
-		    set processed_items = processed_items + ?,
-		        last_progress_at = now()
-		  where import_run_id = ?
-		    and entity_type = ?
-		    and chunk_size = ?
-		    and completed_at is null`,
 		chunk.ItemCount,
 		order.getRunID(),
 		order.getEntityType(),
@@ -138,7 +170,7 @@ func recordCompletedChunk(
 	)
 	if updated.Error != nil {
 		return fmt.Errorf(
-			"advance %s chunk %d progress: %w",
+			"record %s chunk %d progress: %w",
 			order.getEntityType(),
 			chunk.Index,
 			updated.Error,
@@ -146,7 +178,7 @@ func recordCompletedChunk(
 	}
 	if updated.RowsAffected != 1 {
 		return fmt.Errorf(
-			"advance %s chunk %d progress: run summary is unavailable",
+			"record %s chunk %d progress: run is not active, completion already exists, or run summary is unavailable",
 			order.getEntityType(),
 			chunk.Index,
 		)
@@ -159,11 +191,19 @@ func completeEntityProgress(order Order, totalItems, totalChunks int64) error {
 		return nil
 	}
 	updated := order.getDB().WithContext(order.getContext()).Exec(
-		`with coverage as (
+		`with active_run as (
+		    select id
+		      from public.discogs_import_run
+		     where id = ?
+		       and status = 'running'
+		     for update
+		),
+		coverage as (
 		    select count(*) as completed_chunks,
 		           coalesce(sum(item_count), 0) as completed_items,
 		           count(*) filter (
-		               where first_item_index <> chunk_index * ?
+		               where chunk_index >= ?
+		                  or first_item_index <> chunk_index * ?
 		                  or item_count <> case
 		                      when chunk_index = ? - 1 then ? - first_item_index
 		                      else ?
@@ -178,14 +218,16 @@ func completeEntityProgress(order Order, totalItems, totalChunks int64) error {
 		       total_chunks = ?,
 		       completed_at = now(),
 		       last_progress_at = now()
-		  from coverage
-		 where import_run_id = ?
+		  from coverage, active_run
+		 where import_run_id = active_run.id
 		   and entity_type = ?
 		   and chunk_size = ?
 		   and processed_items = ?
 		   and coverage.completed_chunks = ?
 		   and coverage.completed_items = ?
 		   and coverage.invalid_chunks = 0`,
+		order.getRunID(),
+		totalChunks,
 		order.getChunkSize(),
 		totalChunks,
 		totalItems,
@@ -194,7 +236,6 @@ func completeEntityProgress(order Order, totalItems, totalChunks int64) error {
 		order.getEntityType(),
 		totalItems,
 		totalChunks,
-		order.getRunID(),
 		order.getEntityType(),
 		order.getChunkSize(),
 		totalItems,

--- a/src/batch/progress.go
+++ b/src/batch/progress.go
@@ -1,0 +1,216 @@
+package batch
+
+import (
+	"fmt"
+
+	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	"gorm.io/gorm"
+)
+
+type ChunkMetadata struct {
+	Index          int64
+	FirstItemIndex int64
+	ItemCount      int
+}
+
+func executeChunk(
+	order Order,
+	chunk ChunkMetadata,
+	write func(Order) result.Result,
+) result.Result {
+	db := order.getDB().WithContext(order.getContext())
+	written := result.NewResult(0, nil)
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if order.getRunID() != 0 {
+			completed, checkErr := chunkAlreadyCompleted(tx, order, chunk)
+			if checkErr != nil {
+				return checkErr
+			}
+			if completed {
+				return nil
+			}
+		}
+
+		written = write(order.withDB(tx))
+		if written.IsErr() {
+			return written.Err()
+		}
+		if order.getRunID() == 0 {
+			return nil
+		}
+		return recordCompletedChunk(tx, order, chunk)
+	})
+	if err != nil {
+		return result.NewResult(0, err)
+	}
+	return written
+}
+
+func chunkAlreadyCompleted(
+	tx *gorm.DB,
+	order Order,
+	chunk ChunkMetadata,
+) (bool, error) {
+	type recordedChunk struct {
+		FirstItemIndex int64
+		ItemCount      int
+	}
+	var recorded recordedChunk
+	query := tx.Raw(
+		`select first_item_index, item_count
+		   from public.discogs_import_run_chunk
+		  where import_run_id = ?
+		    and entity_type = ?
+		    and chunk_index = ?`,
+		order.getRunID(),
+		order.getEntityType(),
+		chunk.Index,
+	).Scan(&recorded)
+	if query.Error != nil {
+		return false, fmt.Errorf(
+			"check %s chunk %d progress: %w",
+			order.getEntityType(),
+			chunk.Index,
+			query.Error,
+		)
+	}
+	if query.RowsAffected == 0 {
+		return false, nil
+	}
+	if recorded.FirstItemIndex != chunk.FirstItemIndex || recorded.ItemCount != chunk.ItemCount {
+		return false, fmt.Errorf(
+			"check %s chunk %d progress: recorded range (%d, %d) does not match source range (%d, %d)",
+			order.getEntityType(),
+			chunk.Index,
+			recorded.FirstItemIndex,
+			recorded.ItemCount,
+			chunk.FirstItemIndex,
+			chunk.ItemCount,
+		)
+	}
+	return true, nil
+}
+
+func recordCompletedChunk(
+	tx *gorm.DB,
+	order Order,
+	chunk ChunkMetadata,
+) error {
+	inserted := tx.Exec(
+		`insert into public.discogs_import_run_chunk
+		    (import_run_id, entity_type, chunk_index, first_item_index, item_count)
+		 values (?, ?, ?, ?, ?)
+		 on conflict do nothing`,
+		order.getRunID(),
+		order.getEntityType(),
+		chunk.Index,
+		chunk.FirstItemIndex,
+		chunk.ItemCount,
+	)
+	if inserted.Error != nil {
+		return fmt.Errorf(
+			"record %s chunk %d progress: %w",
+			order.getEntityType(),
+			chunk.Index,
+			inserted.Error,
+		)
+	}
+	if inserted.RowsAffected != 1 {
+		return fmt.Errorf(
+			"record %s chunk %d progress: completion already exists",
+			order.getEntityType(),
+			chunk.Index,
+		)
+	}
+
+	updated := tx.Exec(
+		`update public.discogs_import_run_dump
+		    set processed_items = processed_items + ?,
+		        last_progress_at = now()
+		  where import_run_id = ?
+		    and entity_type = ?
+		    and chunk_size = ?
+		    and completed_at is null`,
+		chunk.ItemCount,
+		order.getRunID(),
+		order.getEntityType(),
+		order.getChunkSize(),
+	)
+	if updated.Error != nil {
+		return fmt.Errorf(
+			"advance %s chunk %d progress: %w",
+			order.getEntityType(),
+			chunk.Index,
+			updated.Error,
+		)
+	}
+	if updated.RowsAffected != 1 {
+		return fmt.Errorf(
+			"advance %s chunk %d progress: run summary is unavailable",
+			order.getEntityType(),
+			chunk.Index,
+		)
+	}
+	return nil
+}
+
+func completeEntityProgress(order Order, totalItems, totalChunks int64) error {
+	if order.getRunID() == 0 {
+		return nil
+	}
+	updated := order.getDB().WithContext(order.getContext()).Exec(
+		`with coverage as (
+		    select count(*) as completed_chunks,
+		           coalesce(sum(item_count), 0) as completed_items,
+		           count(*) filter (
+		               where first_item_index <> chunk_index * ?
+		                  or item_count <> case
+		                      when chunk_index = ? - 1 then ? - first_item_index
+		                      else ?
+		                  end
+		           ) as invalid_chunks
+		      from public.discogs_import_run_chunk
+		     where import_run_id = ?
+		       and entity_type = ?
+		)
+		update public.discogs_import_run_dump
+		   set total_items = ?,
+		       total_chunks = ?,
+		       completed_at = now(),
+		       last_progress_at = now()
+		  from coverage
+		 where import_run_id = ?
+		   and entity_type = ?
+		   and chunk_size = ?
+		   and processed_items = ?
+		   and coverage.completed_chunks = ?
+		   and coverage.completed_items = ?
+		   and coverage.invalid_chunks = 0`,
+		order.getChunkSize(),
+		totalChunks,
+		totalItems,
+		order.getChunkSize(),
+		order.getRunID(),
+		order.getEntityType(),
+		totalItems,
+		totalChunks,
+		order.getRunID(),
+		order.getEntityType(),
+		order.getChunkSize(),
+		totalItems,
+		totalChunks,
+		totalItems,
+	)
+	if updated.Error != nil {
+		return fmt.Errorf("complete %s progress: %w", order.getEntityType(), updated.Error)
+	}
+	if updated.RowsAffected != 1 {
+		return fmt.Errorf(
+			"complete %s progress: chunk coverage does not match %d items in %d chunks",
+			order.getEntityType(),
+			totalItems,
+			totalChunks,
+		)
+	}
+	return nil
+}

--- a/src/batch/progress_test.go
+++ b/src/batch/progress_test.go
@@ -2,11 +2,13 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
 	"github.com/dsub-io/go-open-discogs-batch/src/cache"
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	"github.com/dsub-io/go-open-discogs-batch/src/result"
 	"github.com/dsub-io/open-discogs-model/model"
 	"github.com/knadh/koanf"
 	"github.com/stretchr/testify/require"
@@ -14,9 +16,81 @@ import (
 )
 
 const (
-	progressFailureFunction = "fail_selected_import_chunk"
-	progressFailureTrigger  = "fail_selected_import_chunk_trigger"
+	progressCompletionFailureFunction = "fail_import_completion"
+	progressCompletionFailureTrigger  = "fail_import_completion_trigger"
+	progressFailureFunction           = "fail_selected_import_chunk"
+	progressFailureTrigger            = "fail_selected_import_chunk_trigger"
+	progressTransferFailureFunction   = "fail_import_progress_transfer"
+	progressTransferFailureTrigger    = "fail_import_progress_transfer_trigger"
 )
+
+func TestFailedRunRejectsLateChunkAndEntityCompletion(t *testing.T) {
+	const (
+		chunkSize  = 1
+		entityType = "master"
+	)
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	dumps := []*model.DiscogsDump{
+		importDump(entityType, "2026-07-01", "f"),
+	}
+	coordinator := NewImportExecutionCoordinator(sqlDB, "late-worker-test")
+	preparation, err := coordinator.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	require.NoError(t, coordinator.Complete(ctx, errors.New("fixture failure")))
+	order := NewTrackedOrder(
+		ctx,
+		chunkSize,
+		1,
+		"unused",
+		db,
+		preparation.RunID,
+		entityType,
+		false,
+	)
+
+	lateChunk := executeChunk(
+		order,
+		ChunkMetadata{Index: 0, FirstItemIndex: 0, ItemCount: 1},
+		func(transactionOrder Order) result.Result {
+			writeErr := transactionOrder.getDB().Exec(
+				"insert into public.genre (name) values ('late-worker-fixture')",
+			).Error
+			return result.NewResult(1, writeErr)
+		},
+	)
+	require.ErrorContains(t, lateChunk.Err(), "run is not active")
+	var genreRows int64
+	require.NoError(t, db.Raw(
+		"select count(*) from public.genre where name = 'late-worker-fixture'",
+	).Scan(&genreRows).Error)
+	require.Zero(t, genreRows)
+	require.Empty(t, completedChunkIndexes(t, db, preparation.RunID, entityType))
+	_, err = insertBySlice[*model.Genre](order)(ctx, []*model.Genre{{Name: "late-simple-fixture"}})
+	require.ErrorContains(t, err, "run is not active")
+	require.NoError(t, db.Raw(
+		"select count(*) from public.genre where name = 'late-simple-fixture'",
+	).Scan(&genreRows).Error)
+	require.Zero(t, genreRows)
+
+	err = completeEntityProgress(order, 0, 0)
+	require.ErrorContains(t, err, "chunk coverage does not match")
+	var completed bool
+	require.NoError(t, db.Raw(
+		`select completed_at is not null
+		   from public.discogs_import_run_dump
+		  where import_run_id = ?
+		    and entity_type = ?`,
+		preparation.RunID,
+		entityType,
+	).Scan(&completed).Error)
+	require.False(t, completed)
+}
 
 func TestImportResumesOutOfOrderChunks(t *testing.T) {
 	const (
@@ -64,12 +138,18 @@ func TestImportResumesOutOfOrderChunks(t *testing.T) {
 		db,
 		failedPreparation.RunID,
 		entityType,
+		false,
 	))
 	require.ErrorContains(t, failed.Err(), "intentional chunk failure")
 	require.NoError(t, failedCoordinator.Complete(ctx, failed.Err()))
 
 	committedBeforeRetry := completedChunkIndexes(t, db, failedPreparation.RunID, entityType)
 	require.ElementsMatch(t, []int64{0, 2}, committedBeforeRetry)
+	var rolledBackRows int64
+	require.NoError(t, db.Raw(
+		"select count(*) from public.master where id = 2",
+	).Scan(&rolledBackRows).Error)
+	require.Zero(t, rolledBackRows)
 	removeChunkFailure(t, db)
 
 	retryCoordinator := NewImportExecutionCoordinator(sqlDB, "resume-test")
@@ -97,6 +177,7 @@ func TestImportResumesOutOfOrderChunks(t *testing.T) {
 		db,
 		retryPreparation.RunID,
 		entityType,
+		true,
 	))
 	require.NoError(t, retried.Err())
 	require.NoError(t, retryCoordinator.Complete(ctx, nil))
@@ -122,10 +203,235 @@ func TestImportResumesOutOfOrderChunks(t *testing.T) {
 		db,
 		forcedPreparation.RunID,
 		entityType,
+		false,
 	))
 	require.NoError(t, forced.Err())
 	require.NoError(t, forcedCoordinator.Complete(ctx, nil))
 	require.Equal(t, resumedState, normalizedBusinessState(t, db))
+}
+
+func TestImportCompletionFailureRemainsResumable(t *testing.T) {
+	const (
+		chunkSize  = 1
+		maxWorkers = 2
+		entityType = "master"
+	)
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	cache.ResetIDs()
+	artistSeed := GetArtistStep(NewOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/artist.xml.gz",
+		db,
+	))()
+	require.NoError(t, artistSeed.Err())
+
+	dumps := []*model.DiscogsDump{
+		importDump(entityType, "2026-07-01", "a"),
+	}
+	coordinator := NewImportExecutionCoordinator(sqlDB, "completion-failure-test")
+	preparation, err := coordinator.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	written := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		preparation.RunID,
+		entityType,
+		false,
+	))
+	require.NoError(t, written.Err())
+	installCompletionFailure(t, db)
+
+	err = coordinator.Complete(ctx, nil)
+	require.ErrorContains(t, err, "intentional completion failure")
+	var status string
+	require.NoError(t, db.Raw(
+		"select status from public.discogs_import_run where id = ?",
+		preparation.RunID,
+	).Scan(&status).Error)
+	require.Equal(t, "running", status)
+	require.ElementsMatch(
+		t,
+		[]int64{0, 1, 2},
+		completedChunkIndexes(t, db, preparation.RunID, entityType),
+	)
+	removeCompletionFailure(t, db)
+
+	retry := NewImportExecutionCoordinator(sqlDB, "completion-failure-test")
+	retryPreparation, err := retry.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	require.Equal(t, preparation.RunID, retryPreparation.ResumedFromRunID)
+	retried := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		retryPreparation.RunID,
+		entityType,
+		true,
+	))
+	require.NoError(t, retried.Err())
+	require.Zero(t, retried.Count())
+	require.NoError(t, retry.Complete(ctx, nil))
+}
+
+func TestResumeAdmissionTransferIsAtomic(t *testing.T) {
+	const (
+		chunkSize  = 1
+		maxWorkers = 2
+		entityType = "master"
+	)
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	cache.ResetIDs()
+	artistSeed := GetArtistStep(NewOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/artist.xml.gz",
+		db,
+	))()
+	require.NoError(t, artistSeed.Err())
+	dumps := []*model.DiscogsDump{
+		importDump(entityType, "2026-07-01", "b"),
+	}
+	failed := NewImportExecutionCoordinator(sqlDB, "transfer-failure-test")
+	failedPreparation, err := failed.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	written := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		failedPreparation.RunID,
+		entityType,
+		false,
+	))
+	require.NoError(t, written.Err())
+	require.NoError(t, failed.Complete(ctx, context.Canceled))
+	installTransferFailure(t, db)
+
+	failedTransfer := NewImportExecutionCoordinator(sqlDB, "transfer-failure-test")
+	_, err = failedTransfer.Prepare(ctx, dumps, chunkSize, false, false)
+	require.ErrorContains(t, err, "intentional progress transfer failure")
+	require.ElementsMatch(
+		t,
+		[]int64{0, 1, 2},
+		completedChunkIndexes(t, db, failedPreparation.RunID, entityType),
+	)
+	var runCount int64
+	require.NoError(t, db.Raw(
+		"select count(*) from public.discogs_import_run",
+	).Scan(&runCount).Error)
+	require.Equal(t, int64(1), runCount)
+	removeTransferFailure(t, db)
+
+	retry := NewImportExecutionCoordinator(sqlDB, "transfer-failure-test")
+	retryPreparation, err := retry.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	require.Equal(t, failedPreparation.RunID, retryPreparation.ResumedFromRunID)
+	retried := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		retryPreparation.RunID,
+		entityType,
+		true,
+	))
+	require.NoError(t, retried.Err())
+	require.Zero(t, retried.Count())
+	require.NoError(t, retry.Complete(ctx, nil))
+}
+
+func TestMultiEntityResumeSkipsCompletedEntity(t *testing.T) {
+	const (
+		chunkSize  = 1
+		maxWorkers = 2
+	)
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	dumps := []*model.DiscogsDump{
+		importDump("artist", "2026-07-01", "d"),
+		importDump("master", "2026-07-01", "e"),
+	}
+
+	cache.ResetIDs()
+	failed := NewImportExecutionCoordinator(sqlDB, "multi-entity-resume-test")
+	failedPreparation, err := failed.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	artist := GetArtistStep(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/artist.xml.gz",
+		db,
+		failedPreparation.RunID,
+		"artist",
+		false,
+	))()
+	require.NoError(t, artist.Err())
+	assertCompletedRunSummary(t, db, failedPreparation.RunID, "artist", 3, 3)
+	require.NoError(t, failed.Complete(ctx, context.Canceled))
+
+	cache.ResetIDs()
+	retry := NewImportExecutionCoordinator(sqlDB, "multi-entity-resume-test")
+	retryPreparation, err := retry.Prepare(ctx, dumps, chunkSize, false, false)
+	require.NoError(t, err)
+	require.Equal(t, failedPreparation.RunID, retryPreparation.ResumedFromRunID)
+	repeatedArtist := GetArtistStep(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/artist.xml.gz",
+		db,
+		retryPreparation.RunID,
+		"artist",
+		true,
+	))()
+	require.NoError(t, repeatedArtist.Err())
+	require.Zero(t, repeatedArtist.Count())
+	master := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		retryPreparation.RunID,
+		"master",
+		true,
+	))
+	require.NoError(t, master.Err())
+	require.NoError(t, retry.Complete(ctx, nil))
+	assertCompletedRunSummary(t, db, retryPreparation.RunID, "artist", 3, 3)
+	assertCompletedRunSummary(t, db, retryPreparation.RunID, "master", 3, 3)
+	require.Empty(t, completedChunkIndexes(t, db, retryPreparation.RunID, "artist"))
+	require.Empty(t, completedChunkIndexes(t, db, retryPreparation.RunID, "master"))
 }
 
 func TestReleaseInterruptionConvergesWhenManifestExpands(t *testing.T) {
@@ -173,6 +479,7 @@ func TestReleaseInterruptionConvergesWhenManifestExpands(t *testing.T) {
 		db,
 		interruptedPreparation.RunID,
 		"release",
+		false,
 	))
 	require.ErrorContains(t, interrupted.Err(), "intentional chunk failure")
 	require.ElementsMatch(
@@ -197,7 +504,11 @@ func TestReleaseInterruptionConvergesWhenManifestExpands(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Zero(t, expandedPreparation.ResumedFromRunID)
-	require.Empty(t, completedChunkIndexes(t, db, interruptedPreparation.RunID, "release"))
+	require.ElementsMatch(
+		t,
+		[]int64{0, 2},
+		completedChunkIndexes(t, db, interruptedPreparation.RunID, "release"),
+	)
 	var interruptedStatus string
 	require.NoError(t, db.Raw(
 		"select status from public.discogs_import_run where id = ?",
@@ -221,6 +532,7 @@ func TestReleaseInterruptionConvergesWhenManifestExpands(t *testing.T) {
 		db,
 		expandedPreparation.RunID,
 		"artist",
+		false,
 	))()
 	require.NoError(t, artistResult.Err())
 	releaseResult := insertReleases(NewTrackedOrder(
@@ -231,11 +543,13 @@ func TestReleaseInterruptionConvergesWhenManifestExpands(t *testing.T) {
 		db,
 		expandedPreparation.RunID,
 		"release",
+		false,
 	))
 	require.NoError(t, releaseResult.Err())
 	require.NoError(t, expandedCoordinator.Complete(ctx, nil))
 	assertCompletedRunSummary(t, db, expandedPreparation.RunID, "artist", 3, 3)
 	assertCompletedRunSummary(t, db, expandedPreparation.RunID, "release", 3, 3)
+	require.Empty(t, completedChunkIndexes(t, db, interruptedPreparation.RunID, "release"))
 
 	repeatedCoordinator := NewImportExecutionCoordinator(sqlDB, "manifest-expansion-test")
 	repeatedPreparation, err := repeatedCoordinator.Prepare(
@@ -281,6 +595,71 @@ func removeChunkFailure(t *testing.T, db *gorm.DB) {
 	).Error)
 	require.NoError(t, db.Exec(
 		"drop function if exists public."+progressFailureFunction+"()",
+	).Error)
+}
+
+func installCompletionFailure(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		create or replace function public.fail_import_completion()
+		returns trigger
+		language plpgsql
+		as $function$
+		begin
+		    if new.status = 'success' then
+		        raise exception 'intentional completion failure';
+		    end if;
+		    return new;
+		end
+		$function$;
+
+		create trigger fail_import_completion_trigger
+		before update on public.discogs_import_run
+		for each row execute function public.fail_import_completion();`).Error)
+	t.Cleanup(func() {
+		removeCompletionFailure(t, db)
+	})
+}
+
+func removeCompletionFailure(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		"drop trigger if exists "+progressCompletionFailureTrigger+
+			" on public.discogs_import_run",
+	).Error)
+	require.NoError(t, db.Exec(
+		"drop function if exists public."+progressCompletionFailureFunction+"()",
+	).Error)
+}
+
+func installTransferFailure(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		create or replace function public.fail_import_progress_transfer()
+		returns trigger
+		language plpgsql
+		as $function$
+		begin
+		    raise exception 'intentional progress transfer failure';
+		end
+		$function$;
+
+		create trigger fail_import_progress_transfer_trigger
+		before delete on public.discogs_import_run_chunk
+		for each row execute function public.fail_import_progress_transfer();`).Error)
+	t.Cleanup(func() {
+		removeTransferFailure(t, db)
+	})
+}
+
+func removeTransferFailure(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		"drop trigger if exists "+progressTransferFailureTrigger+
+			" on public.discogs_import_run_chunk",
+	).Error)
+	require.NoError(t, db.Exec(
+		"drop function if exists public."+progressTransferFailureFunction+"()",
 	).Error)
 }
 

--- a/src/batch/progress_test.go
+++ b/src/batch/progress_test.go
@@ -1,0 +1,338 @@
+package batch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/cache"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	"github.com/dsub-io/open-discogs-model/model"
+	"github.com/knadh/koanf"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const (
+	progressFailureFunction = "fail_selected_import_chunk"
+	progressFailureTrigger  = "fail_selected_import_chunk_trigger"
+)
+
+func TestImportResumesOutOfOrderChunks(t *testing.T) {
+	const (
+		chunkSize  = 1
+		maxWorkers = 2
+		entityType = "master"
+	)
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	cache.ResetIDs()
+	artistSeed := GetArtistStep(NewOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/artist.xml.gz",
+		db,
+	))()
+	require.NoError(t, artistSeed.Err())
+
+	dumps := []*model.DiscogsDump{
+		importDump(entityType, "2026-07-01", "9"),
+	}
+	failedCoordinator := NewImportExecutionCoordinator(sqlDB, "resume-test")
+	failedPreparation, err := failedCoordinator.Prepare(
+		ctx,
+		dumps,
+		chunkSize,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	installChunkFailure(t, db)
+
+	failed := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		failedPreparation.RunID,
+		entityType,
+	))
+	require.ErrorContains(t, failed.Err(), "intentional chunk failure")
+	require.NoError(t, failedCoordinator.Complete(ctx, failed.Err()))
+
+	committedBeforeRetry := completedChunkIndexes(t, db, failedPreparation.RunID, entityType)
+	require.ElementsMatch(t, []int64{0, 2}, committedBeforeRetry)
+	removeChunkFailure(t, db)
+
+	retryCoordinator := NewImportExecutionCoordinator(sqlDB, "resume-test")
+	retryPreparation, err := retryCoordinator.Prepare(
+		ctx,
+		dumps,
+		chunkSize,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, failedPreparation.RunID, retryPreparation.ResumedFromRunID)
+	require.ElementsMatch(
+		t,
+		committedBeforeRetry,
+		completedChunkIndexes(t, db, retryPreparation.RunID, entityType),
+	)
+	require.Empty(t, completedChunkIndexes(t, db, failedPreparation.RunID, entityType))
+
+	retried := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		retryPreparation.RunID,
+		entityType,
+	))
+	require.NoError(t, retried.Err())
+	require.NoError(t, retryCoordinator.Complete(ctx, nil))
+	assertCompletedRunSummary(t, db, retryPreparation.RunID, entityType, 3, 3)
+	require.Empty(t, completedChunkIndexes(t, db, retryPreparation.RunID, entityType))
+	resumedState := normalizedBusinessState(t, db)
+
+	forcedCoordinator := NewImportExecutionCoordinator(sqlDB, "resume-test")
+	forcedPreparation, err := forcedCoordinator.Prepare(
+		ctx,
+		dumps,
+		chunkSize,
+		true,
+		false,
+	)
+	require.NoError(t, err)
+	require.Zero(t, forcedPreparation.ResumedFromRunID)
+	forced := InsertMasterRelations(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/master.xml.gz",
+		db,
+		forcedPreparation.RunID,
+		entityType,
+	))
+	require.NoError(t, forced.Err())
+	require.NoError(t, forcedCoordinator.Complete(ctx, nil))
+	require.Equal(t, resumedState, normalizedBusinessState(t, db))
+}
+
+func TestReleaseInterruptionConvergesWhenManifestExpands(t *testing.T) {
+	const (
+		chunkSize  = 1
+		maxWorkers = 2
+	)
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	cache.ResetIDs()
+	for _, seed := range []struct {
+		path string
+		step func(Order) Step
+	}{
+		{path: "testdata/artist.xml.gz", step: newBatch().UpdateArtist},
+		{path: "testdata/label.xml.gz", step: newBatch().UpdateLabel},
+		{path: "testdata/master.xml.gz", step: newBatch().UpdateMaster},
+	} {
+		seedResult := seed.step(NewOrder(ctx, chunkSize, maxWorkers, seed.path, db))()
+		require.NoError(t, seedResult.Err())
+	}
+
+	releaseDump := importDump("release", "2026-07-01", "8")
+	interruptedCoordinator := NewImportExecutionCoordinator(sqlDB, "manifest-expansion-test")
+	interruptedPreparation, err := interruptedCoordinator.Prepare(
+		ctx,
+		[]*model.DiscogsDump{releaseDump},
+		chunkSize,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	installChunkFailure(t, db)
+	interrupted := insertReleases(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/release.xml.gz",
+		db,
+		interruptedPreparation.RunID,
+		"release",
+	))
+	require.ErrorContains(t, interrupted.Err(), "intentional chunk failure")
+	require.ElementsMatch(
+		t,
+		[]int64{0, 2},
+		completedChunkIndexes(t, db, interruptedPreparation.RunID, "release"),
+	)
+	interruptedCoordinator.release(ctx)
+	removeChunkFailure(t, db)
+
+	expandedDumps := []*model.DiscogsDump{
+		importDump("artist", "2026-07-01", "7"),
+		releaseDump,
+	}
+	expandedCoordinator := NewImportExecutionCoordinator(sqlDB, "manifest-expansion-test")
+	expandedPreparation, err := expandedCoordinator.Prepare(
+		ctx,
+		expandedDumps,
+		chunkSize,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.Zero(t, expandedPreparation.ResumedFromRunID)
+	require.Empty(t, completedChunkIndexes(t, db, interruptedPreparation.RunID, "release"))
+	var interruptedStatus string
+	require.NoError(t, db.Raw(
+		"select status from public.discogs_import_run where id = ?",
+		interruptedPreparation.RunID,
+	).Scan(&interruptedStatus).Error)
+	require.Equal(t, "failed", interruptedStatus)
+
+	cache.ResetIDs()
+	config := koanf.New(".")
+	require.NoError(t, config.Set("artists", true))
+	require.NoError(t, config.Set("labels", false))
+	require.NoError(t, config.Set("masters", false))
+	require.NoError(t, config.Set("releases", true))
+	require.NoError(t, preloadReferenceIDs(ctx, sqlDB, config))
+
+	artistResult := GetArtistStep(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/artist.xml.gz",
+		db,
+		expandedPreparation.RunID,
+		"artist",
+	))()
+	require.NoError(t, artistResult.Err())
+	releaseResult := insertReleases(NewTrackedOrder(
+		ctx,
+		chunkSize,
+		maxWorkers,
+		"testdata/release.xml.gz",
+		db,
+		expandedPreparation.RunID,
+		"release",
+	))
+	require.NoError(t, releaseResult.Err())
+	require.NoError(t, expandedCoordinator.Complete(ctx, nil))
+	assertCompletedRunSummary(t, db, expandedPreparation.RunID, "artist", 3, 3)
+	assertCompletedRunSummary(t, db, expandedPreparation.RunID, "release", 3, 3)
+
+	repeatedCoordinator := NewImportExecutionCoordinator(sqlDB, "manifest-expansion-test")
+	repeatedPreparation, err := repeatedCoordinator.Prepare(
+		ctx,
+		expandedDumps,
+		chunkSize,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.True(t, repeatedPreparation.Skipped)
+}
+
+func installChunkFailure(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		create or replace function public.fail_selected_import_chunk()
+		returns trigger
+		language plpgsql
+		as $function$
+		begin
+		    if new.chunk_index = 1 then
+		        perform pg_sleep(0.25);
+		        raise exception 'intentional chunk failure';
+		    end if;
+		    return new;
+		end
+		$function$;
+
+		create trigger fail_selected_import_chunk_trigger
+		before insert on public.discogs_import_run_chunk
+		for each row execute function public.fail_selected_import_chunk();`).Error)
+	t.Cleanup(func() {
+		removeChunkFailure(t, db)
+	})
+}
+
+func removeChunkFailure(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		"drop trigger if exists "+progressFailureTrigger+
+			" on public.discogs_import_run_chunk",
+	).Error)
+	require.NoError(t, db.Exec(
+		"drop function if exists public."+progressFailureFunction+"()",
+	).Error)
+}
+
+func completedChunkIndexes(
+	t *testing.T,
+	db *gorm.DB,
+	runID int64,
+	entityType string,
+) []int64 {
+	t.Helper()
+	indexes := make([]int64, 0)
+	require.NoError(t, db.Raw(
+		`select chunk_index
+		   from public.discogs_import_run_chunk
+		  where import_run_id = ?
+		    and entity_type = ?
+		  order by chunk_index`,
+		runID,
+		entityType,
+	).Scan(&indexes).Error)
+	return indexes
+}
+
+func assertCompletedRunSummary(
+	t *testing.T,
+	db *gorm.DB,
+	runID int64,
+	entityType string,
+	wantItems int64,
+	wantChunks int64,
+) {
+	t.Helper()
+	type summary struct {
+		ProcessedItems int64
+		TotalItems     int64
+		TotalChunks    int64
+		Completed      bool
+	}
+	var actual summary
+	require.NoError(t, db.Raw(
+		`select processed_items,
+		        total_items,
+		        total_chunks,
+		        completed_at is not null as completed
+		   from public.discogs_import_run_dump
+		  where import_run_id = ?
+		    and entity_type = ?`,
+		runID,
+		entityType,
+	).Scan(&actual).Error)
+	require.Equal(t, wantItems, actual.ProcessedItems)
+	require.Equal(t, wantItems, actual.TotalItems)
+	require.Equal(t, wantChunks, actual.TotalChunks)
+	require.True(t, actual.Completed)
+}

--- a/src/batch/reader.go
+++ b/src/batch/reader.go
@@ -1,21 +1,22 @@
 package batch
 
 import (
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/dsub-io/go-open-discogs-batch/src/reader"
 )
 
-func newReadCloser(filepath string, progressBarText string) io.ReadCloser {
+func newReadCloser(filepath string, progressBarText string) (io.ReadCloser, error) {
 	file, err := os.Open(filepath)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("open import file %s: %w", filepath, err)
 	}
 	readCloser, err := reader.NewProgressBarGzipReadCloser(file, progressBarText)
 	if err != nil {
 		_ = file.Close()
-		panic(err)
+		return nil, fmt.Errorf("open gzip import file %s: %w", filepath, err)
 	}
-	return readCloser
+	return readCloser, nil
 }

--- a/src/batch/relations.go
+++ b/src/batch/relations.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/src/result"
 )
 
-type relationChunkWriter[T any] func(Order, []*T) result.Result
+type relationChunkWriter[T any] func(Order, ChunkMetadata, []*T) result.Result
 
 type sourceErrorRecorder struct {
 	mu  sync.Mutex
@@ -49,10 +49,16 @@ func processRelationChunks[T any](
 	results := make(chan result.Result)
 	var workers sync.WaitGroup
 	sourceErrors := new(sourceErrorRecorder)
+	var totalItems int64
+	var totalChunks int64
+	source, err := newReadCloser(order.getFilePath(), progressText)
+	if err != nil {
+		return result.NewResult(0, err)
+	}
 
 	reader.NewReader[T](
 		ctx,
-		newReadCloser(order.getFilePath(), progressText),
+		source,
 		localName,
 	).
 		WindowWithCount(order.getChunkSize()).
@@ -60,10 +66,20 @@ func processRelationChunks[T any](
 		ForEach(
 			func(value interface{}) {
 				items := value.([]*T)
+				if len(items) == 0 {
+					return
+				}
+				chunk := ChunkMetadata{
+					Index:          totalChunks,
+					FirstItemIndex: totalItems,
+					ItemCount:      len(items),
+				}
+				totalChunks++
+				totalItems += int64(len(items))
 				workers.Add(1)
 				if order.submitWorker(ctx, func() {
 					defer workers.Done()
-					written := writeRelationChunk(order, items)
+					written := writeRelationChunk(order, chunk, items)
 					if written.IsErr() {
 						cancel()
 					}
@@ -87,6 +103,11 @@ func processRelationChunks[T any](
 	}
 	if sourceErr := sourceErrors.get(); sourceErr != nil {
 		sum = sum.Sum(result.NewResult(0, sourceErr))
+	}
+	if !sum.IsErr() {
+		if progressErr := completeEntityProgress(order, totalItems, totalChunks); progressErr != nil {
+			sum = sum.Sum(result.NewResult(0, progressErr))
+		}
 	}
 
 	fmt.Printf("\nUpdated %+v %s\n", sum.Count(), topic)

--- a/src/batch/relations.go
+++ b/src/batch/relations.go
@@ -101,9 +101,7 @@ func processRelationChunks[T any](
 	for next := range results {
 		sum = sum.Sum(next)
 	}
-	if sourceErr := sourceErrors.get(); sourceErr != nil {
-		sum = sum.Sum(result.NewResult(0, sourceErr))
-	}
+	sum = mergeSourceError(sum, sourceErrors.get())
 	if !sum.IsErr() {
 		if progressErr := completeEntityProgress(order, totalItems, totalChunks); progressErr != nil {
 			sum = sum.Sum(result.NewResult(0, progressErr))
@@ -112,4 +110,11 @@ func processRelationChunks[T any](
 
 	fmt.Printf("\nUpdated %+v %s\n", sum.Count(), topic)
 	return sum
+}
+
+func mergeSourceError(sum result.Result, sourceErr error) result.Result {
+	if sourceErr == nil {
+		return sum
+	}
+	return sum.Sum(result.NewResult(0, sourceErr))
 }

--- a/src/batch/release.go
+++ b/src/batch/release.go
@@ -10,6 +10,41 @@ import (
 	"github.com/dsub-io/open-discogs-model/model"
 )
 
+var (
+	labelReleaseItemRelation = integerRelation{
+		table: "label_release_item", parentColumn: "release_item_id", keyColumn: "label_id",
+	}
+	releaseArtistRelation = integerRelation{
+		table: "release_item_artist", parentColumn: "release_item_id", keyColumn: "artist_id",
+	}
+	releaseCreditedArtistRelation = twoIntegerKeyRelation{
+		table: "release_item_credited_artist", parentColumn: "release_item_id",
+		firstKeyColumn: "artist_id", secondKeyColumn: "hash",
+	}
+	releaseFormatRelation = integerRelation{
+		table: "release_item_format", parentColumn: "release_item_id", keyColumn: "hash",
+	}
+	releaseGenreRelation = textRelation{
+		table: "release_item_genre", parentColumn: "release_item_id", keyColumn: "genre",
+	}
+	releaseIdentifierRelation = integerRelation{
+		table: "release_item_identifier", parentColumn: "release_item_id", keyColumn: "hash",
+	}
+	releaseStyleRelation = textRelation{
+		table: "release_item_style", parentColumn: "release_item_id", keyColumn: "style",
+	}
+	releaseTrackRelation = integerRelation{
+		table: "release_item_track", parentColumn: "release_item_id", keyColumn: "hash",
+	}
+	releaseVideoRelation = integerRelation{
+		table: "release_item_video", parentColumn: "release_item_id", keyColumn: "hash",
+	}
+	releaseWorkRelation = twoIntegerKeyRelation{
+		table: "release_item_work", parentColumn: "release_item_id",
+		firstKeyColumn: "label_id", secondKeyColumn: "hash",
+	}
+)
+
 // TODO: double check ptr exceptions on reference
 
 // GetReleaseStep returns a set of steps in a form of composite notary.
@@ -21,74 +56,242 @@ func GetReleaseStep(order Order) Step {
 }
 
 func insertReleases(order Order) result.Result {
+	deleteStale, err := relationTablesContainRows(
+		order,
+		labelReleaseItemRelation.table,
+		releaseArtistRelation.table,
+		releaseCreditedArtistRelation.table,
+		releaseFormatRelation.table,
+		releaseGenreRelation.table,
+		releaseIdentifierRelation.table,
+		releaseStyleRelation.table,
+		releaseTrackRelation.table,
+		releaseVideoRelation.table,
+		releaseWorkRelation.table,
+	)
+	if err != nil {
+		return result.NewResult(0, err)
+	}
 	return processRelationChunks(
 		order,
 		"release relations",
 		"release",
 		"updating releases...",
-		writeReleaseRelationChunk,
+		func(order Order, chunk ChunkMetadata, items []*XmlReleaseRelation) result.Result {
+			return writeReleaseRelationChunk(order, chunk, items, deleteStale)
+		},
 	)
 }
 
-func writeReleaseRelationChunk(order Order, items []*XmlReleaseRelation) result.Result {
-	var (
-		g   = make([]*model.Genre, 0)
-		s   = make([]*model.Style, 0)
-		rel = make([]*model.ReleaseItem, 0)
-		ra  = make([]*model.ReleaseItemArtist, 0)
-		rca = make([]*model.ReleaseItemCreditedArtist, 0)
-		rw  = make([]*model.ReleaseItemWork, 0)
-		rf  = make([]*model.ReleaseItemFormat, 0)
-		rs  = make([]*model.ReleaseItemStyle, 0)
-		rg  = make([]*model.ReleaseItemGenre, 0)
-		ri  = make([]*model.ReleaseItemIdentifier, 0)
-		rt  = make([]*model.ReleaseItemTrack, 0)
-		rv  = make([]*model.ReleaseItemVideo, 0)
-		rl  = make([]*model.LabelReleaseItem, 0)
-	)
-	for _, item := range items {
-		if item == nil {
-			continue
+func writeReleaseRelationChunk(
+	order Order,
+	chunk ChunkMetadata,
+	items []*XmlReleaseRelation,
+	deleteStale bool,
+) result.Result {
+	return executeChunk(order, chunk, func(transactionOrder Order) result.Result {
+		genres := make([]*model.Genre, 0)
+		styles := make([]*model.Style, 0)
+		rootIDs := make([]int32, 0, len(items))
+		releases := make([]*model.ReleaseItem, 0, len(items))
+		artists := make([]*model.ReleaseItemArtist, 0)
+		creditedArtists := make([]*model.ReleaseItemCreditedArtist, 0)
+		works := make([]*model.ReleaseItemWork, 0)
+		formats := make([]*model.ReleaseItemFormat, 0)
+		releaseStyles := make([]*model.ReleaseItemStyle, 0)
+		releaseGenres := make([]*model.ReleaseItemGenre, 0)
+		identifiers := make([]*model.ReleaseItemIdentifier, 0)
+		tracks := make([]*model.ReleaseItemTrack, 0)
+		videos := make([]*model.ReleaseItemVideo, 0)
+		labels := make([]*model.LabelReleaseItem, 0)
+		for _, item := range items {
+			if item == nil {
+				continue
+			}
+			rootIDs = append(rootIDs, item.ID)
+			genres = append(genres, item.GetGenres()...)
+			styles = append(styles, item.GetStyles()...)
+			releases = append(releases, item.GetRelease())
+			artists = append(artists, item.GetReleaseArtists()...)
+			releaseGenres = append(releaseGenres, item.GetReleaseGenres()...)
+			releaseStyles = append(releaseStyles, item.GetReleaseStyles()...)
+			works = append(works, item.GetWorks()...)
+			labels = append(labels, item.GetLabels()...)
+			formats = append(formats, item.GetFormats()...)
+			identifiers = append(identifiers, item.GetIdentifiers()...)
+			tracks = append(tracks, item.GetTracks()...)
+			videos = append(videos, item.GetVideos()...)
+			creditedArtists = append(creditedArtists, item.GetCreditedArtists()...)
 		}
-		g = append(g, item.GetGenres()...)
-		s = append(s, item.GetStyles()...)
-	}
-	if referenceResult := writeReferenceEntities(order, filterGenres(g), filterStyles(s)); referenceResult.IsErr() {
-		return referenceResult
-	}
-	for _, item := range items {
-		if item == nil {
-			continue
+		rootIDs = unique.Slice(rootIDs)
+		if referenceResult := writeReferenceEntities(
+			transactionOrder,
+			filterGenres(genres),
+			filterStyles(styles),
+		); referenceResult.IsErr() {
+			return referenceResult
 		}
-		rel = append(rel, item.GetRelease())
-		ra = append(ra, item.GetReleaseArtists()...)
-		rg = append(rg, item.GetReleaseGenres()...)
-		rs = append(rs, item.GetReleaseStyles()...)
-		rw = append(rw, item.GetWorks()...)
-		rl = append(rl, item.GetLabels()...)
-		rf = append(rf, item.GetFormats()...)
-		ri = append(ri, item.GetIdentifiers()...)
-		rt = append(rt, item.GetTracks()...)
-		rv = append(rv, item.GetVideos()...)
-		rca = append(rca, item.GetCreditedArtists()...)
-	}
-	written := writeChunk(order, rel, ra, rw, rs, rg, rl, rf, ri, rt, rv, rca)
-	if !written.IsErr() {
-		written = written.Sum(updateMasterMainReleases(order, items))
-	}
-	return written
+		written := writeChunk(transactionOrder, releases)
+		if written.IsErr() {
+			return written
+		}
+		reconcile := []func() result.Result{
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					releaseArtistRelation,
+					deleteStale,
+					rootIDs,
+					artists,
+					func(item *model.ReleaseItemArtist) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemArtist) int32 { return item.ArtistID },
+				)
+			},
+			func() result.Result {
+				return reconcileTwoIntegerKeyRelation(
+					transactionOrder,
+					releaseCreditedArtistRelation,
+					deleteStale,
+					rootIDs,
+					creditedArtists,
+					func(item *model.ReleaseItemCreditedArtist) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemCreditedArtist) int32 { return item.ArtistID },
+					func(item *model.ReleaseItemCreditedArtist) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileTwoIntegerKeyRelation(
+					transactionOrder,
+					releaseWorkRelation,
+					deleteStale,
+					rootIDs,
+					works,
+					func(item *model.ReleaseItemWork) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemWork) int32 { return item.LabelID },
+					func(item *model.ReleaseItemWork) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileTextRelation(
+					transactionOrder,
+					releaseStyleRelation,
+					deleteStale,
+					rootIDs,
+					releaseStyles,
+					func(item *model.ReleaseItemStyle) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemStyle) string { return item.Style },
+				)
+			},
+			func() result.Result {
+				return reconcileTextRelation(
+					transactionOrder,
+					releaseGenreRelation,
+					deleteStale,
+					rootIDs,
+					releaseGenres,
+					func(item *model.ReleaseItemGenre) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemGenre) string { return item.Genre },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					labelReleaseItemRelation,
+					deleteStale,
+					rootIDs,
+					labels,
+					func(item *model.LabelReleaseItem) int32 { return item.ReleaseItemID },
+					func(item *model.LabelReleaseItem) int32 { return item.LabelID },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					releaseFormatRelation,
+					deleteStale,
+					rootIDs,
+					formats,
+					func(item *model.ReleaseItemFormat) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemFormat) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					releaseIdentifierRelation,
+					deleteStale,
+					rootIDs,
+					identifiers,
+					func(item *model.ReleaseItemIdentifier) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemIdentifier) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					releaseTrackRelation,
+					deleteStale,
+					rootIDs,
+					tracks,
+					func(item *model.ReleaseItemTrack) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemTrack) int32 { return item.Hash },
+				)
+			},
+			func() result.Result {
+				return reconcileIntegerRelation(
+					transactionOrder,
+					releaseVideoRelation,
+					deleteStale,
+					rootIDs,
+					videos,
+					func(item *model.ReleaseItemVideo) int32 { return item.ReleaseItemID },
+					func(item *model.ReleaseItemVideo) int32 { return item.Hash },
+				)
+			},
+		}
+		for _, reconcileRelation := range reconcile {
+			written = written.Sum(reconcileRelation())
+			if written.IsErr() {
+				return written
+			}
+		}
+		return written.Sum(updateMasterMainReleases(transactionOrder, items))
+	})
 }
 
 func updateMasterMainReleases(order Order, releases []*XmlReleaseRelation) result.Result {
 	updates := make(map[int32]int32)
+	releaseIDs := make([]int32, 0, len(releases))
 	for _, release := range releases {
-		if release == nil || !release.MasterInfo.IsMaster || release.MasterInfo.MasterID == nil {
+		if release == nil {
+			continue
+		}
+		releaseIDs = append(releaseIDs, release.ID)
+		if !release.MasterInfo.IsMaster || release.MasterInfo.MasterID == nil {
 			continue
 		}
 		updates[*release.MasterInfo.MasterID] = release.ID
 	}
+	releaseIDs = unique.Slice(releaseIDs)
+	mainReleaseIDs := make([]int32, 0, len(updates))
+	for _, releaseID := range updates {
+		mainReleaseIDs = append(mainReleaseIDs, releaseID)
+	}
+	cleared := order.getDB().Exec(
+		`update public.master
+		    set main_release_id = null,
+		        last_modified_at = ?
+		  where main_release_id = any(?::integer[])
+		    and not (main_release_id = any(?::integer[]))`,
+		time.Now().UTC(),
+		postgresArray(releaseIDs),
+		postgresArray(mainReleaseIDs),
+	)
+	if cleared.Error != nil {
+		return result.NewResult(0, cleared.Error)
+	}
 	if len(updates) == 0 {
-		return result.NewResult(0, nil)
+		return result.NewResult(int(cleared.RowsAffected), nil)
 	}
 
 	masterIDs := make([]int32, 0, len(updates))
@@ -97,7 +300,7 @@ func updateMasterMainReleases(order Order, releases []*XmlReleaseRelation) resul
 	}
 	sort.Slice(masterIDs, func(left, right int) bool { return masterIDs[left] < masterIDs[right] })
 
-	updated := 0
+	updated := int(cleared.RowsAffected)
 	batchSize := min(order.getChunkSize(), 32_767)
 	for start := 0; start < len(masterIDs); start += batchSize {
 		end := min(start+batchSize, len(masterIDs))

--- a/src/batch/release_test.go
+++ b/src/batch/release_test.go
@@ -9,11 +9,10 @@ import (
 )
 
 func TestReleaseRead(t *testing.T) {
-	var (
-		c = context.Background()
-		r = newReadCloser("testdata/release.xml.gz", "test-read-release")
-		n = "release"
-	)
+	c := context.Background()
+	r, err := newReadCloser("testdata/release.xml.gz", "test-read-release")
+	require.NoError(t, err)
+	n := "release"
 	obs := reader.NewReader[XmlRelease](c, r, n)
 
 	s := make([]*XmlRelease, 0)
@@ -48,11 +47,10 @@ func TestMasterMainReleaseUpdateStatementBatchesMappings(t *testing.T) {
 }
 
 func TestReleaseRelationRead(t *testing.T) {
-	var (
-		c = context.Background()
-		r = newReadCloser("testdata/release.xml.gz", "test-read-release")
-		n = "release"
-	)
+	c := context.Background()
+	r, err := newReadCloser("testdata/release.xml.gz", "test-read-release")
+	require.NoError(t, err)
+	n := "release"
 	obs := reader.NewReader[XmlReleaseRelation](c, r, n)
 	s := make([]*XmlReleaseRelation, 0)
 	for r := range obs.Observe() {

--- a/src/batch/runner.go
+++ b/src/batch/runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/src/data"
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	fileutil "github.com/dsub-io/go-open-discogs-batch/src/file"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
 	"github.com/knadh/koanf"
 	"gorm.io/gorm"
 )
@@ -26,27 +27,46 @@ type importCompleter interface {
 	Complete(context.Context, error) error
 }
 
+type importExecutionCoordinator interface {
+	importCompleter
+	Prepare(context.Context, []*opendiscogsmodel.DiscogsDump, int, bool, bool) (*ImportPreparation, error)
+}
+
+var connectDatabase = database.Connect
+var configureDatabasePool = database.ConfigurePool
+var runDatabaseDDL = RunDDL
+var refreshSelectedData = data.UpdateSelectedData
+var resolveImportPlan = data.ResolveImportPlan
+var fetchImportResources = data.FetchImportResources
+var openSQLDatabase = func(db *gorm.DB) (*sql.DB, error) { return db.DB() }
+var newExecutionCoordinator = func(db *sql.DB, version string) importExecutionCoordinator {
+	return NewImportExecutionCoordinator(db, version)
+}
+var preloadImportReferenceIDs = preloadReferenceIDs
+var newImportBatch = New
+var closeIdentifierRows = func(rows *sql.Rows) error { return rows.Close() }
+
 func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 	var (
 		begin      = time.Now()
 		chunk      = config.Int("chunk-size")
 		maxWorkers = config.Int("max-workers")
 	)
-	if err := database.Connect(config.String("database-url")); err != nil {
+	if err := connectDatabase(config.String("database-url")); err != nil {
 		return err
 	}
-	if err := database.ConfigurePool(database.DB, maxWorkers); err != nil {
+	if err := configureDatabasePool(database.DB, maxWorkers); err != nil {
 		return err
 	}
 
 	fmt.Println("execute DDL update...")
-	if err := RunDDL(database.DB); err != nil {
+	if err := runDatabaseDDL(database.DB); err != nil {
 		return err
 	}
 
 	dataRepo := data.NewDataRepository(database.DB)
 	fmt.Println("refreshing dump catalog...")
-	updated, updateErr := data.UpdateSelectedData(
+	updated, updateErr := refreshSelectedData(
 		ctx,
 		dataRepo,
 		config.Strings("entities"),
@@ -58,16 +78,16 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		fmt.Printf("dump catalog refresh affected: %+v rows\n", updated)
 	}
 
-	plan, err := data.ResolveImportPlan(config, dataRepo)
+	plan, err := resolveImportPlan(config, dataRepo)
 	if err != nil {
 		return errors.Join(updateErr, err)
 	}
 
-	sqlDB, err := database.DB.DB()
+	sqlDB, err := openSQLDatabase(database.DB)
 	if err != nil {
 		return fmt.Errorf("open SQL connection pool: %w", err)
 	}
-	coordinator := NewImportExecutionCoordinator(sqlDB, runner.Version)
+	coordinator := newExecutionCoordinator(sqlDB, runner.Version)
 	preparation, err := coordinator.Prepare(
 		ctx,
 		plan.Dumps,
@@ -89,16 +109,16 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		}
 		return nil
 	}
-	if err := data.FetchImportResources(ctx, plan); err != nil {
+	if err := fetchImportResources(ctx, plan); err != nil {
 		return finalizeImport(ctx, coordinator, plan, false, err)
 	}
 	cache.ResetIDs()
-	if err := preloadReferenceIDs(ctx, sqlDB, config); err != nil {
+	if err := preloadImportReferenceIDs(ctx, sqlDB, config); err != nil {
 		return finalizeImport(ctx, coordinator, plan, false, err)
 	}
 
 	var (
-		b            = New()
+		b            = newImportBatch()
 		totalUpdates = 0
 	)
 	fmt.Printf("max-workers=%d\n", maxWorkers)
@@ -192,7 +212,7 @@ func preloadReferenceIDs(ctx context.Context, db *sql.DB, config *koanf.Koanf) e
 			_ = rows.Close()
 			return fmt.Errorf("read %s identifiers: %w", load.table, err)
 		}
-		if err := rows.Close(); err != nil {
+		if err := closeIdentifierRows(rows); err != nil {
 			return fmt.Errorf("close %s identifier stream: %w", load.table, err)
 		}
 		fmt.Printf("cached %d %s identifiers\n", count, load.table)

--- a/src/batch/runner.go
+++ b/src/batch/runner.go
@@ -111,6 +111,7 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		maxWorkers,
 		database.DB,
 		preparation.RunID,
+		preparation.ResumedFromRunID != 0,
 	)
 
 	for i := range steps {
@@ -208,6 +209,7 @@ func buildImportSteps(
 	maxWorkers int,
 	db *gorm.DB,
 	runID int64,
+	resume bool,
 ) []Step {
 	definitions := []struct {
 		enabled     bool
@@ -233,6 +235,7 @@ func buildImportSteps(
 			db,
 			runID,
 			definition.entityType,
+			resume,
 		)
 		steps = append(steps, definition.build(order))
 	}

--- a/src/batch/runner.go
+++ b/src/batch/runner.go
@@ -20,6 +20,12 @@ type Runner struct {
 	Version string
 }
 
+const importCompletionTimeout = 30 * time.Second
+
+type importCompleter interface {
+	Complete(context.Context, error) error
+}
+
 func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 	var (
 		begin      = time.Now()
@@ -52,7 +58,7 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		fmt.Printf("dump catalog refresh affected: %+v rows\n", updated)
 	}
 
-	plan, err := data.FetchImportPlan(config, dataRepo)
+	plan, err := data.ResolveImportPlan(config, dataRepo)
 	if err != nil {
 		return errors.Join(updateErr, err)
 	}
@@ -65,6 +71,7 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 	preparation, err := coordinator.Prepare(
 		ctx,
 		plan.Dumps,
+		chunk,
 		config.Bool("force"),
 		config.Bool("allow-downgrade"),
 	)
@@ -82,10 +89,12 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		}
 		return nil
 	}
+	if err := data.FetchImportResources(ctx, plan); err != nil {
+		return finalizeImport(ctx, coordinator, plan, false, err)
+	}
 	cache.ResetIDs()
 	if err := preloadReferenceIDs(ctx, sqlDB, config); err != nil {
-		completionErr := coordinator.Complete(ctx, err)
-		return errors.Join(err, completionErr)
+		return finalizeImport(ctx, coordinator, plan, false, err)
 	}
 
 	var (
@@ -93,7 +102,16 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		totalUpdates = 0
 	)
 	fmt.Printf("max-workers=%d\n", maxWorkers)
-	steps := buildImportSteps(ctx, config, plan, b, chunk, maxWorkers, database.DB)
+	steps := buildImportSteps(
+		ctx,
+		config,
+		plan,
+		b,
+		chunk,
+		maxWorkers,
+		database.DB,
+		preparation.RunID,
+	)
 
 	for i := range steps {
 		r := steps[i]()
@@ -104,15 +122,29 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		}
 	}
 
-	if err == nil && config.Bool("cleanup") {
-		err = cleanupImportFiles(plan)
-	}
-	completionErr := coordinator.Complete(ctx, err)
-	if completionErr != nil {
-		err = errors.Join(err, completionErr)
-	}
+	err = finalizeImport(ctx, coordinator, plan, config.Bool("cleanup"), err)
 	printResult(begin, totalUpdates, err)
 	return err
+}
+
+func finalizeImport(
+	ctx context.Context,
+	completer importCompleter,
+	plan *data.ImportPlan,
+	cleanup bool,
+	runErr error,
+) error {
+	completionCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		importCompletionTimeout,
+	)
+	defer cancel()
+	completionErr := completer.Complete(completionCtx, runErr)
+	finalErr := errors.Join(runErr, completionErr)
+	if finalErr != nil || !cleanup {
+		return finalErr
+	}
+	return cleanupImportFiles(plan)
 }
 
 func preloadReferenceIDs(ctx context.Context, db *sql.DB, config *koanf.Koanf) error {
@@ -175,28 +207,32 @@ func buildImportSteps(
 	chunkSize int,
 	maxWorkers int,
 	db *gorm.DB,
+	runID int64,
 ) []Step {
 	definitions := []struct {
 		enabled     bool
+		entityType  string
 		resourceKey string
 		build       func(Order) Step
 	}{
-		{hasArtist(config), "artists", batch.UpdateArtist},
-		{hasLabel(config), "labels", batch.UpdateLabel},
-		{hasMaster(config), "masters", batch.UpdateMaster},
-		{hasRelease(config), "releases", batch.UpdateRelease},
+		{hasArtist(config), "artist", "artists", batch.UpdateArtist},
+		{hasLabel(config), "label", "labels", batch.UpdateLabel},
+		{hasMaster(config), "master", "masters", batch.UpdateMaster},
+		{hasRelease(config), "release", "releases", batch.UpdateRelease},
 	}
 	steps := make([]Step, 0, len(definitions))
 	for _, definition := range definitions {
 		if !definition.enabled {
 			continue
 		}
-		order := NewOrder(
+		order := NewTrackedOrder(
 			ctx,
 			chunkSize,
 			maxWorkers,
 			plan.Resources[definition.resourceKey],
 			db,
+			runID,
+			definition.entityType,
 		)
 		steps = append(steps, definition.build(order))
 	}

--- a/src/batch/runner_cleanup_test.go
+++ b/src/batch/runner_cleanup_test.go
@@ -1,6 +1,8 @@
 package batch
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +10,14 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/src/data"
 	"github.com/stretchr/testify/require"
 )
+
+type completionStub struct {
+	complete func(context.Context, error) error
+}
+
+func (s completionStub) Complete(ctx context.Context, runErr error) error {
+	return s.complete(ctx, runErr)
+}
 
 func TestCleanupImportFilesDeletesOnlySelectedResources(t *testing.T) {
 	directory := t.TempDir()
@@ -25,4 +35,77 @@ func TestCleanupImportFilesDeletesOnlySelectedResources(t *testing.T) {
 	require.NoFileExists(t, artist)
 	require.NoFileExists(t, release)
 	require.FileExists(t, unrelated)
+}
+
+func TestFinalizeImportCommitsBeforeCleanup(t *testing.T) {
+	directory := t.TempDir()
+	resource := filepath.Join(directory, "release.xml.gz")
+	require.NoError(t, os.WriteFile(resource, []byte("fixture"), 0600))
+	plan := &data.ImportPlan{Resources: map[string]string{"releases": resource}}
+	completed := false
+	completer := completionStub{complete: func(_ context.Context, runErr error) error {
+		require.NoError(t, runErr)
+		require.FileExists(t, resource)
+		completed = true
+		return nil
+	}}
+
+	err := finalizeImport(context.Background(), completer, plan, true, nil)
+
+	require.NoError(t, err)
+	require.True(t, completed)
+	require.NoFileExists(t, resource)
+}
+
+func TestFinalizeImportRetainsResourcesOnFailure(t *testing.T) {
+	directory := t.TempDir()
+	resource := filepath.Join(directory, "release.xml.gz")
+	require.NoError(t, os.WriteFile(resource, []byte("fixture"), 0600))
+	plan := &data.ImportPlan{Resources: map[string]string{"releases": resource}}
+	fixtureErr := errors.New("fixture import failure")
+	completer := completionStub{complete: func(_ context.Context, runErr error) error {
+		require.ErrorIs(t, runErr, fixtureErr)
+		return nil
+	}}
+
+	err := finalizeImport(context.Background(), completer, plan, true, fixtureErr)
+
+	require.ErrorIs(t, err, fixtureErr)
+	require.FileExists(t, resource)
+}
+
+func TestFinalizeImportRetainsResourcesWhenCompletionFails(t *testing.T) {
+	directory := t.TempDir()
+	resource := filepath.Join(directory, "release.xml.gz")
+	require.NoError(t, os.WriteFile(resource, []byte("fixture"), 0600))
+	plan := &data.ImportPlan{Resources: map[string]string{"releases": resource}}
+	completionErr := errors.New("fixture completion failure")
+	completer := completionStub{complete: func(_ context.Context, runErr error) error {
+		require.NoError(t, runErr)
+		return completionErr
+	}}
+
+	err := finalizeImport(context.Background(), completer, plan, true, nil)
+
+	require.ErrorIs(t, err, completionErr)
+	require.FileExists(t, resource)
+}
+
+func TestFinalizeImportUsesCompletionContextAfterCancellation(t *testing.T) {
+	directory := t.TempDir()
+	resource := filepath.Join(directory, "release.xml.gz")
+	require.NoError(t, os.WriteFile(resource, []byte("fixture"), 0600))
+	plan := &data.ImportPlan{Resources: map[string]string{"releases": resource}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	completer := completionStub{complete: func(completionCtx context.Context, runErr error) error {
+		require.NoError(t, completionCtx.Err())
+		require.ErrorIs(t, runErr, context.Canceled)
+		return nil
+	}}
+
+	err := finalizeImport(ctx, completer, plan, true, context.Canceled)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.FileExists(t, resource)
 }

--- a/src/batch/runner_error_test.go
+++ b/src/batch/runner_error_test.go
@@ -1,0 +1,192 @@
+package batch
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dsub-io/go-open-discogs-batch/src/data"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	"github.com/dsub-io/go-open-discogs-batch/src/result"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+	"github.com/knadh/koanf"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type executionCoordinatorStub struct {
+	preparation *ImportPreparation
+	prepareErr  error
+	completeErr error
+}
+
+func (s *executionCoordinatorStub) Prepare(
+	context.Context,
+	[]*opendiscogsmodel.DiscogsDump,
+	int,
+	bool,
+	bool,
+) (*ImportPreparation, error) {
+	return s.preparation, s.prepareErr
+}
+
+func (s *executionCoordinatorStub) Complete(context.Context, error) error {
+	return s.completeErr
+}
+
+type batchStub struct {
+	stepResult result.Result
+}
+
+func (s batchStub) step(Order) Step                { return func() result.Result { return s.stepResult } }
+func (s batchStub) UpdateArtist(order Order) Step  { return s.step(order) }
+func (s batchStub) UpdateLabel(order Order) Step   { return s.step(order) }
+func (s batchStub) UpdateMaster(order Order) Step  { return s.step(order) }
+func (s batchStub) UpdateRelease(order Order) Step { return s.step(order) }
+
+type runnerSeams struct {
+	connect       func(string) error
+	configure     func(*gorm.DB, int) error
+	ddl           func(*gorm.DB) error
+	refresh       func(context.Context, data.Repository, []string, string) (int, error)
+	resolve       func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error)
+	fetch         func(context.Context, *data.ImportPlan) error
+	open          func(*gorm.DB) (*sql.DB, error)
+	coordinator   func(*sql.DB, string) importExecutionCoordinator
+	preload       func(context.Context, *sql.DB, *koanf.Koanf) error
+	newBatch      func() Batch
+	databaseValue *gorm.DB
+}
+
+func installRunnerSeams(t *testing.T, seams runnerSeams) {
+	t.Helper()
+	originalConnect := connectDatabase
+	originalConfigure := configureDatabasePool
+	originalDDL := runDatabaseDDL
+	originalRefresh := refreshSelectedData
+	originalResolve := resolveImportPlan
+	originalFetch := fetchImportResources
+	originalOpen := openSQLDatabase
+	originalCoordinator := newExecutionCoordinator
+	originalPreload := preloadImportReferenceIDs
+	originalBatch := newImportBatch
+	originalDB := database.DB
+	t.Cleanup(func() {
+		connectDatabase = originalConnect
+		configureDatabasePool = originalConfigure
+		runDatabaseDDL = originalDDL
+		refreshSelectedData = originalRefresh
+		resolveImportPlan = originalResolve
+		fetchImportResources = originalFetch
+		openSQLDatabase = originalOpen
+		newExecutionCoordinator = originalCoordinator
+		preloadImportReferenceIDs = originalPreload
+		newImportBatch = originalBatch
+		database.DB = originalDB
+	})
+	connectDatabase = seams.connect
+	configureDatabasePool = seams.configure
+	runDatabaseDDL = seams.ddl
+	refreshSelectedData = seams.refresh
+	resolveImportPlan = seams.resolve
+	fetchImportResources = seams.fetch
+	openSQLDatabase = seams.open
+	newExecutionCoordinator = seams.coordinator
+	preloadImportReferenceIDs = seams.preload
+	newImportBatch = seams.newBatch
+	database.DB = seams.databaseValue
+}
+
+func defaultRunnerSeams() runnerSeams {
+	coordinator := &executionCoordinatorStub{preparation: &ImportPreparation{RunID: 1}}
+	return runnerSeams{
+		connect:   func(string) error { return nil },
+		configure: func(*gorm.DB, int) error { return nil },
+		ddl:       func(*gorm.DB) error { return nil },
+		refresh: func(context.Context, data.Repository, []string, string) (int, error) {
+			return 0, nil
+		},
+		resolve: func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			return &data.ImportPlan{
+				Resources: map[string]string{"artists": "unused"},
+				Dumps:     []*opendiscogsmodel.DiscogsDump{importDump("artist", "2026-07-01", "a")},
+			}, nil
+		},
+		fetch:       func(context.Context, *data.ImportPlan) error { return nil },
+		open:        func(*gorm.DB) (*sql.DB, error) { return nil, nil },
+		coordinator: func(*sql.DB, string) importExecutionCoordinator { return coordinator },
+		preload:     func(context.Context, *sql.DB, *koanf.Koanf) error { return nil },
+		newBatch: func() Batch {
+			return batchStub{stepResult: result.NewResult(1, nil)}
+		},
+	}
+}
+
+func runnerConfig(t *testing.T) *koanf.Koanf {
+	t.Helper()
+	config := koanf.New(".")
+	for key, value := range map[string]interface{}{
+		"entities":    []string{"artist"},
+		"artists":     true,
+		"chunk-size":  1,
+		"max-workers": 1,
+	} {
+		require.NoError(t, config.Set(key, value))
+	}
+	return config
+}
+
+func TestRunnerPropagatesEveryStageFailure(t *testing.T) {
+	expected := errors.New("fixture")
+	tests := []struct {
+		name   string
+		mutate func(*runnerSeams)
+	}{
+		{"connect", func(s *runnerSeams) { s.connect = func(string) error { return expected } }},
+		{"pool", func(s *runnerSeams) { s.configure = func(*gorm.DB, int) error { return expected } }},
+		{"ddl", func(s *runnerSeams) { s.ddl = func(*gorm.DB) error { return expected } }},
+		{"catalog and plan", func(s *runnerSeams) {
+			s.refresh = func(context.Context, data.Repository, []string, string) (int, error) { return 0, expected }
+			s.resolve = func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) { return nil, expected }
+		}},
+		{"open SQL pool", func(s *runnerSeams) { s.open = func(*gorm.DB) (*sql.DB, error) { return nil, expected } }},
+		{"prepare", func(s *runnerSeams) {
+			s.coordinator = func(*sql.DB, string) importExecutionCoordinator {
+				return &executionCoordinatorStub{prepareErr: expected}
+			}
+		}},
+		{"fetch", func(s *runnerSeams) { s.fetch = func(context.Context, *data.ImportPlan) error { return expected } }},
+		{"preload", func(s *runnerSeams) {
+			s.preload = func(context.Context, *sql.DB, *koanf.Koanf) error { return expected }
+		}},
+		{"step", func(s *runnerSeams) {
+			s.newBatch = func() Batch { return batchStub{stepResult: result.NewResult(0, expected)} }
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			seams := defaultRunnerSeams()
+			test.mutate(&seams)
+			installRunnerSeams(t, seams)
+			require.ErrorIs(t, (&Runner{Version: "test"}).Run(context.Background(), runnerConfig(t)), expected)
+		})
+	}
+}
+
+func TestBuildImportStepsSkipsDisabledEntitiesAndPrintsError(t *testing.T) {
+	config := koanf.New(".")
+	require.Empty(t, buildImportSteps(
+		context.Background(),
+		config,
+		&data.ImportPlan{Resources: map[string]string{}},
+		batchStub{stepResult: result.NewResult(0, nil)},
+		1,
+		1,
+		nil,
+		1,
+		false,
+	))
+	printResult(time.Now(), 1, errors.New("fixture"))
+}

--- a/src/batch/runner_reference_test.go
+++ b/src/batch/runner_reference_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPreloadReferenceIDsForReleaseOnlyImport(t *testing.T) {
-	pg := testutils.GetDatabase(testutils.Postgres)
+	pg := testutils.GetDatabase(t, testutils.Postgres)
 	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
 	require.NoError(t, err)
 	require.NoError(t, RunDDL(db))

--- a/src/batch/runner_test.go
+++ b/src/batch/runner_test.go
@@ -1,0 +1,107 @@
+package batch
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dsub-io/go-open-discogs-batch/internal/testserver"
+	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/data"
+	"github.com/knadh/koanf"
+	"github.com/stretchr/testify/require"
+)
+
+type runnerFixture struct {
+	entity   string
+	filename string
+	body     []byte
+	checksum string
+}
+
+func TestRunnerEndToEndAndSuccessfulSkip(t *testing.T) {
+	fixtures := make([]runnerFixture, 0, 4)
+	for _, entity := range []string{"artist", "label", "master", "release"} {
+		filename := fmt.Sprintf("discogs_20260701_%ss.xml.gz", entity)
+		body, err := os.ReadFile(filepath.Join("testdata", entity+".xml.gz"))
+		require.NoError(t, err)
+		fixtures = append(fixtures, runnerFixture{
+			entity:   entity,
+			filename: filename,
+			body:     body,
+			checksum: fmt.Sprintf("%x", sha256.Sum256(body)),
+		})
+	}
+
+	listing := new(strings.Builder)
+	listing.WriteString(`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
+	listing.WriteString(`<Contents><Key>data/2026/discogs_20260701_CHECKSUM.txt</Key></Contents>`)
+	checksums := new(strings.Builder)
+	fixtureByPath := make(map[string]runnerFixture, len(fixtures))
+	for _, fixture := range fixtures {
+		fmt.Fprintf(listing, `<Contents><Key>data/2026/%s</Key></Contents>`, fixture.filename)
+		fmt.Fprintf(checksums, "%s *%s\n", fixture.checksum, fixture.filename)
+		fixtureByPath["/data/2026/"+fixture.filename] = fixture
+	}
+	listing.WriteString(`</ListBucketResult>`)
+
+	server := testserver.NewServer(func(
+		requests []*testserver.HttpRequest,
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		if r.URL.Query().Has("download") {
+			_, _ = w.Write([]byte(checksums.String()))
+			return
+		}
+		if fixture, ok := fixtureByPath[r.URL.Path]; ok {
+			_, _ = w.Write(fixture.body)
+			return
+		}
+		_, _ = w.Write([]byte(listing.String()))
+	})
+	defer server.Close()
+
+	originalS3URL, originalDataURL := data.DiscogsS3BaseUrl, data.DiscogsDataBaseURL
+	t.Cleanup(func() {
+		data.DiscogsS3BaseUrl = originalS3URL
+		data.DiscogsDataBaseURL = originalDataURL
+	})
+	data.DiscogsS3BaseUrl = server.URL + "/"
+	data.DiscogsDataBaseURL = server.URL + "/"
+
+	postgres := testutils.GetDatabase(t, testutils.Postgres)
+	config := koanf.New(".")
+	for key, value := range map[string]interface{}{
+		"database-url":    testutils.GetDsn(testutils.Postgres, postgres),
+		"entities":        []string{"artist", "label", "master", "release"},
+		"dump-month":      "2026-07",
+		"data-dir":        t.TempDir(),
+		"chunk-size":      5,
+		"max-workers":     2,
+		"cleanup":         true,
+		"force":           false,
+		"allow-downgrade": false,
+		"artists":         true,
+		"labels":          true,
+		"masters":         true,
+		"releases":        true,
+	} {
+		require.NoError(t, config.Set(key, value))
+	}
+
+	runner := &Runner{Version: "test"}
+	require.NoError(t, runner.Run(context.Background(), config))
+	for _, fixture := range fixtures {
+		require.NoFileExists(t, filepath.Join(config.String("data-dir"), fixture.filename))
+	}
+
+	require.NoError(t, runner.Run(context.Background(), config))
+	require.NoError(t, config.Set("cleanup", false))
+	require.NoError(t, runner.Run(context.Background(), config))
+}

--- a/src/batch/testdata/cross-language-state.json
+++ b/src/batch/testdata/cross-language-state.json
@@ -51,24 +51,9 @@
       "name_variation": "J. Winkelman"
     },
     {
-      "hash": 1103154064,
-      "artist_id": 3,
-      "name_variation": "Josh Wink \"DJ Wink\""
-    },
-    {
-      "hash": 110708147,
-      "artist_id": 3,
-      "name_variation": "J. Wink (DJ Wink)"
-    },
-    {
       "hash": -1151638115,
       "artist_id": 3,
       "name_variation": "Josh Wink (DJ Wink)"
-    },
-    {
-      "hash": 1244431614,
-      "artist_id": 3,
-      "name_variation": "Josh Winks"
     },
     {
       "hash": -1275716287,
@@ -76,19 +61,9 @@
       "name_variation": "Mr. Barth \u0026 A.D."
     },
     {
-      "hash": 1276483187,
-      "artist_id": 2,
-      "name_variation": "MR JAMES BARTH \u0026 A. D."
-    },
-    {
       "hash": -1432653649,
       "artist_id": 1,
       "name_variation": "Persuader"
-    },
-    {
-      "hash": 1478676304,
-      "artist_id": 3,
-      "name_variation": "Josh Wink (Dj Winx)"
     },
     {
       "hash": -1514976674,
@@ -96,19 +71,9 @@
       "name_variation": "Josh Winkelman"
     },
     {
-      "hash": 1564163618,
-      "artist_id": 3,
-      "name_variation": "Josh Winx"
-    },
-    {
       "hash": -1695014485,
       "artist_id": 3,
       "name_variation": "J. Wink"
-    },
-    {
-      "hash": 1697719264,
-      "artist_id": 3,
-      "name_variation": "J.Winkelman"
     },
     {
       "hash": -1923453047,
@@ -129,6 +94,66 @@
       "hash": -2144161211,
       "artist_id": 3,
       "name_variation": "J Wink"
+    },
+    {
+      "hash": -336875354,
+      "artist_id": 1,
+      "name_variation": "The Presuader"
+    },
+    {
+      "hash": -476011505,
+      "artist_id": 3,
+      "name_variation": "Dosh Wink"
+    },
+    {
+      "hash": -520191267,
+      "artist_id": 3,
+      "name_variation": "Wink, Josh"
+    },
+    {
+      "hash": -582380539,
+      "artist_id": 2,
+      "name_variation": "Mr Barth \u0026 A.D."
+    },
+    {
+      "hash": -72025349,
+      "artist_id": 3,
+      "name_variation": "DJ Josh Wink"
+    },
+    {
+      "hash": 1103154064,
+      "artist_id": 3,
+      "name_variation": "Josh Wink \"DJ Wink\""
+    },
+    {
+      "hash": 110708147,
+      "artist_id": 3,
+      "name_variation": "J. Wink (DJ Wink)"
+    },
+    {
+      "hash": 1244431614,
+      "artist_id": 3,
+      "name_variation": "Josh Winks"
+    },
+    {
+      "hash": 1276483187,
+      "artist_id": 2,
+      "name_variation": "MR JAMES BARTH \u0026 A. D."
+    },
+    {
+      "hash": 1478676304,
+      "artist_id": 3,
+      "name_variation": "Josh Wink (Dj Winx)"
+    },
+    {
+      "hash": 1564163618,
+      "artist_id": 3,
+      "name_variation": "Josh Winx"
+    },
+    {
+      "hash": 1697719264,
+      "artist_id": 3,
+      "name_variation": "J.Winkelman"
     },
     {
       "hash": 2314874,
@@ -171,34 +196,9 @@
       "name_variation": "Josh Winkelmann"
     },
     {
-      "hash": -336875354,
-      "artist_id": 1,
-      "name_variation": "The Presuader"
-    },
-    {
       "hash": 41562583,
       "artist_id": 2,
       "name_variation": "Mr. James Barth \u0026 A. D."
-    },
-    {
-      "hash": -476011505,
-      "artist_id": 3,
-      "name_variation": "Dosh Wink"
-    },
-    {
-      "hash": -520191267,
-      "artist_id": 3,
-      "name_variation": "Wink, Josh"
-    },
-    {
-      "hash": -582380539,
-      "artist_id": 2,
-      "name_variation": "Mr Barth \u0026 A.D."
-    },
-    {
-      "hash": -72025349,
-      "artist_id": 3,
-      "name_variation": "DJ Josh Wink"
     },
     {
       "hash": 83581172,
@@ -248,16 +248,6 @@
       "artist_id": 3
     },
     {
-      "url": "https://en.wikipedia.org/wiki/Jesper_Dahlbäck",
-      "hash": 877791006,
-      "artist_id": 1
-    },
-    {
-      "url": "https://joshwink.bandcamp.com",
-      "hash": 2044061375,
-      "artist_id": 3
-    },
-    {
       "url": "http://soundcloud.com/joshwinkofficial",
       "hash": 1522532408,
       "artist_id": 3
@@ -300,6 +290,16 @@
     {
       "url": "http://www.youtube.com/user/JoshWinkVEVO",
       "hash": 230796051,
+      "artist_id": 3
+    },
+    {
+      "url": "https://en.wikipedia.org/wiki/Jesper_Dahlbäck",
+      "hash": 877791006,
+      "artist_id": 1
+    },
+    {
+      "url": "https://joshwink.bandcamp.com",
+      "hash": 2044061375,
       "artist_id": 3
     }
   ],
@@ -380,13 +380,13 @@
       "label_id": 1
     },
     {
-      "url": "http://planetecommunications.bandcamp.com",
-      "hash": 1685522527,
+      "url": "http://planet-e.net",
+      "hash": 866183985,
       "label_id": 1
     },
     {
-      "url": "http://planet-e.net",
-      "hash": 866183985,
+      "url": "http://planetecommunications.bandcamp.com",
+      "hash": 1685522527,
       "label_id": 1
     },
     {
@@ -403,36 +403,6 @@
       "url": "http://soundcloud.com/siestarecords",
       "hash": 1622163405,
       "label_id": 4
-    },
-    {
-      "url": "https://seasonsrecordings.bigcartel.com/",
-      "hash": -2104698560,
-      "label_id": 3
-    },
-    {
-      "url": "https://soundcloud.com/seasonsrecords",
-      "hash": -1391605607,
-      "label_id": 3
-    },
-    {
-      "url": "https://twitter.com/SeasonsRecords",
-      "hash": 20437514,
-      "label_id": 3
-    },
-    {
-      "url": "https://twitter.com/siestarecords",
-      "hash": 1362842489,
-      "label_id": 4
-    },
-    {
-      "url": "https://www.facebook.com/SEASONS-RECORDINGS-160164731945/",
-      "hash": -2085178872,
-      "label_id": 3
-    },
-    {
-      "url": "https://www.youtube.com/channel/UClv7-8Gfk2Uc47ly6fTWmvQ",
-      "hash": -1339245870,
-      "label_id": 3
     },
     {
       "url": "http://twitter.com/planetedetroit",
@@ -483,6 +453,36 @@
       "url": "http://www.youtube.com/user/planetedetroit",
       "hash": 272605200,
       "label_id": 1
+    },
+    {
+      "url": "https://seasonsrecordings.bigcartel.com/",
+      "hash": -2104698560,
+      "label_id": 3
+    },
+    {
+      "url": "https://soundcloud.com/seasonsrecords",
+      "hash": -1391605607,
+      "label_id": 3
+    },
+    {
+      "url": "https://twitter.com/SeasonsRecords",
+      "hash": 20437514,
+      "label_id": 3
+    },
+    {
+      "url": "https://twitter.com/siestarecords",
+      "hash": 1362842489,
+      "label_id": 4
+    },
+    {
+      "url": "https://www.facebook.com/SEASONS-RECORDINGS-160164731945/",
+      "hash": -2085178872,
+      "label_id": 3
+    },
+    {
+      "url": "https://www.youtube.com/channel/UClv7-8Gfk2Uc47ly6fTWmvQ",
+      "hash": -1339245870,
+      "label_id": 3
     },
     {
       "url": "www.siestarecords.com",
@@ -577,6 +577,13 @@
   ],
   "master_video": [
     {
+      "url": "https://www.youtube.com/watch?v=-CDArPhGJwE",
+      "hash": -1962557807,
+      "title": "Mystical Rhythm (Lush Mix)",
+      "master_id": 1,
+      "description": "Provided to YouTube by EPM Online\n\n          Mystical Rhythm (Lush Mix) · Vince Watson · Vince Watson\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Mixer: Vince Watson\n\n          Auto-generated by YouTube."
+    },
+    {
       "url": "https://www.youtube.com/watch?v=1ZW_Aw124dc",
       "hash": -1406228927,
       "title": "Vince Watson : Bubbles",
@@ -626,20 +633,6 @@
       "description": "vince watson - biologique (1999)"
     },
     {
-      "url": "https://www.youtube.com/watch?v=-CDArPhGJwE",
-      "hash": -1962557807,
-      "title": "Mystical Rhythm (Lush Mix)",
-      "master_id": 1,
-      "description": "Provided to YouTube by EPM Online\n\n          Mystical Rhythm (Lush Mix) · Vince Watson · Vince Watson\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Mixer: Vince Watson\n\n          Auto-generated by YouTube."
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=cjlHl664I9U",
-      "hash": 761424899,
-      "title": "Vince Watson - Rainbow Funk (Music Video)",
-      "master_id": 2,
-      "description": "Buy here: http://www.juno.co.uk/products/biologique/48291-01/\n\n          Vince Watson - Biologique LP\n\n          Label: Alola\n\n          Released: 18/10/1999a\n\n          Genre: Techno"
-    },
-    {
       "url": "https://www.youtube.com/watch?v=CYvoQdT0oQQ",
       "hash": -388188766,
       "title": "Rephlexions",
@@ -652,13 +645,6 @@
       "title": "vince watson - euphorate",
       "master_id": 2,
       "description": "vince watson - biologique ( 1999 )\n          \r\n          \r-uploaded in HD at http://www.TunesToTube.com"
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=fYMa0n5-99A",
-      "hash": -96398355,
-      "title": "Depth Soul",
-      "master_id": 1,
-      "description": "Provided to YouTube by EPM Online\n\n          Depth Soul · Vince Watson · Ben Sims\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Mixer: Ben Sims\n\n          Auto-generated by YouTube."
     },
     {
       "url": "https://www.youtube.com/watch?v=GOffv3rh1cU",
@@ -682,34 +668,6 @@
       "description": "Provided to YouTube by EPM Online\n\n          Simplicity · Vince Watson\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Auto-generated by YouTube."
     },
     {
-      "url": "https://www.youtube.com/watch?v=lmYrZZ97w58",
-      "hash": -1743126957,
-      "title": "Blue Arsed Fly - Bucket (A1)",
-      "master_id": 3,
-      "description": "Blue Arsed Fly ‎– Knackered EP\n          Label: Tresor ‎– Tresor 60\n          Format: Vinyl, 12, EP, 33 ⅓ RPM\n          Country: Germany\n          Released: 13 Jan 1997\n          Genre: Electronic\n          Style: Techno\n\n          https://www.discogs.com/Blue-Arsed-Fly-Knackered-EP/release/5415"
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=_M20bObcvXo",
-      "hash": 1925484139,
-      "title": "Vince Watson - My Subconscious",
-      "master_id": 1,
-      "description": "http://www.discogs.com/Vince-Watson-Moments-In-Time/master/113"
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=ndrHFMbEr7k",
-      "hash": -617363659,
-      "title": "Vince Watson - Into Beyond",
-      "master_id": 1,
-      "description": "Label: Alola\r\n          \r\n          Released: 2002\r\n          Genre: Electronic"
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=o3FI1qAOCwE",
-      "hash": 747765467,
-      "title": "Vince Watson - Into The Deep",
-      "master_id": 2,
-      "description": "Track from Alola"
-    },
-    {
       "url": "https://www.youtube.com/watch?v=QbqM-ty0gTE",
       "hash": 343075263,
       "title": "Vince Watson - Inertia",
@@ -724,18 +682,18 @@
       "description": "Provided to YouTube by EPM Online\n\n          Beneath the Sound · Vince Watson\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Auto-generated by YouTube."
     },
     {
-      "url": "https://www.youtube.com/watch?v=Rs6111Vf91Y",
-      "hash": 2142264979,
-      "title": "Vince Watson - Jazz Satelite [Alola]",
-      "master_id": 2,
-      "description": "http://www.discogs.com/Vince-Watson-Biologique/release/42056\n          Artist:Vince Watson\n          Album: Biologique\n          Label: Alola\n          Cat.No: ALOCD004\n          year:1999\n          Genre: Deep House, House\n          SUPPORT THE ARTIST AND BUY THIS TRACK"
-    },
-    {
       "url": "https://www.youtube.com/watch?v=RVLbjJv-KVI",
       "hash": -630920364,
       "title": "Vince Watson - Moments In Time",
       "master_id": 1,
       "description": "http://www.beatport.com/track/moments-in-time-original-mix/209664"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=Rs6111Vf91Y",
+      "hash": 2142264979,
+      "title": "Vince Watson - Jazz Satelite [Alola]",
+      "master_id": 2,
+      "description": "http://www.discogs.com/Vince-Watson-Biologique/release/42056\n          Artist:Vince Watson\n          Album: Biologique\n          Label: Alola\n          Cat.No: ALOCD004\n          year:1999\n          Genre: Deep House, House\n          SUPPORT THE ARTIST AND BUY THIS TRACK"
     },
     {
       "url": "https://www.youtube.com/watch?v=ULxN8k8FtW4",
@@ -752,6 +710,55 @@
       "description": "Provided to YouTube by EPM Online\n\n          Silhouettes · Vince Watson\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Auto-generated by YouTube."
     },
     {
+      "url": "https://www.youtube.com/watch?v=_M20bObcvXo",
+      "hash": 1925484139,
+      "title": "Vince Watson - My Subconscious",
+      "master_id": 1,
+      "description": "http://www.discogs.com/Vince-Watson-Moments-In-Time/master/113"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=cjlHl664I9U",
+      "hash": 761424899,
+      "title": "Vince Watson - Rainbow Funk (Music Video)",
+      "master_id": 2,
+      "description": "Buy here: http://www.juno.co.uk/products/biologique/48291-01/\n\n          Vince Watson - Biologique LP\n\n          Label: Alola\n\n          Released: 18/10/1999a\n\n          Genre: Techno"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=fYMa0n5-99A",
+      "hash": -96398355,
+      "title": "Depth Soul",
+      "master_id": 1,
+      "description": "Provided to YouTube by EPM Online\n\n          Depth Soul · Vince Watson · Ben Sims\n\n          Alola Vol 2\n\n          ℗ Westbury Music Ltd / Spherecom Music\n\n          Released on: 2001-07-02\n\n          Mixer: Ben Sims\n\n          Auto-generated by YouTube."
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=lmYrZZ97w58",
+      "hash": -1743126957,
+      "title": "Blue Arsed Fly - Bucket (A1)",
+      "master_id": 3,
+      "description": "Blue Arsed Fly ‎– Knackered EP\n          Label: Tresor ‎– Tresor 60\n          Format: Vinyl, 12, EP, 33 ⅓ RPM\n          Country: Germany\n          Released: 13 Jan 1997\n          Genre: Electronic\n          Style: Techno\n\n          https://www.discogs.com/Blue-Arsed-Fly-Knackered-EP/release/5415"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=ndrHFMbEr7k",
+      "hash": -617363659,
+      "title": "Vince Watson - Into Beyond",
+      "master_id": 1,
+      "description": "Label: Alola\r\n          \r\n          Released: 2002\r\n          Genre: Electronic"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=o3FI1qAOCwE",
+      "hash": 747765467,
+      "title": "Vince Watson - Into The Deep",
+      "master_id": 2,
+      "description": "Track from Alola"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=yVcm18a2GG8",
+      "hash": -1086311167,
+      "title": "Vince Watson - Spaceclouds",
+      "master_id": 2,
+      "description": "http://www.discogs.com/Vince-Watson-Biologique/release/42056"
+    },
+    {
       "url": "https://www.youtube.com/watch?v=yoraJcl7MzM",
       "hash": 1054888733,
       "title": "Vince Watson - Lunar Visions",
@@ -764,13 +771,6 @@
       "title": "Vince Watson - Mystical Rhythm",
       "master_id": 2,
       "description": "Vince Watson - Mystical Rhythm"
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=yVcm18a2GG8",
-      "hash": -1086311167,
-      "title": "Vince Watson - Spaceclouds",
-      "master_id": 2,
-      "description": "http://www.discogs.com/Vince-Watson-Biologique/release/42056"
     }
   ],
   "release_item": [
@@ -836,6 +836,12 @@
   ],
   "release_item_credited_artist": [
     {
+      "hash": -737072799,
+      "role": "Producer, Recorded By",
+      "artist_id": 3,
+      "release_item_id": 2
+    },
+    {
       "hash": 2016153506,
       "role": "DJ Mix",
       "artist_id": 3,
@@ -846,12 +852,6 @@
       "role": "Music By [All Tracks By]",
       "artist_id": 3,
       "release_item_id": 1
-    },
-    {
-      "hash": -737072799,
-      "role": "Producer, Recorded By",
-      "artist_id": 3,
-      "release_item_id": 2
     }
   ],
   "release_item_format": [
@@ -903,18 +903,32 @@
       "release_item_id": 2
     },
     {
-      "hash": 1324750513,
-      "type": "Matrix / Runout",
-      "value": "MPO SK026-A -J.T.S.-",
-      "description": "Side A Runout Etching",
-      "release_item_id": 2
-    },
-    {
       "hash": -1720426763,
       "type": "Matrix / Runout",
       "value": "G PHRUPMASTERGENERAL T27 LONDON",
       "description": "Only On A-Side Runout",
       "release_item_id": 1
+    },
+    {
+      "hash": -2120356574,
+      "type": "Matrix / Runout",
+      "value": "MPO SK 032 D1",
+      "description": "D-Side Runout",
+      "release_item_id": 1
+    },
+    {
+      "hash": -487978220,
+      "type": "Barcode",
+      "value": "074646362822",
+      "description": null,
+      "release_item_id": 3
+    },
+    {
+      "hash": 1324750513,
+      "type": "Matrix / Runout",
+      "value": "MPO SK026-A -J.T.S.-",
+      "description": "Side A Runout Etching",
+      "release_item_id": 2
     },
     {
       "hash": 2081551208,
@@ -931,25 +945,11 @@
       "release_item_id": 1
     },
     {
-      "hash": -2120356574,
-      "type": "Matrix / Runout",
-      "value": "MPO SK 032 D1",
-      "description": "D-Side Runout",
-      "release_item_id": 1
-    },
-    {
       "hash": 2143590884,
       "type": "Matrix / Runout",
       "value": "MPO SK 032 C1",
       "description": "C-Side Runout",
       "release_item_id": 1
-    },
-    {
-      "hash": -487978220,
-      "type": "Barcode",
-      "value": "074646362822",
-      "description": null,
-      "release_item_id": 3
     }
   ],
   "release_item_image": [],
@@ -980,13 +980,6 @@
     }
   ],
   "release_item_track": [
-    {
-      "hash": 110451457,
-      "title": "K-Mart Shopping (Hi-Fi Mix)",
-      "duration": "5:42",
-      "position": "8",
-      "release_item_id": 3
-    },
     {
       "hash": -1115650372,
       "title": "Political Prisoner",
@@ -1023,6 +1016,55 @@
       "release_item_id": 2
     },
     {
+      "hash": -1568943240,
+      "title": "Pop Kulture",
+      "duration": "5:03",
+      "position": "7",
+      "release_item_id": 3
+    },
+    {
+      "hash": -1969634041,
+      "title": "Track 2",
+      "duration": "3:39",
+      "position": "14",
+      "release_item_id": 3
+    },
+    {
+      "hash": -234383679,
+      "title": "A Sea Apart",
+      "duration": "5:08",
+      "position": "A1",
+      "release_item_id": 2
+    },
+    {
+      "hash": -272633360,
+      "title": "Untitled",
+      "duration": "2:46",
+      "position": "12",
+      "release_item_id": 3
+    },
+    {
+      "hash": -461484647,
+      "title": "Silver",
+      "duration": "3:16",
+      "position": "11",
+      "release_item_id": 3
+    },
+    {
+      "hash": -559822979,
+      "title": "Anjua (Sneaky 3)",
+      "duration": "5:28",
+      "position": "2",
+      "release_item_id": 3
+    },
+    {
+      "hash": 110451457,
+      "title": "K-Mart Shopping (Hi-Fi Mix)",
+      "duration": "5:42",
+      "position": "8",
+      "release_item_id": 3
+    },
+    {
       "hash": 1442435631,
       "title": "Lovelee Dae (Eight Miles High Mix)",
       "duration": "5:47",
@@ -1034,13 +1076,6 @@
       "title": "Untitled 8",
       "duration": "7:00",
       "position": "1",
-      "release_item_id": 3
-    },
-    {
-      "hash": -1568943240,
-      "title": "Pop Kulture",
-      "duration": "5:03",
-      "position": "7",
       "release_item_id": 3
     },
     {
@@ -1072,20 +1107,6 @@
       "release_item_id": 1
     },
     {
-      "hash": -1969634041,
-      "title": "Track 2",
-      "duration": "3:39",
-      "position": "14",
-      "release_item_id": 3
-    },
-    {
-      "hash": -234383679,
-      "title": "A Sea Apart",
-      "duration": "5:08",
-      "position": "A1",
-      "release_item_id": 2
-    },
-    {
       "hash": 240794111,
       "title": "Södermalm",
       "duration": "5:38",
@@ -1093,25 +1114,11 @@
       "release_item_id": 1
     },
     {
-      "hash": -272633360,
-      "title": "Untitled",
-      "duration": "2:46",
-      "position": "12",
-      "release_item_id": 3
-    },
-    {
       "hash": 322531615,
       "title": "Östermalm",
       "duration": "4:45",
       "position": "A",
       "release_item_id": 1
-    },
-    {
-      "hash": -461484647,
-      "title": "Silver",
-      "duration": "3:16",
-      "position": "11",
-      "release_item_id": 3
     },
     {
       "hash": 487606073,
@@ -1126,13 +1133,6 @@
       "duration": "6:11",
       "position": "B1",
       "release_item_id": 1
-    },
-    {
-      "hash": -559822979,
-      "title": "Anjua (Sneaky 3)",
-      "duration": "5:28",
-      "position": "2",
-      "release_item_id": 3
     },
     {
       "hash": 876530911,
@@ -1151,20 +1151,6 @@
   ],
   "release_item_video": [
     {
-      "url": "https://www.youtube.com/watch?v=afMHNll9EVM",
-      "hash": -104566439,
-      "title": "The Persuader - Gamla Stan",
-      "description": "https://www.discogs.com/The-Persuader-Stockholm/release/1\n\n          The Persuader - Gamla Stan",
-      "release_item_id": 1
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=bqUfNGJEKlo",
-      "hash": 854958393,
-      "title": "Profound Sounds Vol. 1 - Josh Wink",
-      "description": "mix 1999",
-      "release_item_id": 3
-    },
-    {
       "url": "https://www.youtube.com/watch?v=Cawyll0pOI4",
       "hash": 2018104738,
       "title": "The Persuader - Vasastaden",
@@ -1172,25 +1158,11 @@
       "release_item_id": 1
     },
     {
-      "url": "https://www.youtube.com/watch?v=cpQWEQjunF4",
-      "hash": -1953029504,
-      "title": "Profound Sounds Track 1....",
-      "description": "How it SHOULD sound......",
-      "release_item_id": 3
-    },
-    {
       "url": "https://www.youtube.com/watch?v=EBBHR3EMN50",
       "hash": -898492251,
       "title": "The Persuader - Norrmalm",
       "description": "https://www.discogs.com/The-Persuader-Stockholm/release/1\n\n          The Persuader - Norrmalm",
       "release_item_id": 1
-    },
-    {
-      "url": "https://www.youtube.com/watch?v=iaqHaULlqqg",
-      "hash": 1951684427,
-      "title": "Mr. James Barth \u0026 A.D. - Inner City Lullaby",
-      "description": "Follow Mr. James Barth: https://www.facebook.com/CariLekebuschOfficial\n          Buy Record: http://www.discogs.com/Mr-James-Barth-AD-Knockin-Boots-Vol-2-Of-2/release/2\n          More Music: https://www.facebook.com/DoFunkk\n\n          Copyright Notice:\n          I do not own the rights of this",
-      "release_item_id": 2
     },
     {
       "url": "https://www.youtube.com/watch?v=LgLchSRehhc",
@@ -1228,6 +1200,34 @@
       "release_item_id": 1
     },
     {
+      "url": "https://www.youtube.com/watch?v=afMHNll9EVM",
+      "hash": -104566439,
+      "title": "The Persuader - Gamla Stan",
+      "description": "https://www.discogs.com/The-Persuader-Stockholm/release/1\n\n          The Persuader - Gamla Stan",
+      "release_item_id": 1
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=bqUfNGJEKlo",
+      "hash": 854958393,
+      "title": "Profound Sounds Vol. 1 - Josh Wink",
+      "description": "mix 1999",
+      "release_item_id": 3
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=cpQWEQjunF4",
+      "hash": -1953029504,
+      "title": "Profound Sounds Track 1....",
+      "description": "How it SHOULD sound......",
+      "release_item_id": 3
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=iaqHaULlqqg",
+      "hash": 1951684427,
+      "title": "Mr. James Barth \u0026 A.D. - Inner City Lullaby",
+      "description": "Follow Mr. James Barth: https://www.facebook.com/CariLekebuschOfficial\n          Buy Record: http://www.discogs.com/Mr-James-Barth-AD-Knockin-Boots-Vol-2-Of-2/release/2\n          More Music: https://www.facebook.com/DoFunkk\n\n          Copyright Notice:\n          I do not own the rights of this",
+      "release_item_id": 2
+    },
+    {
       "url": "https://www.youtube.com/watch?v=x_Os7b-iWKs",
       "hash": 174713691,
       "title": "Mr. James Barth \u0026 A.D. - Yeah Kid!",
@@ -1249,15 +1249,15 @@
       "release_item_id": 2
     },
     {
-      "hash": 351735604,
-      "work": "Distributed By",
-      "label_id": 2,
-      "release_item_id": 3
-    },
-    {
       "hash": -579413548,
       "work": "Manufactured By",
       "label_id": 1,
+      "release_item_id": 3
+    },
+    {
+      "hash": 351735604,
+      "work": "Distributed By",
+      "label_id": 2,
       "release_item_id": 3
     }
   ],

--- a/src/batch/xml.go
+++ b/src/batch/xml.go
@@ -39,12 +39,29 @@ func (a *XmlArtist) Transform() rxgo.Observable {
 }
 
 type XmlArtistRelation struct {
-	ID       int32    `xml:"id"`
-	URLs     []string `xml:"urls>url"`
-	NameVars []string `xml:"namevariations>name"`
-	Aliases  []XmlRef `xml:"aliases>name"`
-	Groups   []XmlRef `xml:"groups>name"`
-	Members  []XmlRef `xml:"members>name"`
+	ID          int32    `xml:"id"`
+	Name        *string  `xml:"name"`
+	DataQuality *string  `xml:"data_quality"`
+	Profile     *string  `xml:"profile"`
+	RealName    *string  `xml:"realname"`
+	URLs        []string `xml:"urls>url"`
+	NameVars    []string `xml:"namevariations>name"`
+	Aliases     []XmlRef `xml:"aliases>name"`
+	Groups      []XmlRef `xml:"groups>name"`
+	Members     []XmlRef `xml:"members>name"`
+}
+
+func (a *XmlArtistRelation) GetArtist() *opendiscogsmodel.Artist {
+	now := time.Now().UTC()
+	return &opendiscogsmodel.Artist{
+		ID:             a.ID,
+		CreatedAt:      now,
+		LastModifiedAt: now,
+		DataQuality:    helper.FilterStr(a.DataQuality),
+		Name:           helper.FilterStr(a.Name),
+		Profile:        helper.FilterStr(a.Profile),
+		RealName:       helper.FilterStr(a.RealName),
+	}
 }
 
 func (a *XmlArtistRelation) GetUrls() []*opendiscogsmodel.ArtistURL {
@@ -158,9 +175,26 @@ func (l *XmlLabel) Transform() rxgo.Observable {
 }
 
 type XmlLabelRelation struct {
-	ID        int32    `xml:"id"`
-	URLs      []string `xml:"urls>url"`
-	SubLabels []XmlRef `xml:"sublabels>label"`
+	ID          int32    `xml:"id"`
+	Name        *string  `xml:"name"`
+	ContactInfo *string  `xml:"contactinfo"`
+	Profile     *string  `xml:"profile"`
+	DataQuality *string  `xml:"data_quality"`
+	URLs        []string `xml:"urls>url"`
+	SubLabels   []XmlRef `xml:"sublabels>label"`
+}
+
+func (l *XmlLabelRelation) GetLabel() *opendiscogsmodel.Label {
+	now := time.Now().UTC()
+	return &opendiscogsmodel.Label{
+		ID:             l.ID,
+		CreatedAt:      now,
+		LastModifiedAt: now,
+		Name:           helper.FilterStr(l.Name),
+		ContactInfo:    helper.FilterStr(l.ContactInfo),
+		Profile:        helper.FilterStr(l.Profile),
+		DataQuality:    helper.FilterStr(l.DataQuality),
+	}
 }
 
 func (l *XmlLabelRelation) GetUrls() []*opendiscogsmodel.LabelURL {

--- a/src/cache/cache_test.go
+++ b/src/cache/cache_test.go
@@ -57,6 +57,18 @@ func TestIDSetIgnoresInvalidIDsAndResets(t *testing.T) {
 	require.Zero(t, ids.AllocatedWordBytes())
 }
 
+func TestResetIDsClearsGlobalIdentifierCaches(t *testing.T) {
+	ArtistIDs.Add(1)
+	LabelIDs.Add(2)
+	MasterIDs.Add(3)
+
+	ResetIDs()
+
+	require.False(t, ArtistIDs.Contains(1))
+	require.False(t, LabelIDs.Contains(2))
+	require.False(t, MasterIDs.Contains(3))
+}
+
 func BenchmarkIDSetLoadMillion(b *testing.B) {
 	b.ReportAllocs()
 	for iteration := 0; iteration < b.N; iteration++ {

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -45,6 +45,32 @@ func TestGetReturnsBodyAndPropagatesContext(t *testing.T) {
 	require.Equal(t, []byte("payload"), item.V)
 }
 
+func TestNewClientAndNilContext(t *testing.T) {
+	require.IsType(t, &clientImpl{}, NewClient())
+	client := &clientImpl{wc: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		require.NotNil(t, request.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("payload")),
+		}, nil
+	})}
+
+	item := <-client.Get(nil, "https://example.test/catalog").Observe()
+
+	require.NoError(t, item.E)
+}
+
+func TestGetRejectsMalformedURI(t *testing.T) {
+	client := &clientImpl{wc: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("must not execute")
+	})}
+
+	item := <-client.Get(context.Background(), "://bad-uri").Observe()
+
+	require.Error(t, item.E)
+}
+
 func TestGetRejectsNonSuccessStatus(t *testing.T) {
 	client := &clientImpl{wc: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -353,16 +353,23 @@ type ImportPlan struct {
 }
 
 func FetchImportPlan(k *koanf.Koanf, dataRepo Repository) (*ImportPlan, error) {
+	plan, err := ResolveImportPlan(k, dataRepo)
+	if err != nil {
+		return nil, err
+	}
+	if err := FetchImportResources(context.Background(), plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func ResolveImportPlan(k *koanf.Koanf, dataRepo Repository) (*ImportPlan, error) {
 	plan := &ImportPlan{
 		Resources: make(map[string]string),
 		Dumps:     make([]*opendiscogsmodel.DiscogsDump, 0, len(k.Strings("entities"))),
 	}
 	dumpMonth := k.String("dump-month")
 	dataRootDir := k.String("data-dir")
-	if err := os.MkdirAll(dataRootDir, 0755); err != nil {
-		return nil, err
-	}
-	handler := file.NewHandler()
 	for _, entity := range k.Strings("entities") {
 		var (
 			d   *opendiscogsmodel.DiscogsDump
@@ -378,18 +385,37 @@ func FetchImportPlan(k *koanf.Koanf, dataRepo Repository) (*ImportPlan, error) {
 			return nil, err
 		}
 		var (
-			resourceURI = DiscogsS3BaseUrl + d.URI
 			targetPath  = filepath.Join(dataRootDir, helper.GetLastUriSegment(d.URI))
 			resourceKey = strings.TrimSuffix(entity, "s") + "s"
 		)
-		err = handler.FetchAndCheck(resourceURI, targetPath, d.ChecksumSHA256)
-		if err != nil {
-			return nil, err
-		}
 		plan.Resources[resourceKey] = targetPath
 		plan.Dumps = append(plan.Dumps, d)
 	}
 	return plan, nil
+}
+
+func FetchImportResources(ctx context.Context, plan *ImportPlan) error {
+	handler := file.NewHandler()
+	for _, dump := range plan.Dumps {
+		resourceKey := strings.TrimSuffix(dump.EntityType, "s") + "s"
+		targetPath, found := plan.Resources[resourceKey]
+		if !found {
+			return fmt.Errorf("missing %s import resource path", dump.EntityType)
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			return fmt.Errorf("create %s import directory: %w", dump.EntityType, err)
+		}
+		resourceURI := DiscogsS3BaseUrl + dump.URI
+		if err := handler.FetchAndCheckContext(
+			ctx,
+			resourceURI,
+			targetPath,
+			dump.ChecksumSHA256,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func FetchFiles(k *koanf.Koanf, dataRepo Repository) (map[string]string, error) {

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -137,6 +137,9 @@ func isKnownType(typeStr string) bool {
 func DispatchChecksumFetch(store *checksumStore) func(context.Context, interface{}) (interface{}, error) {
 	return func(ctx context.Context, i interface{}) (interface{}, error) {
 		if dump := i.(*Data); dump.TargetType == "checksum" {
+			if err := ctx.Err(); err != nil {
+				return i, err
+			}
 			select {
 			case v, ok := <-getClient().Get(ctx, checksumDownloadURL(dump.Uri)).Observe():
 				if !ok {
@@ -190,8 +193,15 @@ type chkSumP struct {
 
 func ParseDumpModel(ctx context.Context) func(item rxgo.Item) rxgo.Observable {
 	return func(item rxgo.Item) rxgo.Observable {
+		if item.Error() {
+			return rxgo.Thrown(item.E)
+		}
+		body, ok := item.V.([]byte)
+		if !ok {
+			return rxgo.Thrown(fmt.Errorf("dump listing response was not a byte payload"))
+		}
 		p := xmlparser.NewParser[Data]()
-		buf := bytes.NewBuffer(item.V.([]byte))
+		buf := bytes.NewBuffer(body)
 		return p.Parse(ctx, xmlparser.SimpleTokenOrder(io.NopCloser(buf), "Contents"))
 	}
 }
@@ -222,6 +232,10 @@ func UpdateData(ctx context.Context, repo Repository, maxWorkers int) (int, erro
 		Reduce(helper.SliceReducer[*Data]()).
 		Map(BatchInsertItems(repo)).
 		Observe()
+	return catalogUpdateCount(res)
+}
+
+func catalogUpdateCount(res rxgo.Item) (int, error) {
 	if res.E != nil {
 		return 0, res.E
 	}

--- a/src/data/data_test.go
+++ b/src/data/data_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -125,6 +126,12 @@ func TestPopulateFromUri(t *testing.T) {
 		_, err := PopulateFromUri()(context.Background(), &Data{Uri: "invalid"})
 		require.Error(t, err)
 	})
+	t.Run("must reject invalid date", func(t *testing.T) {
+		_, err := PopulateFromUri()(context.Background(), &Data{
+			Uri: "data/2008/discogs_20081409_releases.xml.gz",
+		})
+		require.ErrorContains(t, err, "invalid dump date")
+	})
 }
 
 func TestNotNilFilter(t *testing.T) {
@@ -140,6 +147,23 @@ func TestNotNilFilter(t *testing.T) {
 type clientStub struct {
 	pl  []byte
 	err error
+}
+
+type observableClientStub struct {
+	observable rxgo.Observable
+}
+
+func (c observableClientStub) Get(context.Context, string) rxgo.Observable {
+	return c.observable
+}
+
+type signalingClientStub struct {
+	called chan<- struct{}
+}
+
+func (c signalingClientStub) Get(context.Context, string) rxgo.Observable {
+	close(c.called)
+	return rxgo.Never()
 }
 
 func (c clientStub) Get(_ context.Context, _ string) rxgo.Observable {
@@ -180,6 +204,39 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 		dump := &Data{TargetType: "checksum", Uri: "checksum.txt"}
 		_, err := DispatchChecksumFetch(newChecksumStore())(context.Background(), dump)
 		require.ErrorIs(t, err, fetchErr)
+	})
+	t.Run("must reject an empty response", func(t *testing.T) {
+		getClient = func() client.Client { return observableClientStub{observable: rxgo.Empty()} }
+		dump := &Data{TargetType: "checksum", Uri: "checksum.txt"}
+		_, err := DispatchChecksumFetch(newChecksumStore())(context.Background(), dump)
+		require.ErrorContains(t, err, "response closed")
+	})
+	t.Run("must reject a non-byte response", func(t *testing.T) {
+		getClient = func() client.Client {
+			return observableClientStub{observable: rxgo.Just("invalid")()}
+		}
+		dump := &Data{TargetType: "checksum", Uri: "checksum.txt"}
+		_, err := DispatchChecksumFetch(newChecksumStore())(context.Background(), dump)
+		require.ErrorContains(t, err, "not a byte payload")
+	})
+	t.Run("must honor cancellation before requesting", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		dump := &Data{TargetType: "checksum", Uri: "checksum.txt"}
+		_, err := DispatchChecksumFetch(newChecksumStore())(ctx, dump)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("must honor cancellation while awaiting response", func(t *testing.T) {
+		called := make(chan struct{})
+		getClient = func() client.Client { return signalingClientStub{called: called} }
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-called
+			cancel()
+		}()
+		dump := &Data{TargetType: "checksum", Uri: "checksum.txt"}
+		_, err := DispatchChecksumFetch(newChecksumStore())(ctx, dump)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 }
 
@@ -231,13 +288,25 @@ func TestParseDataModel(t *testing.T) {
 			assert.NotEmpty(t, v.Uri)
 		}
 	})
+	t.Run("propagates source and payload errors", func(t *testing.T) {
+		expected := errors.New("fixture")
+		result := <-ParseDumpModel(context.Background())(rxgo.Error(expected)).Observe()
+		require.ErrorIs(t, result.E, expected)
+
+		result = <-ParseDumpModel(context.Background())(rxgo.Of("invalid")).Observe()
+		require.ErrorContains(t, result.E, "not a byte payload")
+	})
 }
 
 type RepositoryStub struct {
-	items []*Data
+	items    []*Data
+	batchErr error
 }
 
 func (r *RepositoryStub) BatchInsert(data []*Data) (int, error) {
+	if r.batchErr != nil {
+		return 0, r.batchErr
+	}
 	r.items = data
 	return len(data), nil
 }
@@ -322,6 +391,39 @@ func TestUpdateDataRejectsNonPositiveMaxWorkers(t *testing.T) {
 	require.ErrorContains(t, err, "max-workers must be a positive integer")
 }
 
+func TestUpdateDataPropagatesListingFailure(t *testing.T) {
+	server := testserver.NewServer(func(
+		requests []*testserver.HttpRequest,
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		http.Error(w, "fixture", http.StatusInternalServerError)
+	})
+	defer server.Close()
+	originalURL := DiscogsS3BaseUrl
+	t.Cleanup(func() { DiscogsS3BaseUrl = originalURL })
+	DiscogsS3BaseUrl = server.URL
+
+	updated, err := UpdateData(context.Background(), &RepositoryStub{}, 1)
+	require.Equal(t, -1, updated)
+	require.Error(t, err)
+}
+
+func TestCatalogUpdateCount(t *testing.T) {
+	expected := errors.New("fixture")
+	updated, err := catalogUpdateCount(rxgo.Error(expected))
+	require.Zero(t, updated)
+	require.ErrorIs(t, err, expected)
+
+	updated, err = catalogUpdateCount(rxgo.Of("not-a-count"))
+	require.Zero(t, updated)
+	require.ErrorContains(t, err, "did not contain a count")
+
+	updated, err = catalogUpdateCount(rxgo.Of(7))
+	require.NoError(t, err)
+	require.Equal(t, 7, updated)
+}
+
 func TestUpdateSelectedDataBoundsChecksumRequests(t *testing.T) {
 	listing := resource.Read("testdata/update-data-test.xml")
 	server := testserver.NewServer(func(requests []*testserver.HttpRequest, w http.ResponseWriter, r *http.Request) {
@@ -356,6 +458,131 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 	require.Equal(t, 3, updated)
 	require.Len(t, repo.items, 3)
 	require.Len(t, server.Requests(), 2, "one listing plus one shared-date checksum request")
+}
+
+func TestUpdateSelectedDataErrorBoundaries(t *testing.T) {
+	listing := resource.Read("testdata/update-data-test.xml")
+	tests := []struct {
+		name            string
+		listingResponse []byte
+		checksumStatus  int
+		checksumBody    string
+		want            string
+	}{
+		{
+			name:            "missing checksum manifest",
+			listingResponse: bytes.Replace(listing, checksumContents(listing), nil, 1),
+			checksumStatus:  http.StatusOK,
+			want:            "checksum manifest not found",
+		},
+		{
+			name:            "checksum fetch failure",
+			listingResponse: listing,
+			checksumStatus:  http.StatusInternalServerError,
+			want:            "returned 500",
+		},
+		{
+			name:            "missing entity checksum",
+			listingResponse: listing,
+			checksumStatus:  http.StatusOK,
+			checksumBody:    validChecksumTextSliceSample[1],
+			want:            "checksum not found",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := testserver.NewServer(func(
+				requests []*testserver.HttpRequest,
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				if r.URL.Query().Has("download") {
+					w.WriteHeader(test.checksumStatus)
+					_, _ = w.Write([]byte(test.checksumBody))
+					return
+				}
+				_, _ = w.Write(test.listingResponse)
+			})
+			defer server.Close()
+			originalS3URL, originalDataURL := DiscogsS3BaseUrl, DiscogsDataBaseURL
+			t.Cleanup(func() {
+				DiscogsS3BaseUrl = originalS3URL
+				DiscogsDataBaseURL = originalDataURL
+			})
+			DiscogsS3BaseUrl = server.URL
+			DiscogsDataBaseURL = server.URL
+
+			updated, err := UpdateSelectedData(
+				context.Background(),
+				&RepositoryStub{},
+				[]string{"artist"},
+				"",
+			)
+			require.Equal(t, -1, updated)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func checksumContents(listing []byte) []byte {
+	start := bytes.Index(listing, []byte("    <Contents>"))
+	if start < 0 {
+		return nil
+	}
+	end := bytes.Index(listing[start:], []byte("    </Contents>"))
+	if end < 0 {
+		return nil
+	}
+	return listing[start : start+end+len("    </Contents>")]
+}
+
+func TestUpdateSelectedDataPropagatesListingFailure(t *testing.T) {
+	server := testserver.NewServer(func(
+		requests []*testserver.HttpRequest,
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		http.Error(w, "fixture", http.StatusInternalServerError)
+	})
+	defer server.Close()
+	originalURL := DiscogsS3BaseUrl
+	t.Cleanup(func() { DiscogsS3BaseUrl = originalURL })
+	DiscogsS3BaseUrl = server.URL
+
+	updated, err := UpdateSelectedData(context.Background(), &RepositoryStub{}, []string{"artist"}, "")
+	require.Equal(t, -1, updated)
+	require.Error(t, err)
+}
+
+func TestSelectRefreshCandidatesHonorsMonthAndLatest(t *testing.T) {
+	items := []*Data{
+		{TargetType: "artists", GeneratedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
+		{TargetType: "artists", GeneratedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+		{TargetType: "labels", GeneratedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	candidates := selectRefreshCandidates(items, []string{"artist"}, "2026-06")
+	require.Len(t, candidates, 1)
+	require.Equal(t, time.June, candidates[0].GeneratedAt.Month())
+}
+
+func TestFetchBytesErrorBoundaries(t *testing.T) {
+	originalClient := getClient
+	t.Cleanup(func() { getClient = originalClient })
+	expected := errors.New("fixture")
+
+	getClient = getClientStub(nil, expected)
+	_, err := fetchBytes(context.Background(), "fixture")
+	require.ErrorIs(t, err, expected)
+
+	getClient = func() client.Client {
+		return observableClientStub{observable: rxgo.Just("invalid")()}
+	}
+	_, err = fetchBytes(context.Background(), "fixture")
+	require.ErrorContains(t, err, "unexpected response body")
+
+	getClient = func() client.Client { return observableClientStub{observable: rxgo.Empty()} }
+	_, err = fetchBytes(context.Background(), "fixture")
+	require.ErrorContains(t, err, "empty response")
 }
 
 func TestFetchFiles(t *testing.T) {
@@ -507,4 +734,43 @@ func TestResolveImportPlanDoesNotDownload(t *testing.T) {
 	require.Contains(t, plan.Resources["artists"], "discogs_20101001_artists.xml.gz")
 	require.NoDirExists(t, dataDirectory)
 	require.Empty(t, server.Requests())
+}
+
+func TestResolveImportPlanUsesLatestDump(t *testing.T) {
+	config := koanf.New(".")
+	require.NoError(t, config.Set("entities", []string{"artist"}))
+	require.NoError(t, config.Set("data-dir", t.TempDir()))
+	repository := &RepositoryStub{items: []*Data{
+		{
+			GeneratedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			TargetType:  "artists",
+			Uri:         "data/2026/discogs_20260701_artists.xml.gz",
+		},
+	}}
+
+	plan, err := ResolveImportPlan(config, repository)
+	require.NoError(t, err)
+	require.Len(t, plan.Dumps, 1)
+	require.Contains(t, plan.Resources["artists"], "discogs_20260701_artists.xml.gz")
+}
+
+func TestFetchImportResourcesRejectsInvalidPlanAndDirectory(t *testing.T) {
+	dump := &opendiscogsmodel.DiscogsDump{
+		EntityType:     "artist",
+		URI:            "data/2026/discogs_20260701_artists.xml.gz",
+		ChecksumSHA256: strings.Repeat("0", 64),
+	}
+	require.ErrorContains(t, FetchImportResources(context.Background(), &ImportPlan{
+		Resources: map[string]string{},
+		Dumps:     []*opendiscogsmodel.DiscogsDump{dump},
+	}), "missing artist import resource path")
+
+	blockingFile := filepath.Join(t.TempDir(), "blocking-file")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("fixture"), 0600))
+	require.ErrorContains(t, FetchImportResources(context.Background(), &ImportPlan{
+		Resources: map[string]string{
+			"artists": filepath.Join(blockingFile, "child", "artists.xml.gz"),
+		},
+		Dumps: []*opendiscogsmodel.DiscogsDump{dump},
+	}), "create artist import directory")
 }

--- a/src/data/data_test.go
+++ b/src/data/data_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -467,4 +468,43 @@ data-dir: testdata/
 		require.ErrorContains(t, err, "checksum")
 		require.Nil(t, result)
 	})
+}
+
+func TestResolveImportPlanDoesNotDownload(t *testing.T) {
+	server := testserver.NewServer(func(
+		requests []*testserver.HttpRequest,
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		t.Fatalf("resolve import plan must not request %s", r.URL.String())
+	})
+	defer server.Close()
+	origin := DiscogsS3BaseUrl
+	defer func() { DiscogsS3BaseUrl = origin }()
+	DiscogsS3BaseUrl = server.URL + "/"
+
+	dataDirectory := filepath.Join(t.TempDir(), "not-created")
+	config := koanf.New(".")
+	require.NoError(t, config.Set("entities", []string{"artist"}))
+	require.NoError(t, config.Set("dump-month", "2010-10"))
+	require.NoError(t, config.Set("data-dir", dataDirectory))
+	repository := &RepositoryStub{}
+	_, err := repository.BatchInsert([]*Data{
+		{
+			ETag:        "artist-2010-10",
+			GeneratedAt: time.Date(2010, 10, 1, 0, 0, 0, 0, time.UTC),
+			Checksum:    strings.Repeat("a", 64),
+			TargetType:  "artist",
+			Uri:         "data/2010/discogs_20101001_artists.xml.gz",
+		},
+	})
+	require.NoError(t, err)
+
+	plan, err := ResolveImportPlan(config, repository)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Dumps, 1)
+	require.Contains(t, plan.Resources["artists"], "discogs_20101001_artists.xml.gz")
+	require.NoDirExists(t, dataDirectory)
+	require.Empty(t, server.Requests())
 }

--- a/src/data/repository_test.go
+++ b/src/data/repository_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"errors"
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
+	"strings"
 	"testing"
 	"time"
 )
@@ -72,6 +74,33 @@ func (s *DataRepoSuite) TestFindLatestByTypeUsesIndependentEntityDate() {
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), "latest-label-new", latest.ETag)
 	require.Equal(s.T(), "label", latest.EntityType)
+}
+
+func (s *DataRepoSuite) TestFindLatestByTypeReturnsNotFound() {
+	_, err := s.repo.FindLatestByType("never-existing-entity")
+	require.ErrorContains(s.T(), err, "latest never-existing-entity data not found")
+}
+
+func (s *DataRepoSuite) TestBatchInsertSkipsChecksumOnlyCatalog() {
+	count, err := s.repo.BatchInsert([]*Data{{TargetType: "checksum"}})
+	require.NoError(s.T(), err)
+	require.Zero(s.T(), count)
+}
+
+func (s *DataRepoSuite) TestBatchInsertPropagatesDatabaseError() {
+	expected := errors.New("fixture")
+	errorDB := s.DB.Session(&gorm.Session{})
+	errorDB.AddError(expected)
+	repository := NewDataRepository(errorDB)
+
+	count, err := repository.BatchInsert([]*Data{{
+		GeneratedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		TargetType:  "artist",
+		Checksum:    strings.Repeat("a", 64),
+		Uri:         "data/2026/discogs_20260701_artists.xml.gz",
+	}})
+	require.Zero(s.T(), count)
+	require.ErrorIs(s.T(), err, expected)
 }
 
 func (s *DataRepoSuite) TestBatchInsert() {

--- a/src/data/repository_test.go
+++ b/src/data/repository_test.go
@@ -18,15 +18,13 @@ type DataRepoSuite struct {
 	repo Repository
 }
 
-func (s *DataRepoSuite) Prepare() {
-	if database.DB == nil {
-		dbInfo := testutils.GetDatabase(testutils.Postgres)
-		require.NoError(s.T(), database.Connect(testutils.GetDsn(testutils.Postgres, dbInfo)))
-		s.DB = database.DB
-		require.NoError(s.T(), testutils.ApplySharedSchema(s.DB))
-		s.DB.Logger.LogMode(3)
-		s.repo = NewDataRepository(s.DB)
-	}
+func (s *DataRepoSuite) SetupSuite() {
+	dbInfo := testutils.GetDatabase(s.T(), testutils.Postgres)
+	require.NoError(s.T(), database.Connect(testutils.GetDsn(testutils.Postgres, dbInfo)))
+	s.DB = database.DB
+	require.NoError(s.T(), testutils.ApplySharedSchema(s.DB))
+	s.DB.Logger.LogMode(3)
+	s.repo = NewDataRepository(s.DB)
 }
 
 func TestInit(t *testing.T) {
@@ -34,7 +32,6 @@ func TestInit(t *testing.T) {
 }
 
 func (s *DataRepoSuite) TestFindByYear() {
-	s.Prepare()
 	_, err := s.repo.FindByYearMonthType("1900", "03", "artist")
 	require.ErrorContains(s.T(), err, "1900")
 	require.ErrorContains(s.T(), err, "03")
@@ -42,14 +39,12 @@ func (s *DataRepoSuite) TestFindByYear() {
 }
 
 func (s *DataRepoSuite) TestFindByYearInvalidFormat() {
-	s.Prepare()
 	_, err := s.repo.FindByYearMonthType("xxxx", "xx", "Xx")
 	require.ErrorContains(s.T(), err, "failed to parse")
 	require.ErrorContains(s.T(), err, "xxxx.xx")
 }
 
 func (s *DataRepoSuite) TestFindLatestByTypeUsesIndependentEntityDate() {
-	s.Prepare()
 	items := []*Data{
 		{
 			ETag:        "latest-label-old",
@@ -80,7 +75,6 @@ func (s *DataRepoSuite) TestFindLatestByTypeUsesIndependentEntityDate() {
 }
 
 func (s *DataRepoSuite) TestBatchInsert() {
-	s.Prepare()
 	var (
 		etag = "test-etag-test-batch-insert"
 		gen  = time.Now()

--- a/src/database/gorm_test.go
+++ b/src/database/gorm_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 	"testing"
 )
 
@@ -35,5 +36,13 @@ func TestConnect(t *testing.T) {
 	t.Run("must complain", func(t *testing.T) {
 		err := Connect("test")
 		assert.ErrorContains(t, err, "unsupported dsn. please check again")
+	})
+
+	t.Run("reject missing dsn", func(t *testing.T) {
+		assert.ErrorContains(t, Connect(""), "missing dsn")
+	})
+
+	t.Run("report unavailable SQL pool", func(t *testing.T) {
+		assert.ErrorContains(t, ConfigurePool(&gorm.DB{Config: &gorm.Config{}}, 1), "open SQL connection pool")
 	})
 }

--- a/src/database/gorm_test.go
+++ b/src/database/gorm_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConnect(t *testing.T) {
 	t.Run("connect postgres", func(t *testing.T) {
-		pg := testutils.GetDatabase(testutils.Postgres)
+		pg := testutils.GetDatabase(t, testutils.Postgres)
 		dsn := testutils.GetDsn(testutils.Postgres, pg)
 		fmt.Println("DSN", dsn)
 		err := Connect(dsn)

--- a/src/dateparser/dateparser.go
+++ b/src/dateparser/dateparser.go
@@ -7,7 +7,6 @@ import (
 
 var releaseDateDelimRegexp = regexp.MustCompile(`[-_. \D]`)
 var dateByDelimRegexp = regexp.MustCompile(`^(\d+)[-_. ](\d+)[-_. ](\d+)$`)
-var fourDigitYearOnlyRegexp = regexp.MustCompile(`^(\d{4})(\\D{1,2})$`)
 var fourDigitYearMonthOnlyRegexp = regexp.MustCompile(`^(\d{4})(\d{1,2})\D{0,2}$`)
 
 func ParseYMD(ymd string) (y, m, d *int16) {
@@ -23,9 +22,7 @@ func ParseYMD(ymd string) (y, m, d *int16) {
 		}
 	}
 	ymd = releaseDateDelimRegexp.ReplaceAllString(ymd, "")
-	if m := fourDigitYearOnlyRegexp.FindStringSubmatch(ymd); m != nil {
-		ymd = m[1]
-	} else if m := fourDigitYearMonthOnlyRegexp.FindStringSubmatch(ymd); m != nil {
+	if m := fourDigitYearMonthOnlyRegexp.FindStringSubmatch(ymd); m != nil {
 		ymd = m[1] + minTwoDigit(m[2])
 	}
 

--- a/src/file/file.go
+++ b/src/file/file.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -27,6 +28,8 @@ type Handler interface {
 	// FetchAndCheck calls Fetch to retrieve file, while checking the checksum to validate incoming file.
 	// The file will be deleted if checksum fails.
 	FetchAndCheck(uri string, filepath string, checksum string) error
+	// FetchAndCheckContext is FetchAndCheck with cancellation support.
+	FetchAndCheckContext(context.Context, string, string, string) error
 	// Write writes byte array content to given filepath and permission.
 	Write(filepath string, content []byte, perm os.FileMode) error
 	// Read reads byte array content from given filepath. This works as identical delegation to os.ReadFile.
@@ -128,13 +131,23 @@ func (h *handlerImpl) Checksum(filepath string, checksum string) error {
 }
 
 func (h *handlerImpl) Fetch(uri string, filepath string) error {
-	// grab request
-	req := h.newRequest(uri, filepath)
-	// request
+	req, err := h.newRequest(uri, filepath)
+	if err != nil {
+		return err
+	}
 	return h.execGrabReq(req)
 }
 
 func (h *handlerImpl) FetchAndCheck(uri string, filepath string, checksum string) error {
+	return h.FetchAndCheckContext(context.Background(), uri, filepath, checksum)
+}
+
+func (h *handlerImpl) FetchAndCheckContext(
+	ctx context.Context,
+	uri string,
+	filepath string,
+	checksum string,
+) error {
 	var (
 		sum      []byte
 		err      error
@@ -163,7 +176,11 @@ func (h *handlerImpl) FetchAndCheck(uri string, filepath string, checksum string
 		return err
 	}
 	// grab request with checksum
-	req := h.newRequestWithChecksum(uri, filepath, sum)
+	req, err := h.newRequestWithChecksum(uri, filepath, sum)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
 	// request
 	return h.execGrabReq(req)
 }
@@ -188,15 +205,25 @@ func (h *handlerImpl) Write(filepath string, content []byte, perm os.FileMode) e
 	return err
 }
 
-func (h *handlerImpl) newRequest(uri, filepath string) *grab.Request {
-	req, _ := grab.NewRequest(filepath, uri)
-	return req
+func (h *handlerImpl) newRequest(uri, filepath string) (*grab.Request, error) {
+	req, err := grab.NewRequest(filepath, uri)
+	if err != nil {
+		return nil, fmt.Errorf("create download request: %w", err)
+	}
+	return req, nil
 }
 
-func (h *handlerImpl) newRequestWithChecksum(uri, filepath string, checksum []byte) *grab.Request {
-	req := h.newRequest(uri, filepath)
+func (h *handlerImpl) newRequestWithChecksum(
+	uri string,
+	filepath string,
+	checksum []byte,
+) (*grab.Request, error) {
+	req, err := h.newRequest(uri, filepath)
+	if err != nil {
+		return nil, err
+	}
 	req.SetChecksum(sha256.New(), checksum, true)
-	return req
+	return req, nil
 }
 
 func (h *handlerImpl) execGrabReq(req *grab.Request) error {

--- a/src/file/file.go
+++ b/src/file/file.go
@@ -46,6 +46,17 @@ type handlerImpl struct {
 	reader Reader
 }
 
+type writableFile interface {
+	Write([]byte) (int, error)
+	Close() error
+}
+
+var openWritableFile = openFileForWrite
+
+func openFileForWrite(filepath string, perm os.FileMode) (writableFile, error) {
+	return os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+}
+
 type Reader interface {
 	ReadFile(path string) ([]byte, error)
 	Exists(path string) (bool, error)
@@ -85,7 +96,7 @@ func (h *handlerImpl) Copy(source, target string, targetPerm os.FileMode) error 
 		return err
 	}
 	defer src.Close()
-	if dst, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0666); err != nil {
+	if dst, err = os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, targetPerm); err != nil {
 		_ = src.Close()
 		return err
 	}
@@ -194,7 +205,7 @@ func (h *handlerImpl) getDecodedChecksum(checksum string) ([]byte, error) {
 }
 
 func (h *handlerImpl) Write(filepath string, content []byte, perm os.FileMode) error {
-	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	f, err := openWritableFile(filepath, perm)
 	if err != nil {
 		return err
 	}

--- a/src/file/file_test.go
+++ b/src/file/file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"github.com/dsub-io/go-open-discogs-batch/internal/test/resource"
 	"github.com/dsub-io/go-open-discogs-batch/internal/testserver"
 	"github.com/stretchr/testify/assert"
@@ -94,6 +95,11 @@ func Test_handlerImpl_Checksum(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChecksumReturnsReadError(t *testing.T) {
+	err := (&handlerImpl{}).Checksum(t.TempDir(), strings.Repeat("0", 64))
+	require.Error(t, err)
 }
 
 func Test_handlerImpl_Copy(t *testing.T) {
@@ -190,6 +196,12 @@ func Test_handlerImpl_Delete(t *testing.T) {
 	}
 }
 
+func TestDeleteReturnsUnexpectedError(t *testing.T) {
+	directory := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "child"), []byte("fixture"), 0600))
+	require.Error(t, (&handlerImpl{}).Delete(directory))
+}
+
 func Test_handlerImpl_Fetch(t *testing.T) {
 	expected := string(resource.Read("testdata/test.xml"))
 	s := testserver.NewServerWithStaticResponse(expected)
@@ -204,7 +216,10 @@ func Test_handlerImpl_Fetch(t *testing.T) {
 
 	slowServer := testserver.NewServer(
 		func(requests []*testserver.HttpRequest, w http.ResponseWriter, r *http.Request) {
-			<-time.After(time.Millisecond * 200)
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(expected)))
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			<-time.After(time.Millisecond * 600)
 			_, _ = w.Write([]byte(expected))
 		})
 
@@ -354,6 +369,49 @@ func Test_handlerImpl_FetchAndCheck(t *testing.T) {
 	}
 }
 
+func TestFetchAndCheckContextErrorBoundaries(t *testing.T) {
+	validFile := filepath.Join(t.TempDir(), "valid")
+	require.NoError(t, os.WriteFile(validFile, resource.Read("testdata/test.xml"), 0600))
+	require.NoError(t, (&handlerImpl{reader: &fileReaderImpl{}}).FetchAndCheckContext(
+		context.Background(),
+		"https://example.invalid/not-used",
+		validFile,
+		"69718470e15145cf586db15389bb2bf81b4cf4ee179aa6c0dd61afaf17d56b3d",
+	))
+
+	handler := &handlerImpl{reader: testFileReader{existsErr: errors.New("stat failure")}}
+	require.ErrorContains(t, handler.FetchAndCheckContext(
+		context.Background(),
+		"https://example.invalid/resource",
+		filepath.Join(t.TempDir(), "resource"),
+		strings.Repeat("0", 64),
+	), "stat failure")
+
+	directory := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "child"), []byte("fixture"), 0600))
+	handler = &handlerImpl{reader: testFileReader{exists: true}}
+	require.Error(t, handler.FetchAndCheckContext(
+		context.Background(),
+		"https://example.invalid/resource",
+		directory,
+		strings.Repeat("0", 64),
+	))
+
+	handler = &handlerImpl{reader: testFileReader{}}
+	require.ErrorContains(t, handler.FetchAndCheckContext(
+		context.Background(),
+		"https://example.invalid/resource",
+		filepath.Join(t.TempDir(), "resource"),
+		"not-hex",
+	), "failed to decode checksum")
+	require.ErrorContains(t, handler.FetchAndCheckContext(
+		context.Background(),
+		"://invalid",
+		filepath.Join(t.TempDir(), "resource"),
+		strings.Repeat("0", 64),
+	), "create download request")
+}
+
 func Test_handlerImpl_Write(t *testing.T) {
 	openedFilePath := "testdata/test_write_opened_file.txt"
 	f, _ := os.OpenFile(openedFilePath, os.O_RDONLY, 0644)
@@ -391,14 +449,43 @@ func Test_handlerImpl_Write(t *testing.T) {
 	}
 }
 
+type writableFileStub struct {
+	writeErr error
+	closeErr error
+}
+
+func (f *writableFileStub) Write([]byte) (int, error) { return 0, f.writeErr }
+func (f *writableFileStub) Close() error              { return f.closeErr }
+
+func TestWriteErrorBoundaries(t *testing.T) {
+	handler := &handlerImpl{}
+	require.Error(t, handler.Write(t.TempDir(), []byte("fixture"), 0600))
+
+	originalOpen := openWritableFile
+	t.Cleanup(func() { openWritableFile = originalOpen })
+	writeErr := errors.New("write failure")
+	openWritableFile = func(string, os.FileMode) (writableFile, error) {
+		return &writableFileStub{writeErr: writeErr, closeErr: errors.New("close failure")}, nil
+	}
+	require.ErrorIs(t, handler.Write("unused", []byte("fixture"), 0600), writeErr)
+
+	closeErr := errors.New("close failure")
+	openWritableFile = func(string, os.FileMode) (writableFile, error) {
+		return &writableFileStub{closeErr: closeErr}, nil
+	}
+	require.ErrorIs(t, handler.Write("unused", []byte("fixture"), 0600), closeErr)
+}
+
 type testFileReader struct {
-	path string
-	res  []byte
-	err  error
+	path      string
+	res       []byte
+	err       error
+	exists    bool
+	existsErr error
 }
 
 func (t testFileReader) Exists(path string) (bool, error) {
-	panic("no-op")
+	return t.exists, t.existsErr
 }
 
 func (t testFileReader) ReadFile(path string) ([]byte, error) {
@@ -480,4 +567,17 @@ func TestNewHandler(t *testing.T) {
 			assert.Equalf(t, tt.want, NewHandler(), "NewHandler()")
 		})
 	}
+}
+
+func TestFileReaderExists(t *testing.T) {
+	reader := &fileReaderImpl{}
+	exists, err := reader.Exists(filepath.Join(t.TempDir(), "missing"))
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	regularFile := filepath.Join(t.TempDir(), "regular")
+	require.NoError(t, os.WriteFile(regularFile, []byte("fixture"), 0600))
+	exists, err = reader.Exists(filepath.Join(regularFile, "child"))
+	require.Error(t, err)
+	require.False(t, exists)
 }

--- a/src/file/file_test.go
+++ b/src/file/file_test.go
@@ -2,15 +2,46 @@ package file
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"github.com/dsub-io/go-open-discogs-batch/internal/test/resource"
 	"github.com/dsub-io/go-open-discogs-batch/internal/testserver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestFetchAndCheckContextHonorsCancellation(t *testing.T) {
+	handler := NewHandler()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	target := filepath.Join(t.TempDir(), "cancelled-download")
+
+	err := handler.FetchAndCheckContext(
+		ctx,
+		"https://example.invalid/cancelled-download",
+		target,
+		strings.Repeat("0", 64),
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoFileExists(t, target)
+}
+
+func TestFetchRejectsInvalidURI(t *testing.T) {
+	handler := NewHandler()
+	target := filepath.Join(t.TempDir(), "invalid-download")
+
+	err := handler.Fetch("://invalid", target)
+
+	require.ErrorContains(t, err, "create download request")
+	require.NoFileExists(t, target)
+}
 
 func Test_handlerImpl_Checksum(t *testing.T) {
 	type args struct {

--- a/src/helper/extract_test.go
+++ b/src/helper/extract_test.go
@@ -11,4 +11,5 @@ func TestExtractGormPKColumns(t *testing.T) {
 	extractedColumns := ExtractGormPKColumns(m)
 	assert.Contains(t, extractedColumns, "id")
 	assert.Len(t, extractedColumns, 1)
+	assert.Equal(t, extractedColumns, ExtractGormPKColumns(&m))
 }

--- a/src/helper/func_test.go
+++ b/src/helper/func_test.go
@@ -72,6 +72,17 @@ func TestMapWindowedSlice(t *testing.T) {
 			require.NotEmpty(t, values)
 		}
 	})
+
+	t.Run("mapper ignores nil items", func(t *testing.T) {
+		items := make(chan rxgo.Item, 2)
+		items <- rxgo.Item{}
+		items <- rxgo.Of(1)
+		close(items)
+		observable := rxgo.FromChannel(items)
+		value, err := f(nil, observable)
+		require.NoError(t, err)
+		require.Equal(t, []int{1}, value)
+	})
 }
 
 func TestFilterStr(t *testing.T) {

--- a/src/helper/hash_test.go
+++ b/src/helper/hash_test.go
@@ -24,3 +24,9 @@ func TestFnv32Str(t *testing.T) {
 		require.Equal(t, bRes, sRes)
 	})
 }
+
+func TestJavaStringHashMatchesJavaSemantics(t *testing.T) {
+	require.Equal(t, int32(0), JavaStringHash(""))
+	require.Equal(t, int32(65), JavaStringHash("A"))
+	require.Equal(t, int32(1_835_364), JavaStringHash("A😀"))
+}

--- a/src/reader/progressbar.go
+++ b/src/reader/progressbar.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"compress/gzip"
+	"errors"
 	"github.com/schollz/progressbar/v3"
 	"io"
 	"os"
@@ -17,7 +18,10 @@ func NewProgressBarGzipReadCloser(f *os.File, progressBarText string) (io.ReadCl
 
 	pb := getProgressBar(GetFilename(progressBarText), -1)
 	pbReader := progressbar.NewReader(reader, pb)
-	return &readCloserImpl{&pbReader, f}, nil
+	return &readCloserImpl{
+		readDelegate:   &pbReader,
+		closeDelegates: []io.Closer{reader, f},
+	}, nil
 }
 
 func getProgressBar(text string, size int64) *progressbar.ProgressBar {
@@ -46,8 +50,8 @@ func GetFilename(filepath string) string {
 }
 
 type readCloserImpl struct {
-	readDelegate  io.Reader
-	closeDelegate io.Closer
+	readDelegate   io.Reader
+	closeDelegates []io.Closer
 }
 
 func (r *readCloserImpl) Read(p []byte) (n int, err error) {
@@ -55,5 +59,9 @@ func (r *readCloserImpl) Read(p []byte) (n int, err error) {
 }
 
 func (r *readCloserImpl) Close() error {
-	return r.closeDelegate.Close()
+	var closeErr error
+	for _, delegate := range r.closeDelegates {
+		closeErr = errors.Join(closeErr, delegate.Close())
+	}
+	return closeErr
 }

--- a/src/reader/progressbar_test.go
+++ b/src/reader/progressbar_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,4 +28,17 @@ func TestNewProgressBarGzipReadCloser(t *testing.T) {
 
 	require.NoError(t, r.Close())
 	require.Error(t, f.Close())
+}
+
+func TestNewProgressBarGzipReadCloserRejectsInvalidGzip(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "invalid.gz")
+	require.NoError(t, os.WriteFile(filePath, []byte("not gzip"), 0o600))
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+
+	reader, err := NewProgressBarGzipReadCloser(f, filePath)
+
+	require.Error(t, err)
+	require.Nil(t, reader)
+	require.NoError(t, f.Close())
 }

--- a/src/result/result_test.go
+++ b/src/result/result_test.go
@@ -14,4 +14,13 @@ func TestResultSumPreservesTheFirstError(t *testing.T) {
 
 	require.Equal(t, 9, sum.Count())
 	require.ErrorIs(t, sum.Err(), firstError)
+	require.True(t, sum.IsErr())
+	require.False(t, NewResult(0, nil).IsErr())
+}
+
+func TestResultSumIgnoresNil(t *testing.T) {
+	result := NewResult(2, nil)
+
+	require.Same(t, result, result.Sum(nil))
+	require.Equal(t, 2, result.Count())
 }

--- a/src/unique/slice_test.go
+++ b/src/unique/slice_test.go
@@ -3,6 +3,7 @@ package unique
 import (
 	"github.com/dsub-io/open-discogs-model/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -23,4 +24,12 @@ func Test_getUniqueSlice(t *testing.T) {
 		result = Slice(artistUrls)
 	)
 	assert.Len(t, result, 2)
+}
+
+func TestSlicePanicsWhenComparableValueCannotBeHashed(t *testing.T) {
+	type unsupported struct {
+		Channel chan int
+	}
+
+	require.Panics(t, func() { Slice([]unsupported{{Channel: make(chan int)}}) })
 }

--- a/src/xmlparser/parser.go
+++ b/src/xmlparser/parser.go
@@ -61,6 +61,10 @@ func NewParser[T any]() Parser[T] {
 
 type parserImpl[T any] struct{}
 
+var beforeEmitSelect = noOpBeforeEmitSelect
+
+func noOpBeforeEmitSelect() {}
+
 func (p *parserImpl[T]) Parse(ctx context.Context, order TokenParseOrder) rxgo.Observable {
 	if ctx == nil {
 		ctx = context.Background()
@@ -69,17 +73,14 @@ func (p *parserImpl[T]) Parse(ctx context.Context, order TokenParseOrder) rxgo.O
 
 	go func(chan rxgo.Item) {
 		defer func() {
-			close(c)
 			_ = order.Close()
+			close(c)
 		}()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			default:
-				if ctx.Err() != nil {
-					return
-				}
 				token, err := order.Token()
 				if err != nil {
 					if !errors.Is(err, io.EOF) {
@@ -108,6 +109,10 @@ func (p *parserImpl[T]) Parse(ctx context.Context, order TokenParseOrder) rxgo.O
 }
 
 func emit(ctx context.Context, target chan<- rxgo.Item, item rxgo.Item) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	beforeEmitSelect()
 	select {
 	case <-ctx.Done():
 		return false

--- a/src/xmlparser/parser_test.go
+++ b/src/xmlparser/parser_test.go
@@ -3,12 +3,55 @@ package xmlparser
 import (
 	"bytes"
 	"context"
+	"encoding/xml"
+	"errors"
 	"github.com/dsub-io/go-open-discogs-batch/internal/test/resource"
+	"github.com/reactivex/rxgo/v2"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 	"time"
 )
+
+type tokenResult struct {
+	token xml.Token
+	err   error
+}
+
+type scriptedOrder struct {
+	tokens     []tokenResult
+	decodeErr  error
+	onDecode   func()
+	tokenCalls int
+	closed     bool
+}
+
+func (s *scriptedOrder) Token() (xml.Token, error) {
+	s.tokenCalls++
+	if len(s.tokens) == 0 {
+		return nil, io.EOF
+	}
+	result := s.tokens[0]
+	s.tokens = s.tokens[1:]
+	return result.token, result.err
+}
+
+func (s *scriptedOrder) DecodeElement(any, *xml.StartElement) error {
+	if s.onDecode != nil {
+		s.onDecode()
+	}
+	return s.decodeErr
+}
+
+func (s *scriptedOrder) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *scriptedOrder) Match(token xml.Token) bool {
+	_, ok := token.(xml.StartElement)
+	return ok
+}
 
 type Data struct {
 	ETag        string `xml:"ETag" gorm:"column:etag"`
@@ -45,4 +88,91 @@ func Test_parserImpl_ParseCtxCancel(t *testing.T) {
 		count++
 	}
 	assert.LessOrEqual(t, count, 777)
+}
+
+func TestParserHandlesNilAndCancelledContexts(t *testing.T) {
+	t.Run("nil context", func(t *testing.T) {
+		order := &scriptedOrder{}
+		items := NewParser[Data]().Parse(nil, order).Observe()
+		_, present := <-items
+		assert.False(t, present)
+		assert.True(t, order.closed)
+	})
+
+	t.Run("already cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		order := &scriptedOrder{}
+		items := NewParser[Data]().Parse(ctx, order).Observe()
+		_, present := <-items
+		assert.False(t, present)
+		assert.Zero(t, order.tokenCalls)
+	})
+}
+
+func TestParserEmitsTokenAndDecodeErrors(t *testing.T) {
+	t.Run("token error", func(t *testing.T) {
+		expected := errors.New("token failure")
+		order := &scriptedOrder{tokens: []tokenResult{{err: expected}}}
+
+		item := <-NewParser[Data]().Parse(context.Background(), order).Observe()
+
+		assert.ErrorIs(t, item.E, expected)
+	})
+
+	t.Run("decode error", func(t *testing.T) {
+		expected := errors.New("decode failure")
+		order := &scriptedOrder{
+			tokens:    []tokenResult{{token: xml.StartElement{Name: xml.Name{Local: "Contents"}}}},
+			decodeErr: expected,
+		}
+
+		item := <-NewParser[Data]().Parse(context.Background(), order).Observe()
+
+		assert.ErrorIs(t, item.E, expected)
+	})
+}
+
+func TestParserStopsWhenContextCancelsDuringDecode(t *testing.T) {
+	for _, decodeErr := range []error{nil, errors.New("decode failure")} {
+		ctx, cancel := context.WithCancel(context.Background())
+		decoded := make(chan struct{})
+		releaseDecode := make(chan struct{})
+		order := &scriptedOrder{
+			tokens:    []tokenResult{{token: xml.StartElement{Name: xml.Name{Local: "Contents"}}}},
+			decodeErr: decodeErr,
+			onDecode: func() {
+				cancel()
+				close(decoded)
+				<-releaseDecode
+			},
+		}
+
+		observable := NewParser[Data]().Parse(ctx, order)
+		<-decoded
+		close(releaseDecode)
+		items := observable.Observe()
+		_, present := <-items
+
+		assert.False(t, present)
+	}
+}
+
+func TestEmitStopsWhenCancellationRacesWithDelivery(t *testing.T) {
+	originalHook := beforeEmitSelect
+	t.Cleanup(func() { beforeEmitSelect = originalHook })
+	ctx, cancel := context.WithCancel(context.Background())
+	beforeEmitSelect = cancel
+	target := make(chan rxgo.Item)
+
+	assert.False(t, emit(ctx, target, rxgo.Of("fixture")))
+}
+
+func TestStartTokenMatcherRejectsNilAndNonStartTokens(t *testing.T) {
+	matcher := NewStartTokenNameMatcher("Contents")
+
+	assert.False(t, matcher(nil))
+	assert.False(t, matcher(xml.CharData("text")))
+	assert.False(t, matcher(xml.StartElement{Name: xml.Name{Local: "Other"}}))
+	assert.True(t, matcher(xml.StartElement{Name: xml.Name{Local: "Contents"}}))
 }


### PR DESCRIPTION
## Summary
- record immutable manifests, per-entity progress, and committed source-chunk ledgers
- resume only exact compatible failed runs and skip only currently clean successful manifests
- reconcile owned relations exactly and fence delayed workers after abandonment
- lock selected entities plus Artist/Label/Master reference dependencies shared by `open-discogs-model v0.2.1`
- retain downloads and valid ledgers on failure; clean selected files only after durable success
- reject dump-listing failures without panicking and make XML cancellation/close ordering race-free
- preserve requested copy permissions and test every production error/cancellation boundary

## Durability boundaries
- canonical relation changes and their exact progress ledger commit together
- core rows are idempotently rerun; compatible completed chunks are skipped after source-range validation
- visibility is chunk-atomic, not whole-snapshot atomic; use versioned database or replica promotion for atomic monthly cutover
- roots absent from an entire newer dump are not deleted
- the v1 32-bit relation hash collision risk is documented and tracked in `open-discogs-model#43`

## Measured impact
- successful-manifest preflight p50/p95/p99: `38.917/50.768/58.719 ms` -> `1.776/2.728/3.038 ms`
- 64 MiB file I/O avoided and median allocations reduced 83.0% on that no-op path
- tracked initial fixture p50: `48.509 ms` -> `73.922 ms`; forced repeat p50: `38.864 ms` -> `72.822 ms`
- the tracked regression is the measured cost of current-checkpoint validation and active-run database fencing; full conditions and reproduction commands are in README
- whole-suite statement coverage: `79.0%` -> `100.0%` (`+21.0 percentage points`)

## Verification
- `go test -race -coverprofile=/tmp/go-open-discogs-coverage.out -covermode=atomic ./...`
- `go tool cover -func=/tmp/go-open-discogs-coverage.out`: total `100.0%`
- `go vet ./...`
- `go test -tags=e2e -run '^(TestBatchE2E|TestImportExecutionCoordinator)$' -count=1 ./src/batch`
- Docker resources with `io.dsub.test-owner=go-open-discogs-batch`: 0 containers, 0 networks, 0 volumes after tests
- signed commits verified locally
