### PR TITLE
feat: expose durable import progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ an import is running. Deployments that require an all-at-once snapshot switch
 must put a separate versioned database or replica promotion boundary around the
 import.
 
+### Progress observability
+
+Download bars use the upstream-reported compressed size. Source-reading bars
+use the exact local compressed file size as their byte denominator and display
+percentage, byte throughput, elapsed time, and source ETA. A source-reading
+percentage describes how much of the gzip stream has been consumed; it does not
+claim that the same percentage of PostgreSQL work has committed.
+
+Tracked entity convergence also writes JSON progress records to stdout at
+start, at most once every five seconds while chunks finish, and at completion
+or failure. `committed_items` comes from `discogs_import_run_dump.processed_items`
+and therefore counts only roots whose canonical entity and complete relation
+set committed atomically with the chunk ledger. `initial_committed_items` makes
+resumed work explicit, `rows_per_second` covers newly committed roots in the
+current process, and `last_committed_progress_at` supports stall detection.
+Each emitted sample performs one primary-key summary read, bounded to 0.2 reads
+per second per active entity plus the start and finish reads; it never scans the
+chunk ledger or entity tables.
+
+`committed_percent` is intentionally omitted while the stream total is unknown.
+It becomes `100` only after end-of-stream coverage validation records exact item
+and chunk totals. Pre-counting every XML root merely to display a speculative
+percentage would add a second full gzip/XML scan. There is no synthetic overall
+percentage across Artist, Label, Master, and Release because their relation
+fan-out and database cost differ substantially.
+
 ## Requirements
 
 - PostgreSQL

