### PR TITLE
perf: apply indexed model schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsub-io/open-discogs-model v0.2.1
+	github.com/dsub-io/open-discogs-model v0.2.2
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dsub-io/open-discogs-model v0.2.1 h1:v5Yis29dv3P9ImXBrYm8TJrI53SGcLjpvJ7ZrMYS63k=
-github.com/dsub-io/open-discogs-model v0.2.1/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
+github.com/dsub-io/open-discogs-model v0.2.2 h1:/BvSrMTEZryWGgcn8F0jDGEVCbT9950Rbt+X02nQL2s=
+github.com/dsub-io/open-discogs-model v0.2.2/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=


### PR DESCRIPTION
## Summary
- consume open-discogs-model v0.2.2
- apply canonical V007 API query indexes through the existing checksum-protected migration ledger
- keep the batch data path and durable resume semantics unchanged

## Measured result
The canonical synthetic PostgreSQL benchmark measured:

- release-title substring p95: 194.535 ms -> 0.136 ms (99.930% lower)
- artist-release lookup p95: 17.309 ms -> 0.061 ms (99.648% lower)
- index storage cost: +164.1 MiB (+54.7%) on the 1,000,000-release dataset

Import duration with indexes present has not been measured on the full dump and remains a pre-production gate.

## Verification
- `go test -race -coverprofile=... -covermode=atomic ./...`: 100.0%
- `go vet ./...`
- `go mod tidy` clean
- govulncheck: no called vulnerabilities
- V007 applied against real PostgreSQL in the suite
- test containers removed; no new container, network, or volume remains