### PR TITLE
fix: use official Discogs dump browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Discogs. The Discogs name identifies only the public data source.
 - Artist, label, master, and release select their newest available dump
   independently unless an exact `--dump-month` is requested.
 - Every run records the selected dump dates, SHA-256 checksums, source URIs,
-  sizes, and stable identifiers as one immutable manifest.
+  and stable identifiers as one immutable manifest.
 - A successful manifest is admitted and skipped before dump files are downloaded
   or checksummed only while all of its entity dumps are still the current
   checkpoints and no later failed or abandoned run has dirtied those entities.
@@ -38,6 +38,13 @@ Discogs. The Discogs name identifies only the public data source.
 
 If the upstream catalog refresh fails, the importer tries the catalog already
 stored in PostgreSQL. It fails if that catalog cannot satisfy the request.
+
+Catalog discovery and file downloads use the official `data.discogs.com` dump
+browser. Direct S3 bucket and object URLs are not part of this contract. The
+browser catalog exposes rounded display sizes, so new catalog rows store
+`size_bytes=0` instead of presenting an estimate as an exact byte count.
+Download progress uses the response `Content-Length` when supplied rather than
+this catalog field.
 
 ### Durability and idempotency boundaries
 

--- a/src/batch/runner_test.go
+++ b/src/batch/runner_test.go
@@ -41,27 +41,26 @@ func TestRunnerEndToEndAndSuccessfulSkip(t *testing.T) {
 	}
 
 	listing := new(strings.Builder)