--- a/src/batch/artist.go
+++ b/src/batch/artist.go
@@ -61,7 +61,7 @@ func insertArtistRelations(order Order) result.Result {
 		order,
 		"artist relations",
 		"artist",
-		"updating artist relations...",
+		"source-read artist relations",
 		func(order Order, chunk ChunkMetadata, items []*XmlArtistRelation) result.Result {
 			return writeArtistRelationChunk(order, chunk, items, deleteStale)
 		},

--- a/src/batch/insert.go
+++ b/src/batch/insert.go
@@ -13,7 +13,7 @@ import (
 )
 
 func InsertSimple[F, T any](order Order, topic string, localName string) result.Result {
-	r, err := newReadCloser(order.getFilePath(), fmt.Sprintf("updating %+v...", topic))
+	r, err := newReadCloser(order.getFilePath(), fmt.Sprintf("source-read %+v", topic))
 	if err != nil {
 		return result.NewResult(0, err)
 	}

--- a/src/batch/label.go
+++ b/src/batch/label.go
@@ -51,7 +51,7 @@ func insertLabelRelations(order Order) result.Result {
 		order,
 		"label relations",
 		"label",
-		"updating label relations...",
+		"source-read label relations",
 		func(order Order, chunk ChunkMetadata, items []*XmlLabelRelation) result.Result {
 			return writeLabelRelationChunk(order, chunk, items, deleteStale)
 		},

--- a/src/batch/master.go
+++ b/src/batch/master.go
@@ -45,7 +45,7 @@ func InsertMasterRelations(order Order) result.Result {
 		order,
 		"master relations",
 		"master",
-		"updating master relations...",
+		"source-read master relations",
 		func(order Order, chunk ChunkMetadata, items []*XmlMasterRelation) result.Result {
 			return writeMasterRelationChunk(order, chunk, items, deleteStale)
 		},

--- a/src/batch/observability.go
+++ b/src/batch/observability.go
@@ -1,0 +1,213 @@
+package batch
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	importProgressEvent         = "import_progress"
+	progressStateStarted        = "started"
+	progressStateRunning        = "running"
+	progressStateCompleted      = "completed"
+	progressStateFailed         = "failed"
+	progressStateObservationErr = "observation_error"
+	defaultProgressInterval     = 5 * time.Second
+)
+
+type committedProgress struct {
+	ProcessedItems int64
+	TotalItems     sql.NullInt64
+	LastProgressAt sql.NullTime
+}
+
+type importProgressRecord struct {
+	Event                 string     `json:"event"`
+	State                 string     `json:"state"`
+	Entity                string     `json:"entity"`
+	CommittedItems        int64      `json:"committed_items"`
+	CommittedPercent      *float64   `json:"committed_percent,omitempty"`
+	RowsPerSecond         float64    `json:"rows_per_second"`
+	ElapsedSeconds        float64    `json:"elapsed_seconds"`
+	Resumed               bool       `json:"resumed"`
+	InitialCommittedItems int64      `json:"initial_committed_items"`
+	LastCommittedProgress *time.Time `json:"last_committed_progress_at,omitempty"`
+	ObservationError      string     `json:"observation_error,omitempty"`
+}
+
+type progressSummaryReader func() (committedProgress, error)
+
+type entityProgressReporter interface {
+	Start()
+	Observe()
+	Finish(bool)
+}
+
+type noopProgressReporter struct{}
+
+func (noopProgressReporter) Start()      {}
+func (noopProgressReporter) Observe()    {}
+func (noopProgressReporter) Finish(bool) {}
+
+type jsonProgressReporter struct {
+	mu             sync.Mutex
+	entity         string
+	resumed        bool
+	interval       time.Duration
+	now            func() time.Time
+	readSummary    progressSummaryReader
+	output         io.Writer
+	startedAt      time.Time
+	lastReportedAt time.Time
+	initialItems   int64
+	baselineSet    bool
+}
+
+func newEntityProgressReporter(order Order) entityProgressReporter {
+	if order.getRunID() == 0 {
+		return noopProgressReporter{}
+	}
+	return &jsonProgressReporter{
+		entity:   order.getEntityType(),
+		resumed:  order.shouldResumeProgress(),
+		interval: defaultProgressInterval,
+		now:      time.Now,
+		readSummary: func() (committedProgress, error) {
+			return readCommittedProgress(order)
+		},
+		output: os.Stdout,
+	}
+}
+
+func (r *jsonProgressReporter) Start() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.now()
+	r.startedAt = now
+	r.lastReportedAt = now
+	summary, err := r.readSummary()
+	if err != nil {
+		r.writeObservationError(now, err)
+		return
+	}
+	r.initialItems = summary.ProcessedItems
+	r.baselineSet = true
+	r.writeRecord(now, progressStateStarted, summary)
+}
+
+func (r *jsonProgressReporter) Observe() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.now()
+	if now.Sub(r.lastReportedAt) < r.interval {
+		return
+	}
+	r.lastReportedAt = now
+	summary, err := r.readSummary()
+	if err != nil {
+		r.writeObservationError(now, err)
+		return
+	}
+	r.setBaselineIfNeeded(summary)
+	r.writeRecord(now, progressStateRunning, summary)
+}
+
+func (r *jsonProgressReporter) Finish(success bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := r.now()
+	summary, err := r.readSummary()
+	if err != nil {
+		r.writeObservationError(now, err)
+		return
+	}
+	r.setBaselineIfNeeded(summary)
+	state := progressStateFailed
+	if success {
+		state = progressStateCompleted
+	}
+	r.writeRecord(now, state, summary)
+}
+
+func (r *jsonProgressReporter) setBaselineIfNeeded(summary committedProgress) {
+	if r.baselineSet {
+		return
+	}
+	r.initialItems = summary.ProcessedItems
+	r.baselineSet = true
+}
+
+func (r *jsonProgressReporter) writeRecord(
+	now time.Time,
+	state string,
+	summary committedProgress,
+) {
+	elapsed := now.Sub(r.startedAt).Seconds()
+	rate := float64(0)
+	if elapsed > 0 {
+		rate = float64(summary.ProcessedItems-r.initialItems) / elapsed
+	}
+	var committedPercent *float64
+	if summary.TotalItems.Valid && summary.TotalItems.Int64 > 0 {
+		percent := float64(summary.ProcessedItems) * 100 / float64(summary.TotalItems.Int64)
+		committedPercent = &percent
+	} else if summary.TotalItems.Valid && summary.TotalItems.Int64 == 0 {
+		percent := float64(100)
+		committedPercent = &percent
+	}
+	var lastProgress *time.Time
+	if summary.LastProgressAt.Valid {
+		lastProgress = &summary.LastProgressAt.Time
+	}
+	r.write(importProgressRecord{
+		Event:                 importProgressEvent,
+		State:                 state,
+		Entity:                r.entity,
+		CommittedItems:        summary.ProcessedItems,
+		CommittedPercent:      committedPercent,
+		RowsPerSecond:         rate,
+		ElapsedSeconds:        elapsed,
+		Resumed:               r.resumed,
+		InitialCommittedItems: r.initialItems,
+		LastCommittedProgress: lastProgress,
+	})
+}
+
+func (r *jsonProgressReporter) writeObservationError(now time.Time, err error) {
+	r.write(importProgressRecord{
+		Event:            importProgressEvent,
+		State:            progressStateObservationErr,
+		Entity:           r.entity,
+		ElapsedSeconds:   now.Sub(r.startedAt).Seconds(),
+		Resumed:          r.resumed,
+		ObservationError: err.Error(),
+	})
+}
+
+func (r *jsonProgressReporter) write(record importProgressRecord) {
+	_ = json.NewEncoder(r.output).Encode(record)
+}
+
+func readCommittedProgress(order Order) (committedProgress, error) {
+	var summary committedProgress
+	query := order.getDB().WithContext(order.getContext()).Raw(
+		`select processed_items, total_items, last_progress_at
+		   from public.discogs_import_run_dump
+		  where import_run_id = ?
+		    and entity_type = ?`,
+		order.getRunID(),
+		order.getEntityType(),
+	).Scan(&summary)
+	if query.Error != nil {
+		return committedProgress{}, query.Error
+	}
+	if query.RowsAffected != 1 {
+		return committedProgress{}, errors.New("import progress summary is unavailable")
+	}
+	return summary, nil
+}

--- a/src/batch/observability_test.go
+++ b/src/batch/observability_test.go
@@ -1,0 +1,246 @@
+package batch
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopProgressReporter(t *testing.T) {
+	noop := noopProgressReporter{}
+	noop.Start()
+	noop.Observe()
+	noop.Finish(true)
+
+	reporter := newEntityProgressReporter(NewOrder(
+		context.Background(),
+		1,
+		1,
+		"unused",
+		nil,
+	))
+
+	reporter.Start()
+	reporter.Observe()
+	reporter.Finish(true)
+	reporter.Finish(false)
+}
+
+func TestJSONProgressReporterLifecycle(t *testing.T) {
+	start := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	now := start
+	lastProgress := start.Add(-time.Minute)
+	summaries := []committedProgress{
+		{
+			ProcessedItems: 40,
+			LastProgressAt: sql.NullTime{Time: lastProgress, Valid: true},
+		},
+		{ProcessedItems: 60},
+		{
+			ProcessedItems: 100,
+			TotalItems:     sql.NullInt64{Int64: 100, Valid: true},
+		},
+	}
+	readIndex := 0
+	var output bytes.Buffer
+	reporter := &jsonProgressReporter{
+		entity:   "release",
+		resumed:  true,
+		interval: defaultProgressInterval,
+		now:      func() time.Time { return now },
+		readSummary: func() (committedProgress, error) {
+			summary := summaries[readIndex]
+			readIndex++
+			return summary, nil
+		},
+		output: &output,
+	}
+
+	reporter.Start()
+	reporter.Observe()
+	now = now.Add(defaultProgressInterval)
+	reporter.Observe()
+	now = now.Add(defaultProgressInterval)
+	reporter.Finish(true)
+
+	records := decodeProgressRecords(t, output.Bytes())
+	require.Len(t, records, 3)
+	require.Equal(t, progressStateStarted, records[0].State)
+	require.Equal(t, int64(40), records[0].CommittedItems)
+	require.Equal(t, int64(40), records[0].InitialCommittedItems)
+	require.Equal(t, lastProgress, *records[0].LastCommittedProgress)
+	require.Nil(t, records[0].CommittedPercent)
+	require.Equal(t, progressStateRunning, records[1].State)
+	require.InDelta(t, 4, records[1].RowsPerSecond, 0.001)
+	require.Equal(t, progressStateCompleted, records[2].State)
+	require.InDelta(t, 100, *records[2].CommittedPercent, 0.001)
+	require.InDelta(t, 6, records[2].RowsPerSecond, 0.001)
+}
+
+func TestJSONProgressReporterFailureAndObservationErrors(t *testing.T) {
+	start := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	now := start
+	expected := errors.New("fixture")
+	responses := []struct {
+		summary committedProgress
+		err     error
+	}{
+		{err: expected},
+		{err: expected},
+		{err: expected},
+		{
+			summary: committedProgress{
+				TotalItems: sql.NullInt64{Valid: true},
+			},
+		},
+	}
+	responseIndex := 0
+	var output bytes.Buffer
+	reporter := &jsonProgressReporter{
+		entity:   "artist",
+		interval: defaultProgressInterval,
+		now:      func() time.Time { return now },
+		readSummary: func() (committedProgress, error) {
+			response := responses[responseIndex]
+			responseIndex++
+			return response.summary, response.err
+		},
+		output: &output,
+	}
+
+	reporter.Start()
+	now = now.Add(defaultProgressInterval)
+	reporter.Observe()
+	reporter.Finish(true)
+	reporter.Finish(false)
+
+	records := decodeProgressRecords(t, output.Bytes())
+	require.Len(t, records, 4)
+	for index := 0; index < 3; index++ {
+		require.Equal(t, progressStateObservationErr, records[index].State)
+		require.Equal(t, expected.Error(), records[index].ObservationError)
+	}
+	require.Equal(t, progressStateFailed, records[3].State)
+	require.InDelta(t, 100, *records[3].CommittedPercent, 0.001)
+	require.Zero(t, records[3].InitialCommittedItems)
+	require.Zero(t, records[3].RowsPerSecond)
+}
+
+func TestJSONProgressReporterRecoversBaselineAfterStartObservationError(t *testing.T) {
+	start := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	now := start
+	readCount := 0
+	var output bytes.Buffer
+	reporter := &jsonProgressReporter{
+		entity:   "master",
+		interval: defaultProgressInterval,
+		now:      func() time.Time { return now },
+		readSummary: func() (committedProgress, error) {
+			readCount++
+			if readCount == 1 {
+				return committedProgress{}, errors.New("fixture")
+			}
+			return committedProgress{
+				ProcessedItems: 25,
+				TotalItems:     sql.NullInt64{Int64: 25, Valid: true},
+			}, nil
+		},
+		output: &output,
+	}
+
+	reporter.Start()
+	now = now.Add(defaultProgressInterval)
+	reporter.Observe()
+
+	records := decodeProgressRecords(t, output.Bytes())
+	require.Len(t, records, 2)
+	require.Equal(t, progressStateRunning, records[1].State)
+	require.Equal(t, int64(25), records[1].InitialCommittedItems)
+	require.Zero(t, records[1].RowsPerSecond)
+}
+
+func TestReadCommittedProgress(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+		mock.ExpectQuery("select processed_items, total_items, last_progress_at").
+			WithArgs(int64(7), "master").
+			WillReturnRows(sqlmock.NewRows(
+				[]string{"processed_items", "total_items", "last_progress_at"},
+			).AddRow(25, nil, now))
+		order := NewTrackedOrder(
+			context.Background(), 5, 1, "unused", db, 7, "master", true,
+		)
+
+		summary, err := readCommittedProgress(order)
+
+		require.NoError(t, err)
+		require.Equal(t, int64(25), summary.ProcessedItems)
+		require.False(t, summary.TotalItems.Valid)
+		require.Equal(t, now, summary.LastProgressAt.Time)
+	})
+
+	t.Run("query failure", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		expected := errors.New("fixture")
+		mock.ExpectQuery("select processed_items, total_items, last_progress_at").
+			WithArgs(int64(8), "label").
+			WillReturnError(expected)
+		order := NewTrackedOrder(
+			context.Background(), 5, 1, "unused", db, 8, "label", false,
+		)
+
+		_, err := readCommittedProgress(order)
+
+		require.ErrorIs(t, err, expected)
+	})
+
+	t.Run("missing summary", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("select processed_items, total_items, last_progress_at").
+			WithArgs(int64(9), "artist").
+			WillReturnRows(sqlmock.NewRows(
+				[]string{"processed_items", "total_items", "last_progress_at"},
+			))
+		order := NewTrackedOrder(
+			context.Background(), 5, 1, "unused", db, 9, "artist", false,
+		)
+
+		_, err := readCommittedProgress(order)
+
+		require.ErrorContains(t, err, "summary is unavailable")
+	})
+}
+
+func TestTrackedOrderProgressReporterUsesDurableSummary(t *testing.T) {
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectQuery("select processed_items, total_items, last_progress_at").
+		WithArgs(int64(10), "release").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"processed_items", "total_items", "last_progress_at"},
+		).AddRow(3, nil, nil))
+	reporter := newEntityProgressReporter(NewTrackedOrder(
+		context.Background(), 1, 1, "unused", db, 10, "release", true,
+	))
+
+	reporter.Start()
+}
+
+func decodeProgressRecords(t *testing.T, payload []byte) []importProgressRecord {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	records := make([]importProgressRecord, 0)
+	for decoder.More() {
+		var record importProgressRecord
+		require.NoError(t, decoder.Decode(&record))
+		records = append(records, record)
+	}
+	return records
+}

