### PR TITLE
feat: support configurable database schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Discogs. The Discogs name identifies only the public data source.
 
 ## Import behavior and safety
 
-- Schema migrations and the dump catalog refresh run automatically.
+- The selected database schema, canonical migrations, tables, indexes, and dump catalog refresh run automatically.
 - Artist, label, master, and release select their newest available dump
   independently unless an exact `--dump-month` is requested.
 - Every run records the selected dump dates, SHA-256 checksums, source URIs,
@@ -119,15 +119,21 @@ fan-out and database cost differ substantially.
 ```shell
 go-open-discogs-batch \
   --database-url 'postgresql://user:password@localhost:5432/open_discogs' \
+  --database-schema open_discogs \
   --entities artist,label,master,release
 ```
 
 Use `--dump-month=2026-07` to require that exact month. Without it, each selected
 entity uses its own latest available dump.
 
+The PostgreSQL database itself must already exist. A normal batch run needs no separate `init` command: it creates `--database-schema` when missing, then creates or migrates the canonical tables inside it. Creating a missing schema requires `CREATE` on the target database. For an existing schema, the batch role requires `USAGE` and `CREATE`, write access to imported tables, and ownership or equivalent DDL authority for migrations. If those privileges are intentionally unavailable, pre-create the schema with a DBA-managed role and grant the batch role the required schema and table privileges before running the importer.
+
+When `--database-schema` / `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` is omitted, the importer uses `public` and emits a `WARN` on every startup. This is convenient for compatibility but can mix OpenDiscogs objects with unrelated public tables, so a dedicated name such as `open_discogs` is recommended. Schema names use portable PostgreSQL identifiers: 1–63 lowercase letters, digits, or underscores, starting with a letter or underscore.
+
 | Option | Environment variable | Default | Purpose |
 | --- | --- | --- | --- |
 | `--database-url` | `OPEN_DISCOGS_BATCH_DATABASE_URL` | required | PostgreSQL URI including percent-encoded credentials |
+| `--database-schema` | `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` | `public` | Schema to create or migrate; `public` emits a startup warning |
 | `--entities`, `-e` | `OPEN_DISCOGS_BATCH_ENTITIES` | all four | Comma-separated `artist`, `label`, `master`, `release` |
 | `--dump-month`, `-m` | `OPEN_DISCOGS_BATCH_DUMP_MONTH` | latest per entity | Exact dump month in `yyyy-MM` form |
 | `--data-dir` | `OPEN_DISCOGS_BATCH_DATA_DIR` | `~/.cache/open-discogs-batch` | Download directory |
@@ -244,6 +250,7 @@ docker pull ghcr.io/dsub-io/go-open-discogs-batch:latest
 docker run --rm \
   --cpus=4 \
   -e OPEN_DISCOGS_BATCH_DATABASE_URL='postgresql://user:password@db:5432/open_discogs' \
+  -e OPEN_DISCOGS_BATCH_DATABASE_SCHEMA='open_discogs' \
   -e OPEN_DISCOGS_BATCH_ENTITIES='artist,label,master,release' \
   -e OPEN_DISCOGS_BATCH_DATA_DIR=/data \
   -e OPEN_DISCOGS_BATCH_MAX_WORKERS=4 \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/dsub-io/go-open-discogs-batch/src/batch"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/posflag"
@@ -49,6 +50,7 @@ var environmentOptionNames = map[string]string{
 	"CLEANUP":         "cleanup",
 	"FORCE":           "force",
 	"ALLOW_DOWNGRADE": "allow-downgrade",
+	"DATABASE_SCHEMA": "database-schema",
 }
 
 var booleanEnvironmentOptions = map[string]struct{}{
@@ -80,6 +82,7 @@ into the canonical PostgreSQL schema published by open-discogs-model.`,
 	dataDir := filepath.Join(getHomeDir(new(homeDirSupplier)), ".cache", "open-discogs-batch")
 	f := rootCmd.Flags()
 	f.String("database-url", "", "PostgreSQL URI including credentials (required)")
+	f.String("database-schema", database.DefaultSchemaName, "PostgreSQL schema for canonical tables")
 	f.StringSliceP("entities", "e", []string{"artist", "label", "master", "release"}, "entities to import")
 	f.StringP("dump-month", "m", "", "exact dump month in yyyy-MM form (default: latest per entity)")
 	f.String("data-dir", dataDir, "download directory")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -28,12 +28,14 @@ func TestPublicDefaults(t *testing.T) {
 	require.Equal(t, []string{"artist", "label", "master", "release"}, conf.Strings("entities"))
 	require.Equal(t, 5000, conf.Int("chunk-size"))
 	require.Equal(t, runtime.GOMAXPROCS(0), conf.Int("max-workers"))
+	require.Equal(t, "public", conf.String("database-schema"))
 	require.Equal(t, filepath.Join(getHomeDir(new(homeDirSupplier)), ".cache", "open-discogs-batch"), conf.String("data-dir"))
 	require.False(t, conf.Bool("cleanup"))
 }
 
 func TestEnvironmentVariablesAndCommandLinePrecedence(t *testing.T) {
 	t.Setenv("OPEN_DISCOGS_BATCH_DATABASE_URL", "postgresql://env:pass@db:5432/discogs")
+	t.Setenv("OPEN_DISCOGS_BATCH_DATABASE_SCHEMA", "env_schema")
 	t.Setenv("OPEN_DISCOGS_BATCH_ENTITIES", "artist, release")
 	t.Setenv("OPEN_DISCOGS_BATCH_DUMP_MONTH", "2026-07")
 	t.Setenv("OPEN_DISCOGS_BATCH_DATA_DIR", "/env-data")
@@ -46,6 +48,7 @@ func TestEnvironmentVariablesAndCommandLinePrecedence(t *testing.T) {
 	executeWithoutBatch(
 		t,
 		"--database-url", "postgresql://cli:pass@db:5432/discogs",
+		"--database-schema", "cli_schema",
 		"--entities", "label,master",
 		"--chunk-size", "5500",
 		"--max-workers", "3",
@@ -53,6 +56,7 @@ func TestEnvironmentVariablesAndCommandLinePrecedence(t *testing.T) {
 	)
 
 	require.Equal(t, "postgresql://cli:pass@db:5432/discogs", conf.String("database-url"))
+	require.Equal(t, "cli_schema", conf.String("database-schema"))
 	require.Equal(t, []string{"label", "master"}, conf.Strings("entities"))
 	require.Equal(t, "2026-07", conf.String("dump-month"))
 	require.Equal(t, "/cli-data", conf.String("data-dir"))

--- a/cmd/validation.go
+++ b/cmd/validation.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	"github.com/knadh/koanf"
 )
 
@@ -32,6 +33,9 @@ func (v *validator) Validate(config *koanf.Koanf) error {
 		return err
 	}
 	if err := ValidDatabaseURL(config.String("database-url")); err != nil {
+		return err
+	}
+	if err := database.ValidateSchemaName(config.String("database-schema")); err != nil {
 		return err
 	}
 	if err := ValidChunkSize(config.String("chunk-size")); err != nil {

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	"github.com/knadh/koanf"
 	"github.com/stretchr/testify/require"
 )
@@ -60,6 +61,7 @@ func TestValidDumpMonth(t *testing.T) {
 func TestValidator(t *testing.T) {
 	config := koanf.New(".")
 	require.NoError(t, config.Set("database-url", "postgresql://user:pass@db:5432/discogs"))
+	require.NoError(t, config.Set("database-schema", database.DefaultSchemaName))
 	require.NoError(t, config.Set("entities", []string{"artist"}))
 	require.NoError(t, config.Set("chunk-size", 5000))
 	require.NoError(t, config.Set("max-workers", 4))
@@ -75,6 +77,7 @@ func TestValidatorReportsEveryConfigurationBoundary(t *testing.T) {
 	valid := func() *koanf.Koanf {
 		config := koanf.New(".")
 		require.NoError(t, config.Set("database-url", "postgresql://user:pass@db:5432/discogs"))
+		require.NoError(t, config.Set("database-schema", database.DefaultSchemaName))
 		require.NoError(t, config.Set("entities", []string{"artist"}))
 		require.NoError(t, config.Set("chunk-size", 5000))
 		require.NoError(t, config.Set("max-workers", 4))
@@ -92,6 +95,10 @@ func TestValidatorReportsEveryConfigurationBoundary(t *testing.T) {
 	config = valid()
 	require.NoError(t, config.Set("database-url", "mysql://user:pass@db/catalog"))
 	require.ErrorContains(t, new(validator).Validate(config), "database-url")
+
+	config = valid()
+	require.NoError(t, config.Set("database-schema", "Invalid-Schema"))
+	require.ErrorContains(t, new(validator).Validate(config), "database-schema")
 
 	config = valid()
 	require.NoError(t, config.Set("chunk-size", 0))

--- a/src/batch/convergence.go
+++ b/src/batch/convergence.go
@@ -47,7 +47,7 @@ func reconcileIntegerRelation[T comparable](
 	}
 	deleted := order.getDB().Exec(
 		fmt.Sprintf(
-			`delete from public.%s current
+			`delete from %s current
 			  where current.%s = any(?::integer[])
 			    and not exists (
 			        select 1
@@ -91,7 +91,7 @@ func reconcileTextRelation[T comparable](
 	}
 	deleted := order.getDB().Exec(
 		fmt.Sprintf(
-			`delete from public.%s current
+			`delete from %s current
 			  where current.%s = any(?::integer[])
 			    and not exists (
 			        select 1
@@ -138,7 +138,7 @@ func reconcileTwoIntegerKeyRelation[T comparable](
 	}
 	deleted := order.getDB().Exec(
 		fmt.Sprintf(
-			`delete from public.%s current
+			`delete from %s current
 			  where current.%s = any(?::integer[])
 			    and not exists (
 			        select 1
@@ -179,7 +179,7 @@ func postgresArray[T comparable](values []T) pgtype.Array[T] {
 func relationTablesContainRows(order Order, tables ...string) (bool, error) {
 	checks := make([]string, len(tables))
 	for index, table := range tables {
-		checks[index] = fmt.Sprintf("exists (select 1 from public.%s limit 1)", table)
+		checks[index] = fmt.Sprintf("exists (select 1 from %s limit 1)", table)
 	}
 	var containsRows bool
 	query := order.getDB().Raw(

--- a/src/batch/coverage_test.go
+++ b/src/batch/coverage_test.go
@@ -419,9 +419,9 @@ func TestReleaseUpdateAndReferenceFilters(t *testing.T) {
 	require.Empty(t, filterStyles([]*opendiscogsmodel.Style{{Name: " "}}))
 
 	db, mock, _ := newMockGorm(t)
-	mock.ExpectExec("update public.master").
+	mock.ExpectExec("update master").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("UPDATE public.master AS target").
+	mock.ExpectExec("UPDATE master AS target").
 		WillReturnError(expected)
 	masterID := int32(1)
 	actual = updateMasterMainReleases(
@@ -486,10 +486,10 @@ func TestLabelChunkUsesSubLabelKeys(t *testing.T) {
 	t.Cleanup(cache.ResetIDs)
 	db, mock, _ := newMockGorm(t)
 	mock.ExpectBegin()
-	mock.ExpectExec("delete from public.label_url").
+	mock.ExpectExec("delete from label_url").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("delete from public.label_sub_label").
+	mock.ExpectExec("delete from label_sub_label").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnError(errors.New("fixture"))
 	mock.ExpectRollback()

--- a/src/batch/database_error_test.go
+++ b/src/batch/database_error_test.go
@@ -11,6 +11,7 @@ import (
 	"testing/fstest"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	"github.com/dsub-io/go-open-discogs-batch/src/result"
 	opendiscogsmanifest "github.com/dsub-io/open-discogs-model/manifest"
 	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
@@ -53,40 +54,47 @@ func newMockGorm(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
 }
 
 func TestRunDDLErrorBoundaries(t *testing.T) {
+	schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
+	require.NoError(t, schemaErr)
 	originalLoad := loadSchemaMigrations
 	t.Cleanup(func() { loadSchemaMigrations = originalLoad })
 	expected := errors.New("fixture")
 	loadSchemaMigrations = func() (fs.FS, error) { return nil, expected }
 	require.ErrorContains(t, RunDDL(nil), "load shared schema migrations")
 	loadSchemaMigrations = originalLoad
+	require.ErrorContains(t, RunDDLInSchema(nil, "Invalid"), "database-schema")
 
 	db, mock, _ := newMockGorm(t)
-	mock.ExpectExec("create table if not exists public.open_discogs_schema_migration").
+	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
 		WillReturnError(expected)
-	require.ErrorContains(t, runDDL(db, fstest.MapFS{}), "create schema migration ledger")
+	require.ErrorContains(t, runDDL(db, fstest.MapFS{}, schema), "create schema migration ledger")
 }
 
 func TestRunDDLReadFailure(t *testing.T) {
+	schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
+	require.NoError(t, schemaErr)
 	db, mock, _ := newMockGorm(t)
-	mock.ExpectExec("create table if not exists public.open_discogs_schema_migration").
+	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	migrations := fstest.MapFS{
 		"001-broken.sql": &fstest.MapFile{Mode: fs.ModeDir},
 	}
-	require.ErrorContains(t, runDDL(db, migrations), "read shared migration")
+	require.ErrorContains(t, runDDL(db, migrations, schema), "read shared migration")
 }
 
 func TestRunDDLPropagatesMigrationFailure(t *testing.T) {
+	schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
+	require.NoError(t, schemaErr)
 	db, mock, _ := newMockGorm(t)
 	expected := errors.New("fixture")
-	mock.ExpectExec("create table if not exists public.open_discogs_schema_migration").
+	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectBegin()
-	mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").WillReturnError(expected)
+	mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
 	mock.ExpectRollback()
 	require.ErrorContains(t, runDDL(db, fstest.MapFS{
 		"001.sql": &fstest.MapFile{Data: []byte("select 1")},
-	}), "read migration ledger")
+	}, schema), "read migration ledger")
 }
 
 func TestApplyMigrationErrorBoundaries(t *testing.T) {
@@ -100,7 +108,7 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "ledger query failure",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
 				mock.ExpectRollback()
 			},
 			want: "read migration ledger",
@@ -109,7 +117,7 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "changed checksum",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("old"))
 				mock.ExpectRollback()
 			},
@@ -119,7 +127,7 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "migration execution failure",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
 				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnError(expected)
 				mock.ExpectRollback()
@@ -130,10 +138,10 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "ledger insert failure",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
 				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnResult(sqlmock.NewResult(0, 0))
-				mock.ExpectExec("insert into public.open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectExec(regexp.QuoteMeta(`insert into "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
 				mock.ExpectRollback()
 			},
 			want: "record shared migration",