-	listing.WriteString(`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
-	listing.WriteString(`<Contents><Key>data/2026/discogs_20260701_CHECKSUM.txt</Key></Contents>`)
+	listing.WriteString(`<a href="?download=data%2F2026%2Fdiscogs_20260701_CHECKSUM.txt">checksum</a>`)
 	checksums := new(strings.Builder)
-	fixtureByPath := make(map[string]runnerFixture, len(fixtures))
+	fixtureByURI := make(map[string]runnerFixture, len(fixtures))
 	for _, fixture := range fixtures {
-		fmt.Fprintf(listing, `<Contents><Key>data/2026/%s</Key></Contents>`, fixture.filename)
+		fmt.Fprintf(listing, `<a href="?download=data%%2F2026%%2F%s">%s</a>`, fixture.filename, fixture.filename)
 		fmt.Fprintf(checksums, "%s *%s\n", fixture.checksum, fixture.filename)
-		fixtureByPath["/data/2026/"+fixture.filename] = fixture
+		fixtureByURI["data/2026/"+fixture.filename] = fixture
 	}
-	listing.WriteString(`</ListBucketResult>`)
 
 	server := testserver.NewServer(func(
 		requests []*testserver.HttpRequest,
 		w http.ResponseWriter,
 		r *http.Request,
 	) {
-		if r.URL.Query().Has("download") {
+		download := r.URL.Query().Get("download")
+		if strings.HasSuffix(download, "CHECKSUM.txt") {
 			_, _ = w.Write([]byte(checksums.String()))
 			return
 		}
-		if fixture, ok := fixtureByPath[r.URL.Path]; ok {
+		if fixture, ok := fixtureByURI[download]; ok {
 			_, _ = w.Write(fixture.body)
 			return
 		}
@@ -69,12 +68,8 @@ func TestRunnerEndToEndAndSuccessfulSkip(t *testing.T) {
 	})
 	defer server.Close()
 
-	originalS3URL, originalDataURL := data.DiscogsS3BaseUrl, data.DiscogsDataBaseURL
-	t.Cleanup(func() {
-		data.DiscogsS3BaseUrl = originalS3URL
-		data.DiscogsDataBaseURL = originalDataURL
-	})
-	data.DiscogsS3BaseUrl = server.URL + "/"
+	originalDataURL := data.DiscogsDataBaseURL
+	t.Cleanup(func() { data.DiscogsDataBaseURL = originalDataURL })
 	data.DiscogsDataBaseURL = server.URL + "/"
 
 	postgres := testutils.GetDatabase(t, testutils.Postgres)

--- a/src/data/catalog.go
+++ b/src/data/catalog.go
@@ -1,0 +1,120 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	catalogPrefixParameter = "prefix"
+	downloadParameter      = "download"
+	dumpPathPrefix         = "data/"
+)
+
+var (
+	catalogAnchorPattern = regexp.MustCompile(`<a\s+href="([^"]+)"`)
+	catalogYearPattern   = regexp.MustCompile(`^data/(\d{4})/$`)
+	yearPattern          = regexp.MustCompile(`^\d{4}$`)
+)
+
+func fetchCatalogData(ctx context.Context, dumpMonth string) ([]*Data, error) {
+	year, err := resolveCatalogYear(ctx, dumpMonth)
+	if err != nil {
+		return nil, err
+	}
+	body, err := fetchBytes(ctx, catalogListingURL(year))
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s dump catalog: %w", year, err)
+	}
+	items := parseCatalogData(body)
+	if len(items) == 0 {
+		return nil, fmt.Errorf("%s dump catalog contains no supported files", year)
+	}
+	return items, nil
+}
+
+func resolveCatalogYear(ctx context.Context, dumpMonth string) (string, error) {
+	if dumpMonth != "" {
+		year, _, found := strings.Cut(dumpMonth, "-")
+		if !found || !yearPattern.MatchString(year) {
+			return "", fmt.Errorf("invalid dump month %q", dumpMonth)
+		}
+		return year, nil
+	}
+	body, err := fetchBytes(ctx, DiscogsDataBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch dump catalog index: %w", err)
+	}
+	return latestCatalogYear(body)
+}
+
+func latestCatalogYear(body []byte) (string, error) {
+	latest := ""
+	for _, href := range catalogHrefs(body) {
+		prefix := catalogQueryValue(href, catalogPrefixParameter)
+		match := catalogYearPattern.FindStringSubmatch(prefix)
+		if match != nil && match[1] > latest {
+			latest = match[1]
+		}
+	}
+	if latest == "" {
+		return "", fmt.Errorf("dump catalog index contains no years")
+	}
+	return latest, nil
+}
+
+func parseCatalogData(body []byte) []*Data {
+	items := make([]*Data, 0)
+	for _, href := range catalogHrefs(body) {
+		uri := catalogQueryValue(href, downloadParameter)
+		match := dumpUriPattern.FindStringSubmatch(uri)
+		if match == nil || !isKnownType(strings.ToLower(match[3])) {
+			continue
+		}
+		generatedAt, err := parseDumpDate(match[2])
+		if err != nil {
+			continue
+		}
+		items = append(items, &Data{
+			GeneratedAt: generatedAt,
+			TargetType:  strings.ToLower(match[3]),
+			Uri:         uri,
+		})
+	}
+	return items
+}
+
+func parseDumpDate(value string) (time.Time, error) {
+	return time.Parse(dumpDateLayout, value)
+}
+
+func catalogHrefs(body []byte) []string {
+	matches := catalogAnchorPattern.FindAllSubmatch(body, -1)
+	hrefs := make([]string, 0, len(matches))
+	for _, match := range matches {
+		hrefs = append(hrefs, html.UnescapeString(string(match[1])))
+	}
+	return hrefs
+}
+
+func catalogQueryValue(href string, parameter string) string {
+	parsed, err := url.Parse(href)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get(parameter)
+}
+
+func catalogListingURL(year string) string {
+	prefix := dumpPathPrefix + year + "/"
+	return DiscogsDataBaseURL + "?" + catalogPrefixParameter + "=" + url.QueryEscape(prefix)
+}
+
+func dataDownloadURL(uri string) string {
+	return DiscogsDataBaseURL + "?" + downloadParameter + "=" + url.QueryEscape(uri)
+}

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -22,8 +21,9 @@ import (
 	"github.com/reactivex/rxgo/v2"
 )
 
-var DiscogsS3BaseUrl = "https://discogs-data-dumps.s3.us-west-2.amazonaws.com/"
 var DiscogsDataBaseURL = "https://data.discogs.com/"
+
+const dumpDateLayout = "20060102"
 
 var dumpUriPattern = regexp.MustCompile(`^data/(\d{4})/discogs_(\d{8})_(\w+)\.(.*)$`)
 var checksumPattern = regexp.MustCompile(`^([^ ]+) +.*(\d{8})_([^.]+).*$`)
@@ -80,7 +80,7 @@ func parseChecksumTextLine(line string) (chk chkSumP, ok bool) {
 		return chk, false
 	}
 	c, g, t := match[1], match[2], match[3]