--- a/src/batch/relations.go
+++ b/src/batch/relations.go
@@ -44,6 +44,8 @@ func processRelationChunks[T any](
 	progressText string,
 	writeRelationChunk relationChunkWriter[T],
 ) result.Result {
+	reporter := newEntityProgressReporter(order)
+	reporter.Start()
 	ctx, cancel := context.WithCancel(order.getContext())
 	defer cancel()
 	results := make(chan result.Result)
@@ -53,6 +55,7 @@ func processRelationChunks[T any](
 	var totalChunks int64
 	source, err := newReadCloser(order.getFilePath(), progressText)
 	if err != nil {
+		reporter.Finish(false)
 		return result.NewResult(0, err)
 	}
 
@@ -80,6 +83,7 @@ func processRelationChunks[T any](
 				if order.submitWorker(ctx, func() {
 					defer workers.Done()
 					written := writeRelationChunk(order, chunk, items)
+					reporter.Observe()
 					if written.IsErr() {
 						cancel()
 					}
@@ -107,6 +111,7 @@ func processRelationChunks[T any](
 			sum = sum.Sum(result.NewResult(0, progressErr))
 		}
 	}
+	reporter.Finish(!sum.IsErr())
 
 	fmt.Printf("\nUpdated %+v %s\n", sum.Count(), topic)
 	return sum

--- a/src/batch/release.go
+++ b/src/batch/release.go
@@ -76,7 +76,7 @@ func insertReleases(order Order) result.Result {
 		order,
 		"release relations",
 		"release",
-		"updating releases...",
+		"source-read release relations",
 		func(order Order, chunk ChunkMetadata, items []*XmlReleaseRelation) result.Result {
 			return writeReleaseRelationChunk(order, chunk, items, deleteStale)
 		},

--- a/src/reader/progressbar.go
+++ b/src/reader/progressbar.go
@@ -11,15 +11,19 @@ import (
 )
 
 func NewProgressBarGzipReadCloser(f *os.File, progressBarText string) (io.ReadCloser, error) {
-	reader, err := gzip.NewReader(f)
+	fileInfo, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
 
-	pb := getProgressBar(GetFilename(progressBarText), -1)
-	pbReader := progressbar.NewReader(reader, pb)
+	pb := getProgressBar(GetFilename(progressBarText), fileInfo.Size())
+	pbReader := progressbar.NewReader(f, pb)
+	reader, err := gzip.NewReader(&pbReader)
+	if err != nil {
+		return nil, err
+	}
 	return &readCloserImpl{
-		readDelegate:   &pbReader,
+		readDelegate:   reader,
 		closeDelegates: []io.Closer{reader, f},
 	}, nil
 }
@@ -28,7 +32,9 @@ func getProgressBar(text string, size int64) *progressbar.ProgressBar {
 	pb := progressbar.NewOptions64(size,
 		progressbar.OptionEnableColorCodes(false),
 		progressbar.OptionShowBytes(true),
+		progressbar.OptionShowCount(),
 		progressbar.OptionSetElapsedTime(true),
+		progressbar.OptionSetPredictTime(true),
 		progressbar.OptionThrottle(time.Millisecond*250),
 		progressbar.OptionSetWidth(15),
 		progressbar.OptionShowElapsedTimeOnFinish(),

--- a/src/reader/progressbar_test.go
+++ b/src/reader/progressbar_test.go
@@ -42,3 +42,14 @@ func TestNewProgressBarGzipReadCloserRejectsInvalidGzip(t *testing.T) {
 	require.Nil(t, reader)
 	require.NoError(t, f.Close())
 }
+
+func TestNewProgressBarGzipReadCloserRejectsUnreadableFileMetadata(t *testing.T) {
+	f, err := os.Open("testdata/data.gz")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	reader, err := NewProgressBarGzipReadCloser(f, "closed")
+
+	require.Error(t, err)
+	require.Nil(t, reader)
+}


### PR DESCRIPTION
## Summary

- replace the unknown-length gzip import spinner with exact local compressed-byte progress, throughput, elapsed time, and source ETA
- emit JSON import_progress records for started, running, completed, failed, and non-fatal observation-error states
- report exact durable committed_items, resumed baseline, rows per second, and last committed timestamp from the atomic chunk ledger summary
- expose committed_percent only after end-of-stream coverage establishes the exact total

## Scale and durability

- no pre-count pass is added, avoiding a second full gzip/XML scan before a 200M+ row import
- each sample performs one primary-key summary read; the five-second interval bounds running observations to 0.2 reads/second per active entity, plus start and finish reads
- no schema migration, CLI option, environment variable, unbounded queue, or full-dataset memory load is introduced
- progress observation failure cannot fail the import

## Validation

- gofmt and go mod tidy metadata check
- go vet ./...
- go test -race -coverprofile=/tmp/open-discogs-go-full.cover -covermode=atomic ./...: 100.0% statements
- tagged dump-to-PostgreSQL E2E: passed
- Docker resources returned to the exact pre-test container/network/volume inventory

## Release note

Feature: imports now distinguish exact source-read percentage from durable database commit progress. The first production-sized dump remains intentionally deferred; no large-dump throughput or ETA claim is inferred from fixtures.