### PR TITLE
fix: cache pinned dump catalogs before refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Discogs. The Discogs name identifies only the public data source.
 If the upstream catalog refresh fails, the importer tries the catalog already
 stored in PostgreSQL. It fails if that catalog cannot satisfy the request.
 
+An exact `--dump-month` uses a complete matching PostgreSQL catalog entry before
+contacting Discogs. If any selected entity is missing, dumps from 2021 onward
+are resolved with one monthly checksum request; its filenames and SHA-256 values
+define all selected download URIs. Older dumps have irregular publication dates,
+so they require one annual catalog request and one checksum request. The importer
+stores every selected URI and checksum before downloading files. Retries of that
+pinned month reuse the stored catalog without another metadata request. A 429,
+5xx, timeout, or malformed response fails the refresh without speculative extra
+requests. Latest-per-entity selection still refreshes upstream first because the
+local database cannot prove that no newer dump exists.
+
 Catalog discovery and file downloads use the official `data.discogs.com` dump
 browser. Direct S3 bucket and object URLs are not part of this contract. The
 browser catalog exposes rounded display sizes, so new catalog rows store

--- a/src/batch/catalog_plan_test.go
+++ b/src/batch/catalog_plan_test.go
@@ -1,0 +1,197 @@
+package batch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dsub-io/go-open-discogs-batch/src/data"
+	"github.com/knadh/koanf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCatalogPlanUsesPinnedCacheWithoutRefresh(t *testing.T) {
+	config := catalogPlanConfig(t, "2026-08")
+	expected := &data.ImportPlan{}
+	resolveCalls := 0
+	refreshCalls := 0
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			resolveCalls++
+			return expected, nil
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			refreshCalls++
+			return 0, nil
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.NoError(t, err)
+	require.Same(t, expected, plan)
+	require.Equal(t, 1, resolveCalls)
+	require.Zero(t, refreshCalls)
+}
+
+func TestResolveCatalogPlanRefreshesMissingPinnedCacheOnce(t *testing.T) {
+	config := catalogPlanConfig(t, "2026-08")
+	expected := &data.ImportPlan{}
+	resolveCalls := 0
+	refreshCalls := 0
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			resolveCalls++
+			if resolveCalls == 1 {
+				return nil, errors.New("cache miss")
+			}
+			return expected, nil
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			refreshCalls++
+			return 4, nil
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.NoError(t, err)
+	require.Same(t, expected, plan)
+	require.Equal(t, 2, resolveCalls)
+	require.Equal(t, 1, refreshCalls)
+}
+
+func TestResolveCatalogPlanReturnsPinnedRefreshAndResolutionErrors(t *testing.T) {
+	config := catalogPlanConfig(t, "2026-08")
+	cacheErr := errors.New("cache miss")
+	refreshErr := errors.New("refresh failed")
+	resolveCalls := 0
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			resolveCalls++
+			return nil, cacheErr
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			return 0, refreshErr
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.Nil(t, plan)
+	require.ErrorIs(t, err, cacheErr)
+	require.ErrorIs(t, err, refreshErr)
+	require.Equal(t, 1, resolveCalls)
+}
+
+func TestResolveCatalogPlanReturnsPinnedPostRefreshResolutionError(t *testing.T) {
+	config := catalogPlanConfig(t, "2026-08")
+	cacheErr := errors.New("cache miss")
+	resolveErr := errors.New("still missing")
+	resolveCalls := 0
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			resolveCalls++
+			if resolveCalls == 1 {
+				return nil, cacheErr
+			}
+			return nil, resolveErr
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			return 4, nil
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.Nil(t, plan)
+	require.ErrorIs(t, err, resolveErr)
+	require.Equal(t, 2, resolveCalls)
+}
+
+func TestResolveCatalogPlanRefreshesLatestBeforeResolution(t *testing.T) {
+	config := catalogPlanConfig(t, "")
+	expected := &data.ImportPlan{}
+	refreshCalls := 0
+	resolveCalls := 0
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			resolveCalls++
+			return expected, nil
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			refreshCalls++
+			return 4, nil
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.NoError(t, err)
+	require.Same(t, expected, plan)
+	require.Equal(t, 1, refreshCalls)
+	require.Equal(t, 1, resolveCalls)
+}
+
+func TestResolveCatalogPlanFallsBackToLatestCache(t *testing.T) {
+	config := catalogPlanConfig(t, "")
+	expected := &data.ImportPlan{}
+	refreshErr := errors.New("refresh failed")
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			return expected, nil
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			return 0, refreshErr
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.NoError(t, err)
+	require.Same(t, expected, plan)
+}
+
+func TestResolveCatalogPlanReturnsLatestRefreshAndResolutionErrors(t *testing.T) {
+	config := catalogPlanConfig(t, "")
+	refreshErr := errors.New("refresh failed")
+	resolveErr := errors.New("cache miss")
+	installCatalogPlanSeams(t,
+		func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) {
+			return nil, resolveErr
+		},
+		func(context.Context, data.Repository, []string, string) (int, error) {
+			return 0, refreshErr
+		},
+	)
+
+	plan, err := resolveCatalogPlan(context.Background(), config, nil)
+
+	require.Nil(t, plan)
+	require.ErrorIs(t, err, refreshErr)
+	require.ErrorIs(t, err, resolveErr)
+}
+
+func catalogPlanConfig(t *testing.T, dumpMonth string) *koanf.Koanf {
+	t.Helper()
+	config := koanf.New(".")
+	require.NoError(t, config.Set("entities", []string{"artist", "label", "master", "release"}))
+	require.NoError(t, config.Set("dump-month", dumpMonth))
+	return config
+}
+
+func installCatalogPlanSeams(
+	t *testing.T,
+	resolve func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error),
+	refresh func(context.Context, data.Repository, []string, string) (int, error),
+) {
+	t.Helper()
+	originalResolve := resolveImportPlan
+	originalRefresh := refreshSelectedData
+	t.Cleanup(func() {
+		resolveImportPlan = originalResolve
+		refreshSelectedData = originalRefresh
+	})
+	resolveImportPlan = resolve
+	refreshSelectedData = refresh
+}