@@ -141,19 +149,23 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
+			require.NoError(t, schemaErr)
 			db, mock, _ := newMockGorm(t)
 			test.setup(mock)
-			require.ErrorContains(t, applyMigration(db, "001.sql", "new", "invalid SQL"), test.want)
+			require.ErrorContains(t, applyMigration(db, schema, "001.sql", "new", "invalid SQL"), test.want)
 		})
 	}
 
 	t.Run("already applied checksum", func(t *testing.T) {
+		schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
+		require.NoError(t, schemaErr)
 		db, mock, _ := newMockGorm(t)
 		mock.ExpectBegin()
-		mock.ExpectQuery("select checksum from public.open_discogs_schema_migration").
+		mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 			WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("same"))
 		mock.ExpectCommit()
-		require.NoError(t, applyMigration(db, "001.sql", "same", "unused"))
+		require.NoError(t, applyMigration(db, schema, "001.sql", "same", "unused"))
 	})
 }
 
@@ -327,13 +339,13 @@ func TestExecutionQueryHelpersPropagateErrors(t *testing.T) {
 
 	t.Run("prune superseded", func(t *testing.T) {
 		mock, tx := newMockTransaction(t)
-		mock.ExpectExec("delete from public.discogs_import_run_chunk run_chunk").WillReturnError(expected)
+		mock.ExpectExec("delete from discogs_import_run_chunk run_chunk").WillReturnError(expected)
 		require.ErrorContains(t, pruneSupersededFailedProgress(context.Background(), tx), "prune superseded")
 	})
 
 	t.Run("record dump", func(t *testing.T) {
 		mock, tx := newMockTransaction(t)
-		mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+		mock.ExpectQuery("insert into discogs_dump").WithArgs(
 			dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
 		).WillReturnError(expected)
 		_, err := findOrInsertDump(context.Background(), tx, dump)
@@ -342,11 +354,11 @@ func TestExecutionQueryHelpersPropagateErrors(t *testing.T) {
 
 	t.Run("resolve existing dump", func(t *testing.T) {
 		mock, tx := newMockTransaction(t)
-		mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+		mock.ExpectQuery("insert into discogs_dump").WithArgs(
 			dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
 		).
 			WillReturnRows(sqlmock.NewRows([]string{"id"}))
-		mock.ExpectQuery("select id.*from public.discogs_dump").WithArgs(
+		mock.ExpectQuery("select id.*from discogs_dump").WithArgs(
 			dump.DumpDate, dump.EntityType, dump.ChecksumSHA256,
 		).WillReturnError(expected)
 		_, err := findOrInsertDump(context.Background(), tx, dump)
@@ -355,7 +367,7 @@ func TestExecutionQueryHelpersPropagateErrors(t *testing.T) {
 
 	t.Run("insert run", func(t *testing.T) {
 		mock, tx := newMockTransaction(t)
-		mock.ExpectQuery("insert into public.discogs_import_run").WithArgs(
+		mock.ExpectQuery("insert into discogs_import_run").WithArgs(
 			"fingerprint", false, false, processorName, "version", sqlmock.AnyArg(),
 		).WillReturnError(expected)
 		_, err := insertImportRun(context.Background(), tx, "fingerprint", false, false, "version", 7)
@@ -373,64 +385,64 @@ func TestCopyResumeProgressErrorBoundaries(t *testing.T) {
 		{
 			name: "summary execution",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnError(expected)
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnError(expected)
 			},
 			want: "copy import run 1 summaries",
 		},
 		{
 			name: "summary count",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewErrorResult(expected))
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewErrorResult(expected))
 			},
 			want: "count copied import run 1 summaries",
 		},
 		{
 			name: "summary mismatch",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 0))
 			},
 			want: "copied 0 of 1 entities",
 		},
 		{
 			name: "chunk execution",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnError(expected)
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into discogs_import_run_chunk").WithArgs(2, 1).WillReturnError(expected)
 			},
 			want: "copy import run 1 chunks",
 		},
 		{
 			name: "chunk count",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewErrorResult(expected))
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewErrorResult(expected))
 			},
 			want: "count copied import run 1 chunks",
 		},
 		{
 			name: "prune execution",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("delete from public.discogs_import_run_chunk").WithArgs(1).WillReturnError(expected)
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("delete from discogs_import_run_chunk").WithArgs(1).WillReturnError(expected)
 			},
 			want: "prune resumed import run 1 chunks",
 		},
 		{
 			name: "prune count",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("delete from public.discogs_import_run_chunk").WithArgs(1).WillReturnResult(sqlmock.NewErrorResult(expected))
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("delete from discogs_import_run_chunk").WithArgs(1).WillReturnResult(sqlmock.NewErrorResult(expected))
 			},
 			want: "count pruned import run 1 chunks",
 		},
 		{
 			name: "transfer mismatch",
 			setup: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
-				mock.ExpectExec("insert into public.discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 2))
-				mock.ExpectExec("delete from public.discogs_import_run_chunk").WithArgs(1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("insert into discogs_import_run_chunk").WithArgs(2, 1).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectExec("delete from discogs_import_run_chunk").WithArgs(1).WillReturnResult(sqlmock.NewResult(0, 1))
 			},
 			want: "copied 2 but pruned 1",
 		},
@@ -457,20 +469,20 @@ func TestPreloadReferenceIDErrorBoundaries(t *testing.T) {
 
 	t.Run("query", func(t *testing.T) {
 		_, mock, sqlDB := newMockGorm(t)
-		mock.ExpectQuery("SELECT id FROM public.artist").WillReturnError(expected)
+		mock.ExpectQuery("SELECT id FROM artist").WillReturnError(expected)
 		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "stream artist")
 	})
 
 	t.Run("scan", func(t *testing.T) {
 		_, mock, sqlDB := newMockGorm(t)
-		mock.ExpectQuery("SELECT id FROM public.artist").
+		mock.ExpectQuery("SELECT id FROM artist").
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("not-an-integer"))
 		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "scan artist")
 	})
 
 	t.Run("row iteration", func(t *testing.T) {
 		_, mock, sqlDB := newMockGorm(t)
-		mock.ExpectQuery("SELECT id FROM public.artist").WillReturnRows(
+		mock.ExpectQuery("SELECT id FROM artist").WillReturnRows(
 			sqlmock.NewRows([]string{"id"}).AddRow(1).RowError(0, expected),
 		)
 		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "read artist")
@@ -481,7 +493,7 @@ func TestPreloadReferenceIDErrorBoundaries(t *testing.T) {
 		t.Cleanup(func() { closeIdentifierRows = originalClose })
 		closeIdentifierRows = func(*sql.Rows) error { return expected }
 		_, mock, sqlDB := newMockGorm(t)
-		mock.ExpectQuery("SELECT id FROM public.artist").
+		mock.ExpectQuery("SELECT id FROM artist").
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 		require.ErrorContains(t, preloadReferenceIDs(context.Background(), sqlDB, preloadConfig(t)), "close artist")
 	})
@@ -500,7 +512,7 @@ func expectEntityUnlock(mock sqlmock.Sqlmock) {
 }
 
 func expectMarkAbandoned(mock sqlmock.Sqlmock) {
-	mock.ExpectExec("update public.discogs_import_run import_run").
+	mock.ExpectExec("update discogs_import_run import_run").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 }
@@ -518,7 +530,7 @@ func expectNoSuccessfulRun(mock sqlmock.Sqlmock) {
 }
 
 func expectInsertedDump(mock sqlmock.Sqlmock, dump *opendiscogsmodel.DiscogsDump) {
-	mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+	mock.ExpectQuery("insert into discogs_dump").WithArgs(
 		dump.ETag,
 		dump.DumpDate,
 		dump.EntityType,
@@ -535,7 +547,7 @@ func expectNoResumableRun(mock sqlmock.Sqlmock) {
 }
 
 func expectInsertedRun(mock sqlmock.Sqlmock, resumedFrom interface{}) {
-	mock.ExpectQuery("insert into public.discogs_import_run").WithArgs(
+	mock.ExpectQuery("insert into discogs_import_run").WithArgs(
 		sqlmock.AnyArg(),
 		false,
 		false,
@@ -546,7 +558,7 @@ func expectInsertedRun(mock sqlmock.Sqlmock, resumedFrom interface{}) {
 }
 
 func expectInsertedRunDump(mock sqlmock.Sqlmock) {
-	mock.ExpectExec("insert into public.discogs_import_run_dump").
+	mock.ExpectExec("insert into discogs_import_run_dump").
 		WithArgs(int64(2), "artist", int64(1), 5).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 }
@@ -657,7 +669,7 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 			setup: func(mock sqlmock.Sqlmock) {
 				expectEntityLock(mock)
 				mock.ExpectBegin()
-				mock.ExpectExec("update public.discogs_import_run import_run").WithArgs(sqlmock.AnyArg()).WillReturnError(expected)
+				mock.ExpectExec("update discogs_import_run import_run").WithArgs(sqlmock.AnyArg()).WillReturnError(expected)
 				mock.ExpectRollback()
 				expectEntityUnlock(mock)
 			},
@@ -709,7 +721,7 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
 				expectNoSuccessfulRun(mock)
-				mock.ExpectQuery("insert into public.discogs_dump").WithArgs(
+				mock.ExpectQuery("insert into discogs_dump").WithArgs(
 					dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
 				).WillReturnError(expected)
 				mock.ExpectRollback()
@@ -742,7 +754,7 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				expectNoSuccessfulRun(mock)
 				expectInsertedDump(mock, dump)
 				expectNoResumableRun(mock)
-				mock.ExpectQuery("insert into public.discogs_import_run").WithArgs(
+				mock.ExpectQuery("insert into discogs_import_run").WithArgs(
 					sqlmock.AnyArg(), false, false, processorName, "version", sqlmock.AnyArg(),
 				).WillReturnError(expected)
 				mock.ExpectRollback()
@@ -761,7 +773,7 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				expectInsertedDump(mock, dump)
 				expectNoResumableRun(mock)
 				expectInsertedRun(mock, sqlmock.AnyArg())
-				mock.ExpectExec("insert into public.discogs_import_run_dump").WithArgs(int64(2), "artist", int64(1), 5).WillReturnError(expected)
+				mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(int64(2), "artist", int64(1), 5).WillReturnError(expected)
 				mock.ExpectRollback()
 				expectEntityUnlock(mock)
 			},
@@ -780,7 +792,7 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(7))
 				expectInsertedRun(mock, sqlmock.AnyArg())
 				expectInsertedRunDump(mock)
-				mock.ExpectExec("update public.discogs_import_run_dump target").WithArgs(int64(2), int64(7)).WillReturnError(expected)
+				mock.ExpectExec("update discogs_import_run_dump target").WithArgs(int64(2), int64(7)).WillReturnError(expected)
 				mock.ExpectRollback()
 				expectEntityUnlock(mock)
 			},
@@ -840,13 +852,13 @@ func expectCompletionValidation(mock sqlmock.Sqlmock) {
 }
 
 func expectCompletedRunUpdate(mock sqlmock.Sqlmock) {
-	mock.ExpectExec("update public.discogs_import_run").
+	mock.ExpectExec("update discogs_import_run").
 		WithArgs("success", sqlmock.AnyArg(), int64(1)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 }
 
 func expectPrunedSupersededProgress(mock sqlmock.Sqlmock) {
-	mock.ExpectExec("delete from public.discogs_import_run_chunk run_chunk").
+	mock.ExpectExec("delete from discogs_import_run_chunk run_chunk").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 }
 
@@ -878,7 +890,7 @@ func TestImportCoordinatorCompletionFailures(t *testing.T) {
 			name: "status update",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectExec("update public.discogs_import_run").
+				mock.ExpectExec("update discogs_import_run").
 					WithArgs("failed", sqlmock.AnyArg(), int64(1)).
 					WillReturnError(expected)
 				mock.ExpectRollback()
@@ -890,7 +902,7 @@ func TestImportCoordinatorCompletionFailures(t *testing.T) {
 			name: "status result",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectExec("update public.discogs_import_run").
+				mock.ExpectExec("update discogs_import_run").
 					WithArgs("failed", sqlmock.AnyArg(), int64(1)).
 					WillReturnResult(sqlmock.NewErrorResult(expected))
 				mock.ExpectRollback()
@@ -902,7 +914,7 @@ func TestImportCoordinatorCompletionFailures(t *testing.T) {
 			name: "run no longer active",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectExec("update public.discogs_import_run").
+				mock.ExpectExec("update discogs_import_run").
 					WithArgs("failed", sqlmock.AnyArg(), int64(1)).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectRollback()
@@ -916,7 +928,7 @@ func TestImportCoordinatorCompletionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectCompletionValidation(mock)
 				expectCompletedRunUpdate(mock)
-				mock.ExpectExec("delete from public.discogs_import_run_chunk run_chunk").WillReturnError(expected)
+				mock.ExpectExec("delete from discogs_import_run_chunk run_chunk").WillReturnError(expected)
 				mock.ExpectRollback()
 			},
 			want: "prune superseded failed import progress",
@@ -928,7 +940,7 @@ func TestImportCoordinatorCompletionFailures(t *testing.T) {
 				expectCompletionValidation(mock)
 				expectCompletedRunUpdate(mock)
 				expectPrunedSupersededProgress(mock)
-				mock.ExpectExec("delete from public.discogs_import_run_chunk where import_run_id").
+				mock.ExpectExec("delete from discogs_import_run_chunk where import_run_id").
 					WithArgs(int64(1)).
 					WillReturnError(expected)
 				mock.ExpectRollback()
@@ -942,7 +954,7 @@ func TestImportCoordinatorCompletionFailures(t *testing.T) {
 				expectCompletionValidation(mock)
 				expectCompletedRunUpdate(mock)
 				expectPrunedSupersededProgress(mock)
-				mock.ExpectExec("delete from public.discogs_import_run_chunk where import_run_id").
+				mock.ExpectExec("delete from discogs_import_run_chunk where import_run_id").
 					WithArgs(int64(1)).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectCommit().WillReturnError(expected)

--- a/src/batch/ddl.go
+++ b/src/batch/ddl.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	opendiscogsschema "github.com/dsub-io/open-discogs-model/schema"
 	"gorm.io/gorm"
 )
@@ -19,24 +20,33 @@ var loadSchemaMigrations = opendiscogsschema.Migrations
 // RunDDL applies the versioned PostgreSQL migrations embedded in open-discogs-model.
 // Applied checksums are persisted so a released migration can never change silently.
 func RunDDL(db *gorm.DB) error {
+	return RunDDLInSchema(db, database.DefaultSchemaName)
+}
+
+// RunDDLInSchema applies canonical migrations inside the selected PostgreSQL schema.
+func RunDDLInSchema(db *gorm.DB, schemaName string) error {
 	migrations, err := loadSchemaMigrations()
 	if err != nil {
 		return fmt.Errorf("load shared schema migrations: %w", err)
 	}
-	return runDDL(db, migrations)
+	schema, err := database.ParseSchema(schemaName)
+	if err != nil {
+		return err
+	}
+	return runDDL(db, migrations, schema)
 }
 
-func runDDL(db *gorm.DB, migrations fs.FS) error {
+func runDDL(db *gorm.DB, migrations fs.FS, schema database.Schema) error {
 	names, _ := fs.Glob(migrations, "*.sql")
 	sort.Strings(names)
 
-	if err := db.Exec(`
-		create table if not exists public.open_discogs_schema_migration
+	if err := db.Exec(fmt.Sprintf(`
+		create table if not exists %s
 		(
 		    version     varchar(255) primary key,
 		    checksum    char(64) not null,
 		    applied_at  timestamp not null default now()
-		)`).Error; err != nil {
+		)`, schema.Qualify(migrationTable))).Error; err != nil {
 		return fmt.Errorf("create schema migration ledger: %w", err)
 	}
 
@@ -48,18 +58,24 @@ func runDDL(db *gorm.DB, migrations fs.FS) error {
 		sum := sha256.Sum256(contents)
 		checksum := hex.EncodeToString(sum[:])
 
-		if err := applyMigration(db, filepath.Base(name), checksum, string(contents)); err != nil {
+		if err := applyMigration(
+			db,
+			schema,
+			filepath.Base(name),
+			checksum,
+			schema.ScopeCanonicalSQL(string(contents)),
+		); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func applyMigration(db *gorm.DB, version, checksum, sql string) error {
+func applyMigration(db *gorm.DB, schema database.Schema, version, checksum, sql string) error {
 	return db.Transaction(func(tx *gorm.DB) error {
 		var appliedChecksum string
 		result := tx.Raw(
-			"select checksum from public.open_discogs_schema_migration where version = ?",
+			"select checksum from "+schema.Qualify(migrationTable)+" where version = ?",
 			version,
 		).Scan(&appliedChecksum)
 		if result.Error != nil {
@@ -81,7 +97,7 @@ func applyMigration(db *gorm.DB, version, checksum, sql string) error {
 			return fmt.Errorf("apply shared migration %s: %w", version, err)
 		}
 		if err := tx.Exec(
-			"insert into public.open_discogs_schema_migration (version, checksum) values (?, ?)",
+			"insert into "+schema.Qualify(migrationTable)+" (version, checksum) values (?, ?)",
 			version,
 			checksum,
 		).Error; err != nil {

--- a/src/batch/execution.go
+++ b/src/batch/execution.go
@@ -193,7 +193,7 @@ func (c *ImportExecutionCoordinator) Prepare(
 	for index, dump := range dumps {
 		if _, err := tx.ExecContext(
 			ctx,
-			`insert into public.discogs_import_run_dump
+			`insert into discogs_import_run_dump
 			    (import_run_id, entity_type, dump_id, chunk_size)
 			 values ($1, $2, $3, $4)`,
 			runID,
@@ -253,7 +253,7 @@ func (c *ImportExecutionCoordinator) Complete(ctx context.Context, runErr error)
 		if scanErr := tx.QueryRowContext(
 			ctx,
 			`select count(*)
-			   from public.discogs_import_run_dump
+			   from discogs_import_run_dump
 			  where import_run_id = $1
 			    and (completed_at is null
 			         or total_items is null
@@ -282,7 +282,7 @@ func (c *ImportExecutionCoordinator) Complete(ctx context.Context, runErr error)
 	}
 	result, err := tx.ExecContext(
 		ctx,
-		`update public.discogs_import_run
+		`update discogs_import_run
 		    set status = $1,
 		        completed_at = now(),
 		        failure_message = $2
@@ -312,7 +312,7 @@ func (c *ImportExecutionCoordinator) Complete(ctx context.Context, runErr error)
 		}
 		if _, err := tx.ExecContext(
 			ctx,
-			"delete from public.discogs_import_run_chunk where import_run_id = $1",
+			"delete from discogs_import_run_chunk where import_run_id = $1",
 			c.runID,
 		); err != nil {
 			_ = tx.Rollback()
@@ -376,14 +376,14 @@ func markAbandonedRuns(
 	entityTypes []string,
 ) error {
 	if _, err := tx.ExecContext(ctx, `
-		update public.discogs_import_run import_run
+		update discogs_import_run import_run
 		   set status = 'failed',
 		       completed_at = now(),
 		       failure_message = 'recovered after entity advisory locks were released'
 		 where import_run.status = 'running'
 		   and exists (
 		       select 1
-		         from public.discogs_import_run_dump run_dump
+		         from discogs_import_run_dump run_dump
 		        where run_dump.import_run_id = import_run.id
 		          and run_dump.entity_type = any($1::text[])
 		   )`, postgresArray(entityTypes)); err != nil {
@@ -406,7 +406,7 @@ func assertNotDowngrade(
 		err := tx.QueryRowContext(
 			ctx,
 			`select dump_date
-			   from public.discogs_import_checkpoint
+			   from discogs_import_checkpoint
 			  where entity_type = $1`,
 			dump.EntityType,
 		).Scan(&checkpointDate)
@@ -438,15 +438,15 @@ func findSuccessfulRun(
 	err := tx.QueryRowContext(
 		ctx,
 		`select candidate_run.id
-		   from public.discogs_import_run candidate_run
+		   from discogs_import_run candidate_run
 		  where candidate_run.manifest_sha256 = $1
 		    and candidate_run.status = 'success'
 		    and not exists (
 		        select 1
-		          from public.discogs_import_run_dump candidate_dump
-		          left join public.discogs_import_checkpoint checkpoint
+		          from discogs_import_run_dump candidate_dump
+		          left join discogs_import_checkpoint checkpoint
 		            on checkpoint.entity_type = candidate_dump.entity_type
-		          left join public.discogs_import_run_dump current_dump
+		          left join discogs_import_run_dump current_dump
 		            on current_dump.import_run_id = checkpoint.import_run_id
 		           and current_dump.entity_type = checkpoint.entity_type
 		         where candidate_dump.import_run_id = candidate_run.id
@@ -454,12 +454,12 @@ func findSuccessfulRun(
 		    )
 		    and not exists (
 		        select 1
-		          from public.discogs_import_run_dump candidate_dump
-		          join public.discogs_import_checkpoint checkpoint
+		          from discogs_import_run_dump candidate_dump
+		          join discogs_import_checkpoint checkpoint
 		            on checkpoint.entity_type = candidate_dump.entity_type
-		          join public.discogs_import_run_dump failed_dump
+		          join discogs_import_run_dump failed_dump
 		            on failed_dump.entity_type = candidate_dump.entity_type
-		          join public.discogs_import_run failed_run
+		          join discogs_import_run failed_run
 		            on failed_run.id = failed_dump.import_run_id
 		         where candidate_dump.import_run_id = candidate_run.id
 		           and failed_run.status = 'failed'
@@ -492,36 +492,36 @@ func findResumableRun(
 	err := tx.QueryRowContext(
 		ctx,
 		`select import_run.id
-		   from public.discogs_import_run import_run
+		   from discogs_import_run import_run
 		  where import_run.manifest_sha256 = $1
 		    and import_run.status = 'failed'
 		    and import_run.processor = $2
 		    and import_run.processor_version = $3
 		    and not import_run.force_requested
 		    and (select count(*)
-		           from public.discogs_import_run_dump run_dump
+		           from discogs_import_run_dump run_dump
 		          where run_dump.import_run_id = import_run.id) = $4
 		    and not exists (
 		        select 1
-		          from public.discogs_import_run_dump run_dump
+		          from discogs_import_run_dump run_dump
 		         where run_dump.import_run_id = import_run.id
 		           and run_dump.chunk_size is distinct from $5
 		    )
 		    and not exists (
 		        select 1
-		          from public.discogs_import_run_dump run_dump
+		          from discogs_import_run_dump run_dump
 		         where run_dump.import_run_id = import_run.id
 		           and run_dump.processed_items <> (
 		               select coalesce(sum(run_chunk.item_count), 0)
-		                 from public.discogs_import_run_chunk run_chunk
+		                 from discogs_import_run_chunk run_chunk
 		                where run_chunk.import_run_id = run_dump.import_run_id
 		                  and run_chunk.entity_type = run_dump.entity_type
 		           )
 		    )
 		    and not exists (
 		        select 1
-		          from public.discogs_import_run_chunk run_chunk
-		          join public.discogs_import_run_dump run_dump
+		          from discogs_import_run_chunk run_chunk
+		          join discogs_import_run_dump run_dump
 		            on run_dump.import_run_id = run_chunk.import_run_id
 		           and run_dump.entity_type = run_chunk.entity_type
 		         where run_chunk.import_run_id = import_run.id
@@ -530,13 +530,13 @@ func findResumableRun(
 		    )
 		    and not exists (
 		        select 1
-		          from public.discogs_import_run_dump failed_dump
-		          join public.discogs_import_checkpoint checkpoint
+		          from discogs_import_run_dump failed_dump
+		          join discogs_import_checkpoint checkpoint
 		            on checkpoint.entity_type = failed_dump.entity_type
-		          join public.discogs_import_run_dump current_dump
+		          join discogs_import_run_dump current_dump
 		            on current_dump.import_run_id = checkpoint.import_run_id
 		           and current_dump.entity_type = checkpoint.entity_type
-		          join public.discogs_import_run current_run
+		          join discogs_import_run current_run
 		            on current_run.id = checkpoint.import_run_id
 		         where failed_dump.import_run_id = import_run.id
 		           and (current_dump.dump_id <> failed_dump.dump_id
@@ -572,13 +572,13 @@ func copyResumeProgress(
 ) error {
 	summaryResult, err := tx.ExecContext(
 		ctx,
-		`update public.discogs_import_run_dump target
+		`update discogs_import_run_dump target
 		    set processed_items = source.processed_items,
 		        total_items = source.total_items,
 		        total_chunks = source.total_chunks,
 		        last_progress_at = source.last_progress_at,
 		        completed_at = source.completed_at
-		   from public.discogs_import_run_dump source
+		   from discogs_import_run_dump source
 		  where target.import_run_id = $1
 		    and source.import_run_id = $2
 		    and target.entity_type = source.entity_type
@@ -605,10 +605,10 @@ func copyResumeProgress(
 
 	chunkResult, err := tx.ExecContext(
 		ctx,
-		`insert into public.discogs_import_run_chunk
+		`insert into discogs_import_run_chunk
 		    (import_run_id, entity_type, chunk_index, first_item_index, item_count, completed_at)
 		 select $1, entity_type, chunk_index, first_item_index, item_count, completed_at
-		   from public.discogs_import_run_chunk
+		   from discogs_import_run_chunk
 		  where import_run_id = $2`,
 		toRunID,
 		fromRunID,
@@ -622,7 +622,7 @@ func copyResumeProgress(
 	}
 	deleteResult, err := tx.ExecContext(
 		ctx,
-		"delete from public.discogs_import_run_chunk where import_run_id = $1",
+		"delete from discogs_import_run_chunk where import_run_id = $1",
 		fromRunID,
 	)
 	if err != nil {
@@ -646,19 +646,19 @@ func copyResumeProgress(
 func pruneSupersededFailedProgress(ctx context.Context, tx *sql.Tx) error {
 	if _, err := tx.ExecContext(
 		ctx,
-		`delete from public.discogs_import_run_chunk run_chunk
+		`delete from discogs_import_run_chunk run_chunk
 		  where run_chunk.import_run_id in (
 		      select failed_run.id
-		        from public.discogs_import_run failed_run
+		        from discogs_import_run failed_run
 		       where failed_run.status = 'failed'
 		         and not exists (
 		             select 1
-		               from public.discogs_import_run_dump failed_dump
-		               left join public.discogs_import_checkpoint checkpoint
+		               from discogs_import_run_dump failed_dump
+		               left join discogs_import_checkpoint checkpoint
 		                 on checkpoint.entity_type = failed_dump.entity_type
-		               left join public.discogs_import_run current_run
+		               left join discogs_import_run current_run
 		                 on current_run.id = checkpoint.import_run_id
-		               left join public.discogs_import_run_dump current_dump
+		               left join discogs_import_run_dump current_dump
 		                 on current_dump.import_run_id = checkpoint.import_run_id
 		                and current_dump.entity_type = checkpoint.entity_type
 		              where failed_dump.import_run_id = failed_run.id
@@ -681,7 +681,7 @@ func findOrInsertDump(
 	var dumpID int64
 	err := tx.QueryRowContext(
 		ctx,
-		`insert into public.discogs_dump
+		`insert into discogs_dump
 		    (etag, dump_date, entity_type, checksum_sha256, size_bytes, uri)
 		 values ($1, $2, $3, $4, $5, $6)
 		 on conflict (dump_date, entity_type, checksum_sha256) do nothing
@@ -702,7 +702,7 @@ func findOrInsertDump(
 	err = tx.QueryRowContext(
 		ctx,
 		`select id
-		   from public.discogs_dump
+		   from discogs_dump
 		  where dump_date = $1
 		    and entity_type = $2
 		    and checksum_sha256 = $3`,
@@ -732,7 +732,7 @@ func insertImportRun(
 	}
 	err := tx.QueryRowContext(
 		ctx,
-		`insert into public.discogs_import_run
+		`insert into discogs_import_run
 		    (manifest_sha256, status, force_requested,
 		     allow_downgrade_requested, processor, processor_version, resumed_from_run_id)
 		 values ($1, 'running', $2, $3, $4, $5, $6)

--- a/src/batch/observability.go
+++ b/src/batch/observability.go
@@ -197,7 +197,7 @@ func readCommittedProgress(order Order) (committedProgress, error) {
 	var summary committedProgress
 	query := order.getDB().WithContext(order.getContext()).Raw(
 		`select processed_items, total_items, last_progress_at
-		   from public.discogs_import_run_dump
+		   from discogs_import_run_dump
 		  where import_run_id = ?
 		    and entity_type = ?`,
 		order.getRunID(),

--- a/src/batch/progress.go
+++ b/src/batch/progress.go
@@ -32,7 +32,7 @@ func executeActiveRunTransaction(
 		var active activeImportRun
 		fenced := tx.Raw(
 			`select id
-			   from public.discogs_import_run
+			   from discogs_import_run
 			  where id = ?
 			    and status = 'running'
 			  for update`,
@@ -97,7 +97,7 @@ func chunkAlreadyCompleted(
 	var recorded recordedChunk
 	query := tx.Raw(
 		`select first_item_index, item_count
-		   from public.discogs_import_run_chunk
+		   from discogs_import_run_chunk
 		  where import_run_id = ?
 		    and entity_type = ?
 		    and chunk_index = ?`,
@@ -138,20 +138,20 @@ func recordCompletedChunk(
 	updated := tx.Exec(
 		`with active_run as (
 		    select id
-		      from public.discogs_import_run
+		      from discogs_import_run
 		     where id = ?
 		       and status = 'running'
 		     for update
 		),
 		inserted as (
-		    insert into public.discogs_import_run_chunk
+		    insert into discogs_import_run_chunk
 		        (import_run_id, entity_type, chunk_index, first_item_index, item_count)
 		    select active_run.id, ?, ?, ?, ?
 		      from active_run
 		    on conflict do nothing
 		    returning item_count
 		)
-		update public.discogs_import_run_dump run_dump
+		update discogs_import_run_dump run_dump
 		   set processed_items = run_dump.processed_items + inserted.item_count,
 		       last_progress_at = now()
 		  from inserted
@@ -193,7 +193,7 @@ func completeEntityProgress(order Order, totalItems, totalChunks int64) error {
 	updated := order.getDB().WithContext(order.getContext()).Exec(
 		`with active_run as (
 		    select id
-		      from public.discogs_import_run
+		      from discogs_import_run
 		     where id = ?
 		       and status = 'running'
 		     for update
@@ -209,11 +209,11 @@ func completeEntityProgress(order Order, totalItems, totalChunks int64) error {
 		                      else ?
 		                  end
 		           ) as invalid_chunks
-		      from public.discogs_import_run_chunk
+		      from discogs_import_run_chunk
 		     where import_run_id = ?
 		       and entity_type = ?
 		)
-		update public.discogs_import_run_dump
+		update discogs_import_run_dump
 		   set total_items = ?,
 		       total_chunks = ?,
 		       completed_at = now(),

--- a/src/batch/release.go
+++ b/src/batch/release.go
@@ -278,7 +278,7 @@ func updateMasterMainReleases(order Order, releases []*XmlReleaseRelation) resul
 		mainReleaseIDs = append(mainReleaseIDs, releaseID)
 	}
 	cleared := order.getDB().Exec(
-		`update public.master
+		`update master
 		    set main_release_id = null,
 		        last_modified_at = ?
 		  where main_release_id = any(?::integer[])
@@ -325,7 +325,7 @@ func masterMainReleaseUpdateStatement(
 		rows[index] = "(?::integer, ?::integer)"
 		arguments = append(arguments, masterID, updates[masterID])
 	}
-	return `UPDATE public.master AS target
+	return `UPDATE master AS target
 		SET main_release_id = incoming.release_id,
 			last_modified_at = ?
 		FROM (VALUES ` + strings.Join(rows, ", ") + `) AS incoming(master_id, release_id)

--- a/src/batch/release_test.go
+++ b/src/batch/release_test.go
@@ -37,7 +37,7 @@ func TestMasterMainReleaseUpdateStatementBatchesMappings(t *testing.T) {
 
 	query, arguments := masterMainReleaseUpdateStatement([]int32{10, 20, 30}, updates)
 
-	require.Contains(t, query, "UPDATE public.master AS target")
+	require.Contains(t, query, "UPDATE master AS target")
 	require.Equal(t, 3, strings.Count(query, "(?::integer, ?::integer)"))
 	require.Len(t, arguments, 7)
 	require.Equal(t, int32(10), arguments[1])

--- a/src/batch/runner.go
+++ b/src/batch/runner.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -23,6 +24,8 @@ type Runner struct {
 
 const importCompletionTimeout = 30 * time.Second
 
+const publicSchemaWarning = "WARN: database schema is public; set --database-schema or OPEN_DISCOGS_BATCH_DATABASE_SCHEMA to isolate OpenDiscogs tables"
+
 type importCompleter interface {
 	Complete(context.Context, error) error
 }
@@ -32,9 +35,10 @@ type importExecutionCoordinator interface {
 	Prepare(context.Context, []*opendiscogsmodel.DiscogsDump, int, bool, bool) (*ImportPreparation, error)
 }
 
-var connectDatabase = database.Connect
+var connectDatabase = database.ConnectInSchema
 var configureDatabasePool = database.ConfigurePool
-var runDatabaseDDL = RunDDL
+var ensureDatabaseSchema = database.EnsureSchema
+var runDatabaseDDL = RunDDLInSchema
 var refreshSelectedData = data.UpdateSelectedData
 var resolveImportPlan = data.ResolveImportPlan
 var fetchImportResources = data.FetchImportResources
@@ -51,16 +55,29 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 		begin      = time.Now()
 		chunk      = config.Int("chunk-size")
 		maxWorkers = config.Int("max-workers")
+		schemaName = config.String("database-schema")
 	)
-	if err := connectDatabase(config.String("database-url")); err != nil {
+	schema, err := database.ParseSchema(schemaName)
+	if err != nil {
+		return err
+	}
+	if schema.Name() == database.DefaultSchemaName {
+		fmt.Fprintln(os.Stderr, publicSchemaWarning)
+	}
+	if err := connectDatabase(config.String("database-url"), schemaName); err != nil {
 		return err
 	}
 	if err := configureDatabasePool(database.DB, maxWorkers); err != nil {
 		return err
 	}
+	created, err := ensureDatabaseSchema(database.DB, schema)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("database schema ready: %s (created=%t)\n", schema.Name(), created)
 
 	fmt.Println("execute DDL update...")
-	if err := runDatabaseDDL(database.DB); err != nil {
+	if err := runDatabaseDDL(database.DB, schemaName); err != nil {
 		return err
 	}
 
@@ -194,7 +211,7 @@ func preloadReferenceIDs(ctx context.Context, db *sql.DB, config *koanf.Koanf) e
 		if !load.required {
 			continue
 		}
-		rows, err := db.QueryContext(ctx, "SELECT id FROM public."+load.table)
+		rows, err := db.QueryContext(ctx, "SELECT id FROM "+load.table)
 		if err != nil {
 			return fmt.Errorf("stream %s identifiers: %w", load.table, err)
 		}

--- a/src/batch/runner_error_test.go
+++ b/src/batch/runner_error_test.go
@@ -47,9 +47,10 @@ func (s batchStub) UpdateMaster(order Order) Step  { return s.step(order) }
 func (s batchStub) UpdateRelease(order Order) Step { return s.step(order) }
 
 type runnerSeams struct {
-	connect       func(string) error
+	connect       func(string, string) error
 	configure     func(*gorm.DB, int) error
-	ddl           func(*gorm.DB) error
+	ensure        func(*gorm.DB, database.Schema) (bool, error)
+	ddl           func(*gorm.DB, string) error
 	refresh       func(context.Context, data.Repository, []string, string) (int, error)
 	resolve       func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error)
 	fetch         func(context.Context, *data.ImportPlan) error
@@ -64,6 +65,7 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 	t.Helper()
 	originalConnect := connectDatabase
 	originalConfigure := configureDatabasePool
+	originalEnsure := ensureDatabaseSchema
 	originalDDL := runDatabaseDDL
 	originalRefresh := refreshSelectedData
 	originalResolve := resolveImportPlan
@@ -76,6 +78,7 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 	t.Cleanup(func() {
 		connectDatabase = originalConnect
 		configureDatabasePool = originalConfigure
+		ensureDatabaseSchema = originalEnsure
 		runDatabaseDDL = originalDDL
 		refreshSelectedData = originalRefresh
 		resolveImportPlan = originalResolve
@@ -88,6 +91,7 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 	})
 	connectDatabase = seams.connect
 	configureDatabasePool = seams.configure
+	ensureDatabaseSchema = seams.ensure
 	runDatabaseDDL = seams.ddl
 	refreshSelectedData = seams.refresh
 	resolveImportPlan = seams.resolve
@@ -102,9 +106,10 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 func defaultRunnerSeams() runnerSeams {
 	coordinator := &executionCoordinatorStub{preparation: &ImportPreparation{RunID: 1}}
 	return runnerSeams{
-		connect:   func(string) error { return nil },
+		connect:   func(string, string) error { return nil },
 		configure: func(*gorm.DB, int) error { return nil },
-		ddl:       func(*gorm.DB) error { return nil },
+		ensure:    func(*gorm.DB, database.Schema) (bool, error) { return false, nil },
+		ddl:       func(*gorm.DB, string) error { return nil },
 		refresh: func(context.Context, data.Repository, []string, string) (int, error) {
 			return 0, nil
 		},
@@ -128,10 +133,11 @@ func runnerConfig(t *testing.T) *koanf.Koanf {
 	t.Helper()
 	config := koanf.New(".")
 	for key, value := range map[string]interface{}{
-		"entities":    []string{"artist"},
-		"artists":     true,
-		"chunk-size":  1,
-		"max-workers": 1,
+		"entities":        []string{"artist"},
+		"artists":         true,
+		"chunk-size":      1,
+		"max-workers":     1,
+		"database-schema": database.DefaultSchemaName,
 	} {
 		require.NoError(t, config.Set(key, value))
 	}
@@ -144,9 +150,12 @@ func TestRunnerPropagatesEveryStageFailure(t *testing.T) {
 		name   string
 		mutate func(*runnerSeams)
 	}{
-		{"connect", func(s *runnerSeams) { s.connect = func(string) error { return expected } }},
+		{"connect", func(s *runnerSeams) { s.connect = func(string, string) error { return expected } }},
 		{"pool", func(s *runnerSeams) { s.configure = func(*gorm.DB, int) error { return expected } }},
-		{"ddl", func(s *runnerSeams) { s.ddl = func(*gorm.DB) error { return expected } }},
+		{"schema", func(s *runnerSeams) {
+			s.ensure = func(*gorm.DB, database.Schema) (bool, error) { return false, expected }
+		}},
+		{"ddl", func(s *runnerSeams) { s.ddl = func(*gorm.DB, string) error { return expected } }},
 		{"catalog and plan", func(s *runnerSeams) {
 			s.refresh = func(context.Context, data.Repository, []string, string) (int, error) { return 0, expected }
 			s.resolve = func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) { return nil, expected }
@@ -173,6 +182,17 @@ func TestRunnerPropagatesEveryStageFailure(t *testing.T) {
 			require.ErrorIs(t, (&Runner{Version: "test"}).Run(context.Background(), runnerConfig(t)), expected)
 		})
 	}
+}
+
+func TestRunnerRejectsInvalidDatabaseSchema(t *testing.T) {
+	config := runnerConfig(t)
+	require.NoError(t, config.Set("database-schema", "Invalid"))
+
+	require.ErrorContains(
+		t,
+		(&Runner{Version: "test"}).Run(context.Background(), config),
+		"database-schema",
+	)
 }
 
 func TestBuildImportStepsSkipsDisabledEntitiesAndPrintsError(t *testing.T) {

--- a/src/batch/runner_test.go
+++ b/src/batch/runner_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/internal/testserver"
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
 	"github.com/dsub-io/go-open-discogs-batch/src/data"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
 	"github.com/knadh/koanf"
 	"github.com/stretchr/testify/require"
 )
@@ -25,6 +26,7 @@ type runnerFixture struct {
 }
 
 func TestRunnerEndToEndAndSuccessfulSkip(t *testing.T) {
+	const customSchema = "open_discogs"
 	fixtures := make([]runnerFixture, 0, 4)
 	for _, entity := range []string{"artist", "label", "master", "release"} {
 		filename := fmt.Sprintf("discogs_20260701_%ss.xml.gz", entity)
@@ -79,6 +81,7 @@ func TestRunnerEndToEndAndSuccessfulSkip(t *testing.T) {
 	config := koanf.New(".")
 	for key, value := range map[string]interface{}{
 		"database-url":    testutils.GetDsn(testutils.Postgres, postgres),
+		"database-schema": customSchema,
 		"entities":        []string{"artist", "label", "master", "release"},
 		"dump-month":      "2026-07",
 		"data-dir":        t.TempDir(),
@@ -97,6 +100,16 @@ func TestRunnerEndToEndAndSuccessfulSkip(t *testing.T) {
 
 	runner := &Runner{Version: "test"}
 	require.NoError(t, runner.Run(context.Background(), config))
+	var artistCount int64
+	require.NoError(t, database.DB.Raw(
+		`select count(*) from "open_discogs"."artist"`,
+	).Scan(&artistCount).Error)
+	require.Positive(t, artistCount)
+	var publicArtistTable *string
+	require.NoError(t, database.DB.Raw(
+		`select to_regclass('public.artist')::text`,
+	).Scan(&publicArtistTable).Error)
+	require.Nil(t, publicArtistTable)
 	for _, fixture := range fixtures {
 		require.NoFileExists(t, filepath.Join(config.String("data-dir"), fixture.filename))
 	}

--- a/src/database/gorm.go
+++ b/src/database/gorm.go
@@ -3,13 +3,16 @@ package database
 import (
 	"errors"
 	"fmt"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 	"log"
 	"os"
 	"regexp"
 	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 var (
@@ -21,7 +24,12 @@ var DB *gorm.DB
 
 // Connect opens the canonical PostgreSQL database.
 func Connect(dsn string) (err error) {
-	if DB, err = GetConnect(dsn); err != nil {
+	return ConnectInSchema(dsn, DefaultSchemaName)
+}
+
+// ConnectInSchema opens PostgreSQL with the selected schema first in every connection's search path.
+func ConnectInSchema(dsn, schemaName string) (err error) {
+	if DB, err = GetConnectInSchema(dsn, schemaName); err != nil {
 		return
 	}
 	return nil
@@ -47,18 +55,30 @@ func ConfigurePool(db *gorm.DB, maxWorkers int) error {
 }
 
 func GetConnect(dsn string) (*gorm.DB, error) {
-	var dl gorm.Dialector
+	return GetConnectInSchema(dsn, DefaultSchemaName)
+}
+
+// GetConnectInSchema creates a bounded-schema GORM connection without mutating the caller's DSN.
+func GetConnectInSchema(dsn, schemaName string) (*gorm.DB, error) {
 	if len(dsn) == 0 {
 		return nil, errors.New("missing dsn")
-	} else if p.MatchString(dsn) {
-		dl = postgres.Open(dsn)
-	} else {
+	}
+	if !p.MatchString(dsn) {
 		if match := x.FindStringSubmatch(dsn); match != nil {
 			return nil, errors.New("unsupported database from dsn: " + match[1])
-		} else {
-			return nil, errors.New("unsupported dsn. please check again")
 		}
+		return nil, errors.New("unsupported dsn. please check again")
 	}
+	schema, err := ParseSchema(schemaName)
+	if err != nil {
+		return nil, err
+	}
+	connectionConfig, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse PostgreSQL DSN: %w", err)
+	}
+	connectionConfig.RuntimeParams[searchPathParameter] = schema.SearchPath()
+	sqlDB := stdlib.OpenDB(*connectionConfig)
 
 	newLogger := logger.New(
 		log.New(os.Stdout, "\r\n", log.LstdFlags),
@@ -69,8 +89,13 @@ func GetConnect(dsn string) (*gorm.DB, error) {
 			LogLevel:                  logger.Error,
 		})
 
-	return gorm.Open(dl, &gorm.Config{
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
 		Logger:                 newLogger,
 		SkipDefaultTransaction: true,
 	})
+	if err != nil {
+		_ = sqlDB.Close()
+		return nil, err
+	}
+	return db, nil
 }

--- a/src/database/gorm_test.go
+++ b/src/database/gorm_test.go
@@ -2,10 +2,11 @@ package database
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
-	"testing"
 )
 
 func TestConnect(t *testing.T) {
@@ -24,6 +25,12 @@ func TestConnect(t *testing.T) {
 		result := DB.Exec("SELECT 1")
 		assert.Equal(t, int64(1), result.RowsAffected)
 		assert.Nil(t, result.Error)
+
+		connection, connectErr := GetConnect(dsn)
+		assert.NoError(t, connectErr)
+		connectionPool, poolErr := connection.DB()
+		assert.NoError(t, poolErr)
+		assert.NoError(t, connectionPool.Close())
 	})
 	t.Run("reject invalid pool limit", func(t *testing.T) {
 		assert.Error(t, ConfigurePool(DB, 0))
@@ -40,6 +47,24 @@ func TestConnect(t *testing.T) {
 
 	t.Run("reject missing dsn", func(t *testing.T) {
 		assert.ErrorContains(t, Connect(""), "missing dsn")
+	})
+
+	t.Run("reject invalid schema", func(t *testing.T) {
+		_, err := GetConnectInSchema("postgres://user:password@localhost/database", "Invalid")
+		assert.ErrorContains(t, err, "database-schema")
+	})
+
+	t.Run("reject malformed PostgreSQL dsn", func(t *testing.T) {
+		_, err := GetConnectInSchema("postgres://%", DefaultSchemaName)
+		assert.ErrorContains(t, err, "parse PostgreSQL DSN")
+	})
+
+	t.Run("report unavailable PostgreSQL", func(t *testing.T) {
+		_, err := GetConnectInSchema(
+			"postgres://invalid:invalid@127.0.0.1:1/invalid?connect_timeout=1",
+			DefaultSchemaName,
+		)
+		assert.Error(t, err)
 	})
 
 	t.Run("report unavailable SQL pool", func(t *testing.T) {

--- a/src/database/schema.go
+++ b/src/database/schema.go
@@ -1,0 +1,125 @@
+package database
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+const (
+	DefaultSchemaName       = "public"
+	canonicalSchemaPrefix   = "public."
+	maximumSchemaNameLength = 63
+	searchPathParameter     = "search_path"
+)
+
+var schemaNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
+
+// Schema is a validated PostgreSQL schema selected by an operator.
+type Schema struct {
+	name       string
+	identifier string
+}
+
+type databaseCreatePrivilege struct {
+	Name    string `gorm:"column:name"`
+	Allowed bool   `gorm:"column:allowed"`
+}
+
+// ParseSchema validates a portable, unquoted PostgreSQL schema name.
+func ParseSchema(name string) (Schema, error) {
+	trimmed := strings.TrimSpace(name)
+	if len(trimmed) == 0 || len(trimmed) > maximumSchemaNameLength || !schemaNamePattern.MatchString(trimmed) {
+		return Schema{}, fmt.Errorf(
+			"database-schema must be 1 to %d lowercase letters, digits, or underscores and start with a letter or underscore",
+			maximumSchemaNameLength,
+		)
+	}
+	return Schema{name: trimmed, identifier: `"` + trimmed + `"`}, nil
+}
+
+// ValidateSchemaName validates the public CLI and ENV contract.
+func ValidateSchemaName(name string) error {
+	_, err := ParseSchema(name)
+	return err
+}
+
+func (schema Schema) Name() string {
+	return schema.name
+}
+
+func (schema Schema) Identifier() string {
+	return schema.identifier
+}
+
+// SearchPath keeps public available for database-wide extension objects while selecting the
+// requested schema first for every unqualified canonical query.
+func (schema Schema) SearchPath() string {
+	if schema.name == DefaultSchemaName {
+		return schema.identifier
+	}
+	return schema.identifier + `, "` + DefaultSchemaName + `"`
+}
+
+func (schema Schema) Qualify(table string) string {
+	return schema.identifier + `."` + table + `"`
+}
+
+// ScopeCanonicalSQL maps immutable model migrations from their canonical public schema to the
+// operator-selected schema without changing the migration bytes used for checksum verification.
+func (schema Schema) ScopeCanonicalSQL(statement string) string {
+	return strings.ReplaceAll(statement, canonicalSchemaPrefix, schema.identifier+".")
+}
+
+// EnsureSchema creates a missing schema and verifies the DDL privileges required by migrations.
+func EnsureSchema(db *gorm.DB, schema Schema) (bool, error) {
+	if db == nil {
+		return false, fmt.Errorf("prepare database schema %s: database connection is nil", schema.name)
+	}
+	var exists bool
+	if err := db.Raw(
+		"select exists(select 1 from pg_namespace where nspname = ?)",
+		schema.name,
+	).Scan(&exists).Error; err != nil {
+		return false, fmt.Errorf("inspect database schema %s: %w", schema.name, err)
+	}
+	created := false
+	if !exists {
+		var privilege databaseCreatePrivilege
+		if err := db.Raw(
+			"select current_database() as name, has_database_privilege(current_user, current_database(), 'CREATE') as allowed",
+		).Scan(&privilege).Error; err != nil {
+			return false, fmt.Errorf("inspect CREATE privilege for database schema %s: %w", schema.name, err)
+		}
+		if !privilege.Allowed {
+			return false, fmt.Errorf(
+				"database schema %s does not exist and current user lacks CREATE on database %s; pre-create the schema or grant database CREATE",
+				schema.name,
+				privilege.Name,
+			)
+		}
+		if err := db.Exec(
+			"create schema if not exists " + schema.identifier + " authorization current_user",
+		).Error; err != nil {
+			return false, fmt.Errorf("create database schema %s: %w", schema.name, err)
+		}
+		created = true
+	}
+	var canUseAndCreate bool
+	if err := db.Raw(
+		"select has_schema_privilege(current_user, ?, 'USAGE') and has_schema_privilege(current_user, ?, 'CREATE')",
+		schema.name,
+		schema.name,
+	).Scan(&canUseAndCreate).Error; err != nil {
+		return false, fmt.Errorf("inspect privileges for database schema %s: %w", schema.name, err)
+	}
+	if !canUseAndCreate {
+		return false, fmt.Errorf(
+			"current user requires USAGE and CREATE privileges on database schema %s; grant both privileges or use a writable schema",
+			schema.name,
+		)
+	}
+	return created, nil
+}

--- a/src/database/schema_test.go
+++ b/src/database/schema_test.go
@@ -1,0 +1,171 @@
+package database
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func newSchemaMock(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		DisableAutomaticPing:   true,
+		SkipDefaultTransaction: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, sqlDB.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+	return db, mock
+}
+
+func requireSchema(t *testing.T, name string) Schema {
+	t.Helper()
+	schema, err := ParseSchema(name)
+	require.NoError(t, err)
+	return schema
+}
+
+func TestSchemaContract(t *testing.T) {
+	publicSchema := requireSchema(t, DefaultSchemaName)
+	require.Equal(t, DefaultSchemaName, publicSchema.Name())
+	require.Equal(t, `"public"`, publicSchema.Identifier())
+	require.Equal(t, `"public"`, publicSchema.SearchPath())
+	require.Equal(t, `"public"."artist"`, publicSchema.Qualify("artist"))
+	require.Equal(t, `create table "public".artist(id integer)`, publicSchema.ScopeCanonicalSQL(
+		`create table public.artist(id integer)`,
+	))
+	require.NoError(t, ValidateSchemaName(DefaultSchemaName))
+
+	customSchema := requireSchema(t, "open_discogs")
+	require.Equal(t, `"open_discogs", "public"`, customSchema.SearchPath())
+	require.Equal(t, `"open_discogs".artist`, customSchema.ScopeCanonicalSQL(`public.artist`))
+
+	for _, invalid := range []string{"", "OpenDiscogs", "open-discogs", "1schema", strings.Repeat("a", 64)} {
+		require.ErrorContains(t, ValidateSchemaName(invalid), "database-schema")
+	}
+	require.NoError(t, ValidateSchemaName("_"+strings.Repeat("a", 62)))
+}
+
+func TestEnsureSchemaRejectsNilDatabase(t *testing.T) {
+	_, err := EnsureSchema(nil, requireSchema(t, "open_discogs"))
+	require.ErrorContains(t, err, "connection is nil")
+}
+
+func TestEnsureSchemaExisting(t *testing.T) {
+	db, mock := newSchemaMock(t)
+	mock.ExpectQuery(regexp.QuoteMeta("select exists(select 1 from pg_namespace where nspname = $1)")).
+		WithArgs("open_discogs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select has_schema_privilege(current_user, $1, 'USAGE') and has_schema_privilege(current_user, $2, 'CREATE')",
+	)).WithArgs("open_discogs", "open_discogs").
+		WillReturnRows(sqlmock.NewRows([]string{"allowed"}).AddRow(true))
+
+	created, err := EnsureSchema(db, requireSchema(t, "open_discogs"))
+	require.NoError(t, err)
+	require.False(t, created)
+}
+
+func TestEnsureSchemaCreatesMissingSchema(t *testing.T) {
+	db, mock := newSchemaMock(t)
+	mock.ExpectQuery(regexp.QuoteMeta("select exists(select 1 from pg_namespace where nspname = $1)")).
+		WithArgs("open_discogs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select current_database() as name, has_database_privilege(current_user, current_database(), 'CREATE') as allowed",
+	)).WillReturnRows(sqlmock.NewRows([]string{"name", "allowed"}).AddRow("discogs", true))
+	mock.ExpectExec(regexp.QuoteMeta(`create schema if not exists "open_discogs" authorization current_user`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select has_schema_privilege(current_user, $1, 'USAGE') and has_schema_privilege(current_user, $2, 'CREATE')",
+	)).WithArgs("open_discogs", "open_discogs").
+		WillReturnRows(sqlmock.NewRows([]string{"allowed"}).AddRow(true))
+
+	created, err := EnsureSchema(db, requireSchema(t, "open_discogs"))
+	require.NoError(t, err)
+	require.True(t, created)
+}
+
+func TestEnsureSchemaReportsEveryFailure(t *testing.T) {
+	expected := errors.New("fixture")
+	tests := []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+		want  string
+	}{
+		{
+			name: "namespace inspection",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("select exists").WillReturnError(expected)
+			},
+			want: "inspect database schema",
+		},
+		{
+			name: "database privilege inspection",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("select exists").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+				mock.ExpectQuery("select current_database").WillReturnError(expected)
+			},
+			want: "inspect CREATE privilege",
+		},
+		{
+			name: "database privilege denied",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("select exists").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+				mock.ExpectQuery("select current_database").WillReturnRows(
+					sqlmock.NewRows([]string{"name", "allowed"}).AddRow("discogs", false),
+				)
+			},
+			want: "pre-create the schema",
+		},
+		{
+			name: "schema creation",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("select exists").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+				mock.ExpectQuery("select current_database").WillReturnRows(
+					sqlmock.NewRows([]string{"name", "allowed"}).AddRow("discogs", true),
+				)
+				mock.ExpectExec("create schema").WillReturnError(expected)
+			},
+			want: "create database schema",
+		},
+		{
+			name: "schema privilege inspection",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("select exists").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+				mock.ExpectQuery("select has_schema_privilege").WillReturnError(expected)
+			},
+			want: "inspect privileges",
+		},
+		{
+			name: "schema privileges denied",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("select exists").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+				mock.ExpectQuery("select has_schema_privilege").WillReturnRows(
+					sqlmock.NewRows([]string{"allowed"}).AddRow(false),
+				)
+			},
+			want: "USAGE and CREATE",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock := newSchemaMock(t)
+			test.setup(mock)
+			_, err := EnsureSchema(db, requireSchema(t, "open_discogs"))
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `--database-schema` and `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` with `public` compatibility default
- emit a startup `WARN` to stderr whenever `public` is selected
- create a missing selected schema during normal startup, validate privileges, and apply canonical model migrations inside it
- route every import, progress, durability, and idempotency query through the selected schema
- document the pre-existing database requirement and schema ownership contract

## Validation

- `go vet ./...`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...` (100.0%)
- tagged dump-to-PostgreSQL E2E
- custom-schema full import, successful rerun skip, and public isolation
- non-root read-only Docker image `--help` and `--version`

## Release note

Feature/minor: operators can isolate all OpenDiscogs objects in a dedicated PostgreSQL schema without a separate init command.