-	pt, err := time.Parse("20060102", g)
+	pt, err := time.Parse(dumpDateLayout, g)
 	if err != nil {
 		return chk, false
 	}
@@ -97,7 +97,7 @@ func PopulateFromUri() func(_ context.Context, i interface{}) (interface{}, erro
 		if match == nil {
 			return nil, fmt.Errorf("invalid dump URI: %s", dump.Uri)
 		}
-		t, err := time.Parse("20060102", match[2])
+		t, err := time.Parse(dumpDateLayout, match[2])
 		if err != nil {
 			return nil, fmt.Errorf("invalid dump date in URI %s: %w", dump.Uri, err)
 		}
@@ -123,7 +123,7 @@ func ValidUriFilter() func(i interface{}) bool {
 		if match == nil {
 			return false
 		}
-		if _, err := time.Parse("20060102", match[2]); err != nil {
+		if _, err := time.Parse(dumpDateLayout, match[2]); err != nil {
 			return false
 		}
 		return isKnownType(strings.ToLower(match[3]))
@@ -162,7 +162,7 @@ func DispatchChecksumFetch(store *checksumStore) func(context.Context, interface
 }
 
 func checksumDownloadURL(uri string) string {
-	return DiscogsDataBaseURL + "?download=" + url.QueryEscape(uri)
+	return dataDownloadURL(uri)
 }
 
 func SetChecksumValues(m map[time.Time]map[string]string) func(_ context.Context, i interface{}) (interface{}, error) {
@@ -210,16 +210,19 @@ func UpdateData(ctx context.Context, repo Repository, maxWorkers int) (int, erro
 	if maxWorkers <= 0 {
 		return -1, fmt.Errorf("max-workers must be a positive integer")
 	}
-	c := client.NewClient()
 	checksums := newChecksumStore()
+	catalogItems, err := fetchCatalogData(ctx, "")
+	if err != nil {
+		return -1, err
+	}
+	items := make([]interface{}, 0, len(catalogItems))
+	for _, item := range catalogItems {
+		items = append(items, item)
+	}
 
-	items, err := c.Get(ctx, DiscogsS3BaseUrl).
-		FlatMap(ParseDumpModel(ctx)).
-		Filter(NotNilFilter()).
-		Filter(ValidUriFilter()).
-		Map(PopulateFromUri()).
+	items, err = rxgo.Just(items...)().
 		Map(DispatchChecksumFetch(checksums), rxgo.WithPool(maxWorkers)).
-		ToSlice(400, rxgo.WithContext(ctx)) // known size: 777 and beyond
+		ToSlice(len(items), rxgo.WithContext(ctx))
 
 	if err != nil {
 		return -1, err
@@ -253,28 +256,18 @@ func BatchInsertItems(repo Repository) func(_ context.Context, i interface{}) (i
 	}
 }
 
-// UpdateSelectedData refreshes only the catalog rows needed by this invocation. It performs one
-// bucket listing request and at most one checksum request per selected dump date, preventing the
-// unbounded historical checksum fan-out of the legacy full-catalog refresh.
+// UpdateSelectedData refreshes only the catalog rows needed by this invocation. A pinned month
+// requires one catalog request; latest selection requires the index and latest-year catalog. It
+// fetches at most one checksum document per selected dump date.
 func UpdateSelectedData(
 	ctx context.Context,
 	repo Repository,
 	entities []string,
 	dumpMonth string,
 ) (int, error) {
-	items, err := client.NewClient().Get(ctx, DiscogsS3BaseUrl).
-		FlatMap(ParseDumpModel(ctx)).
-		Filter(NotNilFilter()).
-		Filter(ValidUriFilter()).
-		Map(PopulateFromUri()).
-		ToSlice(400, rxgo.WithContext(ctx))
+	all, err := fetchCatalogData(ctx, dumpMonth)
 	if err != nil {
 		return -1, err
-	}
-
-	all := make([]*Data, 0, len(items))
-	for _, item := range items {
-		all = append(all, item.(*Data))
 	}
 	candidates := selectRefreshCandidates(all, entities, dumpMonth)
 	checksumDocuments := make(map[time.Time]map[string]string)
@@ -419,7 +412,7 @@ func FetchImportResources(ctx context.Context, plan *ImportPlan) error {
 		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 			return fmt.Errorf("create %s import directory: %w", dump.EntityType, err)
 		}
-		resourceURI := DiscogsS3BaseUrl + dump.URI
+		resourceURI := dataDownloadURL(dump.URI)
 		if err := handler.FetchAndCheckContext(
 			ctx,
 			resourceURI,

--- a/src/data/data_test.go
+++ b/src/data/data_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,6 +30,135 @@ var validChecksumTextSliceSample = []string{
 	"8c40390a3e07b60e4eaa51dfb665a20a41a5ffc337644fb4420c6adea8ed8f50 *discogs_20080309_artists.xml.gz",
 	"36772fdcfd019c995fb16f0020a8876df96f522f76de1acfa632299255664e59 *discogs_20080309_labels.xml.gz",
 	"e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_20080309_releases.xml.gz",
+}
+
+var updateCatalogURIs = []string{
+	"data/2008/discogs_20080309_CHECKSUM.txt",
+	"data/2008/discogs_20080309_artists.xml.gz",
+	"data/2008/discogs_20080309_labels.xml.gz",
+	"data/2008/discogs_20080309_releases.xml.gz",
+}
+
+func catalogIndexFixture(years ...string) []byte {
+	var body strings.Builder
+	for _, year := range years {
+		fmt.Fprintf(&body, `<a href="?prefix=%s">%s/</a>`, url.QueryEscape("data/"+year+"/"), year)
+	}
+	return []byte(body.String())
+}
+
+func catalogListingFixture(uris ...string) []byte {
+	var body strings.Builder
+	for _, uri := range uris {
+		body.Write(catalogDownloadLink(uri))
+	}
+	return []byte(body.String())
+}
+
+func catalogDownloadLink(uri string) []byte {
+	return []byte(fmt.Sprintf(`<a href="?download=%s">fixture</a>`, url.QueryEscape(uri)))
+}
+
+func TestCatalogParsing(t *testing.T) {
+	t.Run("selects latest year", func(t *testing.T) {
+		year, err := latestCatalogYear(append(
+			catalogIndexFixture("2024", "2026", "2025"),
+			[]byte(`<a href="?prefix=data%2Finvalid%2F&amp;ignored=true">invalid</a>`)...,
+		))
+		require.NoError(t, err)
+		require.Equal(t, "2026", year)
+	})
+
+	t.Run("rejects index without years", func(t *testing.T) {
+		year, err := latestCatalogYear([]byte(`<a href="?download=fixture">fixture</a>`))
+		require.Empty(t, year)
+		require.ErrorContains(t, err, "contains no years")
+	})
+
+	t.Run("parses only supported valid dump links", func(t *testing.T) {
+		body := catalogListingFixture(
+			"data/2026/discogs_20260801_artists.xml.gz",
+			"data/2026/discogs_20260801_unknown.xml.gz",
+			"data/2026/discogs_20261301_labels.xml.gz",
+			"invalid",
+		)
+		items := parseCatalogData(body)
+		require.Len(t, items, 1)
+		require.Equal(t, "artists", items[0].TargetType)
+		require.Equal(t, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), items[0].GeneratedAt)
+	})
+
+	t.Run("handles malformed link URL", func(t *testing.T) {
+		require.Empty(t, catalogQueryValue("%invalid", downloadParameter))
+	})
+}
+
+func TestResolveCatalogYear(t *testing.T) {
+	t.Run("uses pinned year without request", func(t *testing.T) {
+		year, err := resolveCatalogYear(context.Background(), "2026-08")
+		require.NoError(t, err)
+		require.Equal(t, "2026", year)
+	})
+
+	for _, dumpMonth := range []string{"2026", "26-08"} {
+		t.Run("rejects "+dumpMonth, func(t *testing.T) {
+			year, err := resolveCatalogYear(context.Background(), dumpMonth)
+			require.Empty(t, year)
+			require.ErrorContains(t, err, "invalid dump month")
+		})
+	}
+
+	t.Run("reports index request failure", func(t *testing.T) {
+		server := testserver.NewServer(func(
+			requests []*testserver.HttpRequest,
+			w http.ResponseWriter,
+			r *http.Request,
+		) {
+			http.Error(w, "fixture", http.StatusServiceUnavailable)
+		})
+		defer server.Close()
+		origin := DiscogsDataBaseURL
+		t.Cleanup(func() { DiscogsDataBaseURL = origin })
+		DiscogsDataBaseURL = server.URL
+
+		year, err := resolveCatalogYear(context.Background(), "")
+		require.Empty(t, year)
+		require.ErrorContains(t, err, "fetch dump catalog index")
+	})
+}
+
+func TestFetchCatalogDataErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "listing request", want: "fetch 2026 dump catalog"},
+		{name: "empty listing", body: "<html></html>", want: "contains no supported files"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := testserver.NewServer(func(
+				requests []*testserver.HttpRequest,
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				if test.body == "" {
+					http.Error(w, "fixture", http.StatusServiceUnavailable)
+					return
+				}
+				_, _ = w.Write([]byte(test.body))
+			})
+			defer server.Close()
+			origin := DiscogsDataBaseURL
+			t.Cleanup(func() { DiscogsDataBaseURL = origin })
+			DiscogsDataBaseURL = server.URL
+
+			items, err := fetchCatalogData(context.Background(), "2026-08")
+			require.Nil(t, items)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
 }
 
 func Test_parseChecksumTextLine(t *testing.T) {
@@ -347,27 +477,23 @@ func (r *RepositoryStub) FindLatestByType(typ string) (*opendiscogsmodel.Discogs
 }
 
 func TestUpdateData(t *testing.T) {
-	data := resource.Read("testdata/update-data-test.xml")
+	listing := catalogListingFixture(updateCatalogURIs...)
 	server := testserver.NewServer(func(requests []*testserver.HttpRequest, w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
 		if r.URL.Query().Get("download") == "data/2008/discogs_20080309_CHECKSUM.txt" {
 			_, _ = w.Write([]byte(`8c40390a3e07b60e4eaa51dfb665a20a41a5ffc337644fb4420c6adea8ed8f50 *discogs_20080309_artists.xml.gz
 36772fdcfd019c995fb16f0020a8876df96f522f76de1acfa632299255664e59 *discogs_20080309_labels.xml.gz
 e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_20080309_releases.xml.gz\n`))
-		} else if len(path) == 0 || path == "/" {
-			_, _ = w.Write(data)
+		} else if r.URL.Query().Has("prefix") {
+			_, _ = w.Write(listing)
+		} else {
+			_, _ = w.Write(catalogIndexFixture("2008"))
 		}
 	})
 	defer server.Close()
 
 	t.Run("UpdateDate updates items", func(t *testing.T) {
-		s3Origin := DiscogsS3BaseUrl
 		dataOrigin := DiscogsDataBaseURL
-		defer func() {
-			DiscogsS3BaseUrl = s3Origin
-			DiscogsDataBaseURL = dataOrigin
-		}()
-		DiscogsS3BaseUrl = server.URL + "/"
+		defer func() { DiscogsDataBaseURL = dataOrigin }()
 		DiscogsDataBaseURL = server.URL + "/"
 		repo := &RepositoryStub{items: make([]*Data, 0)}
 		updateCount, err := UpdateData(context.Background(), repo, 2)
@@ -375,7 +501,6 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 		require.Equal(t, 4, updateCount)
 		require.Len(t, repo.items, 4)
 		for _, item := range repo.items {
-			require.NotEmpty(t, item.ETag)
 			require.NotEmpty(t, item.GeneratedAt)
 			require.NotEmpty(t, item.TargetType)
 			if item.TargetType != "checksum" {
@@ -400,9 +525,34 @@ func TestUpdateDataPropagatesListingFailure(t *testing.T) {
 		http.Error(w, "fixture", http.StatusInternalServerError)
 	})
 	defer server.Close()
-	originalURL := DiscogsS3BaseUrl
-	t.Cleanup(func() { DiscogsS3BaseUrl = originalURL })
-	DiscogsS3BaseUrl = server.URL
+	originalURL := DiscogsDataBaseURL
+	t.Cleanup(func() { DiscogsDataBaseURL = originalURL })
+	DiscogsDataBaseURL = server.URL
+
+	updated, err := UpdateData(context.Background(), &RepositoryStub{}, 1)
+	require.Equal(t, -1, updated)
+	require.Error(t, err)
+}
+
+func TestUpdateDataPropagatesChecksumFailure(t *testing.T) {
+	server := testserver.NewServer(func(
+		requests []*testserver.HttpRequest,
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		switch {
+		case r.URL.Query().Has(downloadParameter):
+			http.Error(w, "fixture", http.StatusServiceUnavailable)
+		case r.URL.Query().Has(catalogPrefixParameter):
+			_, _ = w.Write(catalogListingFixture(updateCatalogURIs...))
+		default:
+			_, _ = w.Write(catalogIndexFixture("2008"))
+		}
+	})
+	defer server.Close()
+	originalURL := DiscogsDataBaseURL
+	t.Cleanup(func() { DiscogsDataBaseURL = originalURL })
+	DiscogsDataBaseURL = server.URL
 
 	updated, err := UpdateData(context.Background(), &RepositoryStub{}, 1)
 	require.Equal(t, -1, updated)
@@ -425,7 +575,7 @@ func TestCatalogUpdateCount(t *testing.T) {
 }
 
 func TestUpdateSelectedDataBoundsChecksumRequests(t *testing.T) {
-	listing := resource.Read("testdata/update-data-test.xml")
+	listing := catalogListingFixture(updateCatalogURIs...)
 	server := testserver.NewServer(func(requests []*testserver.HttpRequest, w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("download") == "data/2008/discogs_20080309_CHECKSUM.txt" {
 			_, _ = w.Write([]byte(`8c40390a3e07b60e4eaa51dfb665a20a41a5ffc337644fb4420c6adea8ed8f50 *discogs_20080309_artists.xml.gz
@@ -438,12 +588,8 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 	})
 	defer server.Close()
 
-	s3Origin, dataOrigin := DiscogsS3BaseUrl, DiscogsDataBaseURL
-	defer func() {
-		DiscogsS3BaseUrl = s3Origin
-		DiscogsDataBaseURL = dataOrigin
-	}()
-	DiscogsS3BaseUrl = server.URL + "/"
+	dataOrigin := DiscogsDataBaseURL
+	defer func() { DiscogsDataBaseURL = dataOrigin }()
 	DiscogsDataBaseURL = server.URL + "/"
 	repo := &RepositoryStub{}
 
@@ -451,7 +597,7 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 		context.Background(),
 		repo,
 		[]string{"artist", "label", "release"},
-		"",
+		"2008-03",
 	)
 
 	require.NoError(t, err)
@@ -461,7 +607,7 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 }
 
 func TestUpdateSelectedDataErrorBoundaries(t *testing.T) {
-	listing := resource.Read("testdata/update-data-test.xml")
+	listing := catalogListingFixture(updateCatalogURIs...)
 	tests := []struct {
 		name            string
 		listingResponse []byte
@@ -471,7 +617,7 @@ func TestUpdateSelectedDataErrorBoundaries(t *testing.T) {
 	}{
 		{
 			name:            "missing checksum manifest",
-			listingResponse: bytes.Replace(listing, checksumContents(listing), nil, 1),
+			listingResponse: bytes.Replace(listing, catalogDownloadLink(updateCatalogURIs[0]), nil, 1),
 			checksumStatus:  http.StatusOK,
 			want:            "checksum manifest not found",
 		},
@@ -504,36 +650,20 @@ func TestUpdateSelectedDataErrorBoundaries(t *testing.T) {
 				_, _ = w.Write(test.listingResponse)
 			})
 			defer server.Close()
-			originalS3URL, originalDataURL := DiscogsS3BaseUrl, DiscogsDataBaseURL
-			t.Cleanup(func() {
-				DiscogsS3BaseUrl = originalS3URL
-				DiscogsDataBaseURL = originalDataURL
-			})
-			DiscogsS3BaseUrl = server.URL
+			originalDataURL := DiscogsDataBaseURL
+			t.Cleanup(func() { DiscogsDataBaseURL = originalDataURL })
 			DiscogsDataBaseURL = server.URL
 
 			updated, err := UpdateSelectedData(
 				context.Background(),
 				&RepositoryStub{},
 				[]string{"artist"},
-				"",
+				"2008-03",
 			)
 			require.Equal(t, -1, updated)
 			require.ErrorContains(t, err, test.want)
 		})
 	}
-}
-
-func checksumContents(listing []byte) []byte {
-	start := bytes.Index(listing, []byte("    <Contents>"))
-	if start < 0 {
-		return nil
-	}
-	end := bytes.Index(listing[start:], []byte("    </Contents>"))
-	if end < 0 {
-		return nil
-	}
-	return listing[start : start+end+len("    </Contents>")]
 }
 
 func TestUpdateSelectedDataPropagatesListingFailure(t *testing.T) {
@@ -545,9 +675,9 @@ func TestUpdateSelectedDataPropagatesListingFailure(t *testing.T) {
 		http.Error(w, "fixture", http.StatusInternalServerError)
 	})
 	defer server.Close()
-	originalURL := DiscogsS3BaseUrl
-	t.Cleanup(func() { DiscogsS3BaseUrl = originalURL })
-	DiscogsS3BaseUrl = server.URL
+	originalURL := DiscogsDataBaseURL
+	t.Cleanup(func() { DiscogsDataBaseURL = originalURL })
+	DiscogsDataBaseURL = server.URL
 
 	updated, err := UpdateSelectedData(context.Background(), &RepositoryStub{}, []string{"artist"}, "")
 	require.Equal(t, -1, updated)
@@ -589,8 +719,7 @@ func TestFetchFiles(t *testing.T) {
 
 	h := file.NewHandler()
 	server := testserver.NewServer(func(requests []*testserver.HttpRequest, w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		if path == "/fetch-data-result" {
+		if r.URL.Query().Get(downloadParameter) == "fetch-data-result" {
 			data := resource.Read("testdata/fetch-data-test.xml")
 			w.WriteHeader(200)
 			w.Header().Add("Content-Length", strconv.Itoa(len(data)))
@@ -623,9 +752,9 @@ data-dir: testdata
 
 	t.Run("must return items when valid", func(t *testing.T) {
 		t.Cleanup(func() { _ = h.Delete("testdata/fetch-data-result") })
-		origin := DiscogsS3BaseUrl
-		defer func() { DiscogsS3BaseUrl = origin }()
-		DiscogsS3BaseUrl = server.URL + "/"
+		origin := DiscogsDataBaseURL
+		defer func() { DiscogsDataBaseURL = origin }()
+		DiscogsDataBaseURL = server.URL + "/"
 		k := koanf.New(".")
 		err := k.Load(rawbytes.Provider([]byte(`
 entities:
@@ -669,9 +798,9 @@ data-dir: testdata
 	})
 
 	t.Run("must report error when checksum failed", func(t *testing.T) {
-		origin := DiscogsS3BaseUrl
-		defer func() { DiscogsS3BaseUrl = origin }()
-		DiscogsS3BaseUrl = server.URL + "/"
+		origin := DiscogsDataBaseURL
+		defer func() { DiscogsDataBaseURL = origin }()
+		DiscogsDataBaseURL = server.URL + "/"
 		k := koanf.New(".")
 		err := k.Load(rawbytes.Provider([]byte(`
 entities:
@@ -706,9 +835,9 @@ func TestResolveImportPlanDoesNotDownload(t *testing.T) {
 		t.Fatalf("resolve import plan must not request %s", r.URL.String())
 	})
 	defer server.Close()
-	origin := DiscogsS3BaseUrl
-	defer func() { DiscogsS3BaseUrl = origin }()
-	DiscogsS3BaseUrl = server.URL + "/"
+	origin := DiscogsDataBaseURL
+	defer func() { DiscogsDataBaseURL = origin }()
+	DiscogsDataBaseURL = server.URL + "/"
 
 	dataDirectory := filepath.Join(t.TempDir(), "not-created")
 	config := koanf.New(".")


### PR DESCRIPTION
## Summary
- discover dump years and files through the official data.discogs.com browser
- download checksums and dump files through the official download query instead of inaccessible direct S3 URLs
- retain bounded selected-catalog refresh behavior and document unavailable exact catalog sizes

## Why
The S3 bucket listing and direct object endpoints now return HTTP 403, so a fresh v2.3.1 import cannot refresh its catalog or download files. The official dump browser remains available.

## Verification
- official 2026-08 catalog returned artist, label, master, and release entries
- official 2026-08 checksum document returned all four SHA-256 values
- gofmt and go mod tidy diff check
- go vet ./...
- go test -race -coverprofile=coverage.out -covermode=atomic ./...
- total statement coverage: 100.0%
- Docker residue after integration tests: zero containers and no new networks or volumes