--- a/src/batch/runner.go
+++ b/src/batch/runner.go
@@ -82,22 +82,9 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 	}
 
 	dataRepo := data.NewDataRepository(database.DB)
-	fmt.Println("refreshing dump catalog...")
-	updated, updateErr := refreshSelectedData(
-		ctx,
-		dataRepo,
-		config.Strings("entities"),
-		config.String("dump-month"),
-	)
-	if updateErr != nil {
-		fmt.Printf("dump catalog refresh failed; trying cached catalog: %v\n", updateErr)
-	} else {
-		fmt.Printf("dump catalog refresh affected: %+v rows\n", updated)
-	}
-
-	plan, err := resolveImportPlan(config, dataRepo)
+	plan, err := resolveCatalogPlan(ctx, config, dataRepo)
 	if err != nil {
-		return errors.Join(updateErr, err)
+		return err
 	}
 
 	sqlDB, err := openSQLDatabase(database.DB)
@@ -163,6 +150,59 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 	err = finalizeImport(ctx, coordinator, plan, config.Bool("cleanup"), err)
 	printResult(begin, totalUpdates, err)
 	return err
+}
+
+func resolveCatalogPlan(
+	ctx context.Context,
+	config *koanf.Koanf,
+	repository data.Repository,
+) (*data.ImportPlan, error) {
+	dumpMonth := config.String("dump-month")
+	if dumpMonth != "" {
+		plan, cacheErr := resolveImportPlan(config, repository)
+		if cacheErr == nil {
+			fmt.Printf("using cached dump catalog for %s\n", dumpMonth)
+			return plan, nil
+		}
+		fmt.Printf("cached dump catalog unavailable for %s; refreshing once\n", dumpMonth)
+		if _, refreshErr := refreshDumpCatalog(ctx, config, repository); refreshErr != nil {
+			return nil, errors.Join(refreshErr, cacheErr)
+		}
+		plan, err := resolveImportPlan(config, repository)
+		if err != nil {
+			return nil, err
+		}
+		return plan, nil
+	}
+
+	_, refreshErr := refreshDumpCatalog(ctx, config, repository)
+	if refreshErr != nil {
+		fmt.Printf("dump catalog refresh failed; trying cached catalog: %v\n", refreshErr)
+	}
+	plan, err := resolveImportPlan(config, repository)
+	if err != nil {
+		return nil, errors.Join(refreshErr, err)
+	}
+	return plan, nil
+}
+
+func refreshDumpCatalog(
+	ctx context.Context,
+	config *koanf.Koanf,
+	repository data.Repository,
+) (int, error) {
+	fmt.Println("refreshing dump catalog...")
+	updated, err := refreshSelectedData(
+		ctx,
+		repository,
+		config.Strings("entities"),
+		config.String("dump-month"),
+	)
+	if err != nil {
+		return 0, err
+	}
+	fmt.Printf("dump catalog refresh affected: %+v rows\n", updated)
+	return updated, nil
 }
 
 func finalizeImport(

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -23,7 +23,10 @@ import (
 
 var DiscogsDataBaseURL = "https://data.discogs.com/"
 
-const dumpDateLayout = "20060102"
+const (
+	dumpDateLayout                 = "20060102"
+	directChecksumCatalogStartYear = 2021
+)
 
 var dumpUriPattern = regexp.MustCompile(`^data/(\d{4})/discogs_(\d{8})_(\w+)\.(.*)$`)
 var checksumPattern = regexp.MustCompile(`^([^ ]+) +.*(\d{8})_([^.]+).*$`)
@@ -256,15 +259,30 @@ func BatchInsertItems(repo Repository) func(_ context.Context, i interface{}) (i
 	}
 }
 
-// UpdateSelectedData refreshes only the catalog rows needed by this invocation. A pinned month
-// requires one catalog request; latest selection requires the index and latest-year catalog. It
-// fetches at most one checksum document per selected dump date.
+// UpdateSelectedData refreshes only the catalog rows needed by this invocation. Modern pinned
+// months are resolved from one checksum document. Older irregularly dated dumps use one annual
+// catalog request and one checksum request. Latest selection uses the index, latest-year catalog,
+// and at most one checksum document per selected dump date.
 func UpdateSelectedData(
 	ctx context.Context,
 	repo Repository,
 	entities []string,
 	dumpMonth string,
 ) (int, error) {
+	if dumpMonth != "" {
+		month, parseErr := time.Parse("2006-01", dumpMonth)
+		if parseErr != nil {
+			return -1, fmt.Errorf("invalid dump month %q: %w", dumpMonth, parseErr)
+		}
+		if month.Year() >= directChecksumCatalogStartYear {
+			candidates, fetchErr := fetchPinnedChecksumData(ctx, entities, month)
+			if fetchErr != nil {
+				return -1, fetchErr
+			}
+			return repo.BatchInsert(candidates)
+		}
+	}
+
 	all, err := fetchCatalogData(ctx, dumpMonth)
 	if err != nil {
 		return -1, err
@@ -310,6 +328,62 @@ func UpdateSelectedData(
 		candidate.Checksum = checksum
 	}
 	return repo.BatchInsert(candidates)
+}
+
+func fetchPinnedChecksumData(
+	ctx context.Context,
+	entities []string,
+	month time.Time,
+) ([]*Data, error) {
+	manifestDate := time.Date(month.Year(), month.Month(), 1, 0, 0, 0, 0, time.UTC)
+	manifestURI := fmt.Sprintf(
+		"%s%d/discogs_%s_CHECKSUM.txt",
+		dumpPathPrefix,
+		manifestDate.Year(),
+		manifestDate.Format(dumpDateLayout),
+	)
+	body, err := fetchBytes(ctx, checksumDownloadURL(manifestURI))
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s checksum manifest: %w", month.Format("2006-01"), err)
+	}
+	byType := make(map[string]*Data)
+	for _, line := range strings.Split(string(body), "\n") {
+		checksum, ok := parseChecksumTextLine(line)
+		if !ok || checksum.gen.Format("2006-01") != month.Format("2006-01") {
+			continue
+		}
+		entityType := strings.ToLower(checksum.typ)
+		if entityType == "checksum" || !isKnownType(entityType) {
+			continue
+		}
+		byType[entityType] = &Data{
+			GeneratedAt: checksum.gen,
+			Checksum:    checksum.chk,
+			TargetType:  entityType,
+			Uri: fmt.Sprintf(
+				"%s%d/discogs_%s_%s.xml.gz",
+				dumpPathPrefix,
+				checksum.gen.Year(),
+				checksum.gen.Format(dumpDateLayout),
+				entityType,
+			),
+		}
+	}
+
+	candidates := make([]*Data, 0, len(entities))
+	for _, entity := range entities {
+		entityType := strings.TrimSuffix(strings.ToLower(entity), "s") + "s"
+		candidate := byType[entityType]
+		if candidate == nil {
+			return nil, fmt.Errorf(
+				"checksum not found for %s %s",
+				month.Format("2006-01"),
+				entityType,
+			)
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates, nil
 }
 
 func selectRefreshCandidates(items []*Data, entities []string, dumpMonth string) []*Data {

--- a/src/data/data_test.go
+++ b/src/data/data_test.go
@@ -606,6 +606,110 @@ e0e22f8501c2013eda69071a16e35ff785c0a135dee009fe2b67349f907709eb *discogs_200803
 	require.Len(t, server.Requests(), 2, "one listing plus one shared-date checksum request")
 }
 
+func TestUpdateSelectedDataUsesOneRequestForModernPinnedMonth(t *testing.T) {
+	const checksumBody = `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa *discogs_20260801_artists.xml.gz
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb *discogs_20260801_labels.xml.gz
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc *discogs_20260801_masters.xml.gz
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd *discogs_20260801_releases.xml.gz
+`
+	server := testserver.NewServer(func(
+		requests []*testserver.HttpRequest,
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		require.Equal(t, "data/2026/discogs_20260801_CHECKSUM.txt", r.URL.Query().Get(downloadParameter))
+		_, _ = w.Write([]byte(checksumBody))
+	})
+	defer server.Close()
+	originalURL := DiscogsDataBaseURL
+	t.Cleanup(func() { DiscogsDataBaseURL = originalURL })
+	DiscogsDataBaseURL = server.URL
+	repository := &RepositoryStub{}
+
+	updated, err := UpdateSelectedData(
+		context.Background(),
+		repository,
+		[]string{"artist", "label", "master", "release"},
+		"2026-08",
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 4, updated)
+	require.Len(t, repository.items, 4)
+	require.Len(t, server.Requests(), 1)
+	for _, item := range repository.items {
+		require.Equal(t, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), item.GeneratedAt)
+		require.NotEmpty(t, item.Checksum)
+		require.Contains(t, item.Uri, "data/2026/discogs_20260801_")
+	}
+}
+
+func TestUpdateSelectedDataModernPinnedErrorsDoNotFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		dumpMonth string
+		want      string
+		wantCalls int
+	}{
+		{
+			name:      "rate limited",
+			status:    http.StatusTooManyRequests,
+			dumpMonth: "2026-08",
+			want:      "429 Too Many Requests",
+			wantCalls: 1,
+		},
+		{
+			name:      "missing selected checksum",
+			status:    http.StatusOK,
+			body:      "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee *discogs_20260801_unknown.xml.gz",
+			dumpMonth: "2026-08",
+			want:      "checksum not found",
+			wantCalls: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := testserver.NewServer(func(
+				requests []*testserver.HttpRequest,
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.body))
+			})
+			defer server.Close()
+			originalURL := DiscogsDataBaseURL
+			t.Cleanup(func() { DiscogsDataBaseURL = originalURL })
+			DiscogsDataBaseURL = server.URL
+
+			updated, err := UpdateSelectedData(
+				context.Background(),
+				&RepositoryStub{},
+				[]string{"artist"},
+				test.dumpMonth,
+			)
+
+			require.Equal(t, -1, updated)
+			require.ErrorContains(t, err, test.want)
+			require.Len(t, server.Requests(), test.wantCalls)
+		})
+	}
+}
+
+func TestUpdateSelectedDataRejectsInvalidPinnedMonth(t *testing.T) {
+	updated, err := UpdateSelectedData(
+		context.Background(),
+		&RepositoryStub{},
+		[]string{"artist"},
+		"invalid",
+	)
+
+	require.Equal(t, -1, updated)
+	require.ErrorContains(t, err, "invalid dump month")
+}
+
 func TestUpdateSelectedDataErrorBoundaries(t *testing.T) {
 	listing := catalogListingFixture(updateCatalogURIs...)
 	tests := []struct {


### PR DESCRIPTION
## Summary
- resolve an exact dump month from PostgreSQL before contacting Discogs
- populate 2021+ pinned months from one checksum request containing all selected filenames and SHA-256 values
- retain the annual catalog path only for older irregularly dated dumps
- stop immediately on 429, 5xx, timeout, or malformed modern checksum responses without speculative follow-up requests
- document metadata request counts and retry behavior

## Request contract
- complete pinned cache: 0 upstream metadata requests
- uncached pinned month from 2021 onward: exactly 1 checksum request
- uncached older pinned month: 1 annual catalog request plus 1 checksum request
- latest selection: bounded refresh remains required

## Verification
- modern four-entity pinned month resolved with exactly one fixture request
- 429 fixture made exactly one request and did not fall back
- cache hit made zero refresh calls
- gofmt, module metadata, and go vet passed
- go test -race -coverprofile=coverage.out -covermode=atomic ./...
- total statement coverage: 100.0%
- tagged dump-to-PostgreSQL E2E passed
- Docker residue after tests: zero containers and no new networks or volumes

No live Discogs request was made while developing or testing this change.