### PR TITLE
fix: prevent batch deadlocks and preserve progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,16 @@ import.
 
 ### Progress observability
 
-Download bars use the upstream-reported compressed size. Source-reading bars
-use the exact local compressed file size as their byte denominator and display
-percentage, byte throughput, elapsed time, and source ETA. A source-reading
-percentage describes how much of the gzip stream has been consumed; it does not
-claim that the same percentage of PostgreSQL work has committed.
+When stderr is a terminal, downloads and source reads display an interactive
+progress bar on stderr. Line-delimited `byte_progress` JSON records are emitted
+on stdout at start, at most once every five seconds, and at completion or
+failure. The records include stage, resource, completed and total compressed
+bytes, percentage, byte throughput, and elapsed time. Redirecting or piping
+stdout through tools such as `tee` therefore remains parseable without removing
+the terminal bar. A source-read percentage describes how much of the gzip
+stream has been consumed; it does not claim that the same percentage of
+PostgreSQL work has committed. Do not merge stderr into stdout when collecting
+structured output.
 
 Tracked entity convergence also writes JSON progress records to stdout at
 start, at most once every five seconds while chunks finish, and at completion

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0
+	golang.org/x/term v0.45.0
 	gorm.io/driver/postgres v1.6.2
 	gorm.io/gorm v1.31.2
 )
@@ -25,10 +26,12 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.4 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.3.0 // indirect
 	github.com/moby/moby/client v0.5.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 )
@@ -62,7 +65,6 @@ require (
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260627054121-477a66015f15 // indirect
 	github.com/magiconair/properties v1.18.11 // indirect
-	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -75,7 +77,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/teivah/onecontext v1.3.0 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
@@ -89,7 +90,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/progress/reporter.go
+++ b/internal/progress/reporter.go
@@ -1,0 +1,271 @@
+package progress
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/schollz/progressbar/v3"
+	"io"
+	"sync"
+	"time"
+)
+
+const (
+	EventByteProgress = "byte_progress"
+	StageDownload     = "download"
+	StageSourceRead   = "source_read"
+
+	stateStarted   = "started"
+	stateRunning   = "running"
+	stateCompleted = "completed"
+	stateFailed    = "failed"
+
+	defaultReportInterval = 5 * time.Second
+)
+
+type Record struct {
+	Event          string  `json:"event"`
+	State          string  `json:"state"`
+	Stage          string  `json:"stage"`
+	Resource       string  `json:"resource"`
+	CompletedBytes int64   `json:"completed_bytes"`
+	TotalBytes     int64   `json:"total_bytes"`
+	Percent        float64 `json:"percent"`
+	BytesPerSecond float64 `json:"bytes_per_second"`
+	ElapsedSeconds float64 `json:"elapsed_seconds"`
+}
+
+type Reporter struct {
+	mu             sync.Mutex
+	output         io.Writer
+	terminalOutput io.Writer
+	bar            *progressbar.ProgressBar
+	stage          string
+	resource       string
+	totalBytes     int64
+	completedBytes int64
+	startedAt      time.Time
+	lastReportedAt time.Time
+	interval       time.Duration
+	now            func() time.Time
+	finished       bool
+}
+
+func NewReporter(
+	output io.Writer,
+	terminalOutput io.Writer,
+	terminal bool,
+	stage string,
+	resource string,
+	totalBytes int64,
+) *Reporter {
+	return newReporter(
+		output,
+		terminalOutput,
+		terminal,
+		stage,
+		resource,
+		totalBytes,
+		defaultReportInterval,
+		time.Now,
+	)
+}
+
+func newReporter(
+	output io.Writer,
+	terminalOutput io.Writer,
+	terminal bool,
+	stage string,
+	resource string,
+	totalBytes int64,
+	interval time.Duration,
+	now func() time.Time,
+) *Reporter {
+	if output == nil {
+		output = io.Discard
+	}
+	if terminalOutput == nil {
+		terminalOutput = io.Discard
+	}
+	if totalBytes < 0 {
+		totalBytes = 0
+	}
+	reporter := &Reporter{
+		output:         output,
+		terminalOutput: terminalOutput,
+		stage:          stage,
+		resource:       resource,
+		totalBytes:     totalBytes,
+		interval:       interval,
+		now:            now,
+	}
+	if terminal && totalBytes > 0 {
+		reporter.bar = newBar(terminalOutput, stage, resource, totalBytes)
+	}
+	return reporter
+}
+
+func (r *Reporter) Start() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.finished || !r.startedAt.IsZero() {
+		return
+	}
+	now := r.now()
+	r.startedAt = now
+	r.lastReportedAt = now
+	r.write(now, stateStarted)
+	if r.bar != nil {
+		_ = r.bar.RenderBlank()
+	}
+}
+
+func (r *Reporter) Add(completedBytes int64) {
+	if completedBytes <= 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.set(r.completedBytes+completedBytes, false)
+}
+
+func (r *Reporter) Set(completedBytes int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.set(completedBytes, false)
+}
+
+func (r *Reporter) Complete(completedBytes int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.set(completedBytes, true)
+}
+
+func (r *Reporter) Fail(completedBytes int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.finished {
+		return
+	}
+	r.ensureStarted()
+	r.completedBytes = r.normalizedCompletedBytes(completedBytes)
+	r.updateBar()
+	now := r.now()
+	r.write(now, stateFailed)
+	r.finishBar(true)
+	r.finished = true
+}
+
+func (r *Reporter) set(completedBytes int64, forceComplete bool) {
+	if r.finished {
+		return
+	}
+	r.ensureStarted()
+	r.completedBytes = r.normalizedCompletedBytes(completedBytes)
+	r.updateBar()
+	now := r.now()
+	if forceComplete || (r.totalBytes > 0 && r.completedBytes == r.totalBytes) {
+		r.write(now, stateCompleted)
+		r.finishBar(false)
+		r.finished = true
+		return
+	}
+	if now.Sub(r.lastReportedAt) < r.interval {
+		return
+	}
+	r.write(now, stateRunning)
+	r.lastReportedAt = now
+}
+
+func (r *Reporter) updateBar() {
+	if r.bar != nil {
+		_ = r.bar.Set64(r.completedBytes)
+	}
+}
+
+func (r *Reporter) finishBar(failed bool) {
+	if r.bar == nil {
+		return
+	}
+	if failed {
+		_ = r.bar.Clear()
+	} else {
+		_ = r.bar.Finish()
+	}
+	_, _ = fmt.Fprintln(r.terminalOutput)
+}
+
+func (r *Reporter) ensureStarted() {
+	if !r.startedAt.IsZero() {
+		return
+	}
+	now := r.now()
+	r.startedAt = now
+	r.lastReportedAt = now
+	r.write(now, stateStarted)
+}
+
+func (r *Reporter) normalizedCompletedBytes(completedBytes int64) int64 {
+	if completedBytes < r.completedBytes {
+		return r.completedBytes
+	}
+	if r.totalBytes > 0 && completedBytes > r.totalBytes {
+		return r.totalBytes
+	}
+	return completedBytes
+}
+
+func (r *Reporter) write(now time.Time, state string) {
+	elapsed := now.Sub(r.startedAt).Seconds()
+	percent := 0.0
+	if r.totalBytes > 0 {
+		percent = float64(r.completedBytes) * 100 / float64(r.totalBytes)
+	}
+	bytesPerSecond := 0.0
+	if elapsed > 0 {
+		bytesPerSecond = float64(r.completedBytes) / elapsed
+	}
+	record := Record{
+		Event:          EventByteProgress,
+		State:          state,
+		Stage:          r.stage,
+		Resource:       r.resource,
+		CompletedBytes: r.completedBytes,
+		TotalBytes:     r.totalBytes,
+		Percent:        percent,
+		BytesPerSecond: bytesPerSecond,
+		ElapsedSeconds: elapsed,
+	}
+	payload, _ := json.Marshal(record)
+	payload = append(payload, '\n')
+	_, _ = r.output.Write(payload)
+}
+
+func newBar(output io.Writer, stage, resource string, totalBytes int64) *progressbar.ProgressBar {
+	description := resource
+	if stage == StageDownload {
+		description = fmt.Sprintf("writing %s...", resource)
+	}
+	return progressbar.NewOptions64(
+		totalBytes,
+		progressbar.OptionSetWriter(output),
+		progressbar.OptionEnableColorCodes(true),
+		progressbar.OptionUseANSICodes(true),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionShowCount(),
+		progressbar.OptionSetElapsedTime(true),
+		progressbar.OptionSetPredictTime(true),
+		progressbar.OptionThrottle(250*time.Millisecond),
+		progressbar.OptionSetWidth(15),
+		progressbar.OptionShowElapsedTimeOnFinish(),
+		progressbar.OptionSetDescription(description),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "[green]=[reset]",
+			SaucerHead:    "[green]>[reset]",
+			SaucerPadding: " ",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}),
+	)
+}

--- a/internal/progress/reporter_test.go
+++ b/internal/progress/reporter_test.go
@@ -1,0 +1,177 @@
+package progress
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReporterLifecycle(t *testing.T) {
+	var output bytes.Buffer
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	reporter := newReporter(
+		&output,
+		io.Discard,
+		false,
+		StageDownload,
+		"dump.xml.gz",
+		100,
+		defaultReportInterval,
+		func() time.Time { return now },
+	)
+
+	reporter.Start()
+	reporter.Start()
+	reporter.Add(0)
+	reporter.Add(-1)
+	now = now.Add(time.Second)
+	reporter.Add(25)
+	reporter.Set(10)
+	now = now.Add(4 * time.Second)
+	reporter.Set(50)
+	reporter.Set(150)
+	reporter.Set(100)
+	reporter.Fail(100)
+
+	records := decodeRecords(t, output.Bytes())
+	require.Len(t, records, 3)
+	require.Equal(t, Record{
+		Event:          EventByteProgress,
+		State:          stateStarted,
+		Stage:          StageDownload,
+		Resource:       "dump.xml.gz",
+		CompletedBytes: 0,
+		TotalBytes:     100,
+		Percent:        0,
+		BytesPerSecond: 0,
+		ElapsedSeconds: 0,
+	}, records[0])
+	require.Equal(t, stateRunning, records[1].State)
+	require.Equal(t, int64(50), records[1].CompletedBytes)
+	require.Equal(t, 50.0, records[1].Percent)
+	require.Equal(t, 10.0, records[1].BytesPerSecond)
+	require.Equal(t, stateCompleted, records[2].State)
+	require.Equal(t, int64(100), records[2].CompletedBytes)
+	require.Equal(t, 100.0, records[2].Percent)
+	require.Equal(t, 20.0, records[2].BytesPerSecond)
+	require.NotContains(t, output.String(), "\x1b")
+	require.NotContains(t, output.String(), "\r")
+}
+
+func TestReporterStartsImplicitlyAndFails(t *testing.T) {
+	var output bytes.Buffer
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	reporter := newReporter(
+		&output,
+		io.Discard,
+		false,
+		StageSourceRead,
+		"artists",
+		100,
+		defaultReportInterval,
+		func() time.Time { return now },
+	)
+
+	reporter.Set(10)
+	now = now.Add(time.Second)
+	reporter.Fail(200)
+	reporter.Fail(50)
+
+	records := decodeRecords(t, output.Bytes())
+	require.Len(t, records, 2)
+	require.Equal(t, stateStarted, records[0].State)
+	require.Equal(t, stateFailed, records[1].State)
+	require.Equal(t, int64(100), records[1].CompletedBytes)
+	require.Equal(t, 100.0, records[1].Percent)
+}
+
+func TestReporterSupportsUnknownTotalsAndDiscardedOutput(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	reporter := newReporter(
+		nil,
+		nil,
+		false,
+		StageDownload,
+		"unknown",
+		-1,
+		defaultReportInterval,
+		func() time.Time { return now },
+	)
+
+	reporter.Start()
+	now = now.Add(time.Second)
+	reporter.Complete(25)
+	require.Equal(t, int64(0), reporter.totalBytes)
+	require.Equal(t, int64(25), reporter.completedBytes)
+	require.True(t, reporter.finished)
+
+	defaultReporter := NewReporter(nil, nil, false, StageDownload, "default", 0)
+	defaultReporter.Start()
+	defaultReporter.Complete(0)
+}
+
+func TestReporterKeepsTerminalBarOffStructuredOutput(t *testing.T) {
+	var structuredOutput bytes.Buffer
+	var terminalOutput bytes.Buffer
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	reporter := newReporter(
+		&structuredOutput,
+		&terminalOutput,
+		true,
+		StageSourceRead,
+		"artists",
+		100,
+		defaultReportInterval,
+		func() time.Time { return now },
+	)
+
+	reporter.Start()
+	now = now.Add(time.Second)
+	reporter.Set(50)
+	reporter.Fail(50)
+
+	require.NotContains(t, structuredOutput.String(), "\x1b")
+	require.NotContains(t, structuredOutput.String(), "[green]")
+	require.Contains(t, terminalOutput.String(), "\x1b")
+	require.NotContains(t, terminalOutput.String(), "[green]")
+}
+
+func TestReporterCompletesDownloadBar(t *testing.T) {
+	var structuredOutput bytes.Buffer
+	var terminalOutput bytes.Buffer
+	now := time.Date(2026, time.August, 12, 10, 0, 0, 0, time.UTC)
+	reporter := newReporter(
+		&structuredOutput,
+		&terminalOutput,
+		true,
+		StageDownload,
+		"dump.xml.gz",
+		100,
+		defaultReportInterval,
+		func() time.Time { return now },
+	)
+
+	reporter.Start()
+	now = now.Add(time.Second)
+	reporter.Complete(100)
+
+	require.Contains(t, terminalOutput.String(), "writing dump.xml.gz...")
+	require.Contains(t, terminalOutput.String(), "100%")
+	require.NotContains(t, structuredOutput.String(), "\x1b")
+}
+
+func decodeRecords(t *testing.T, payload []byte) []Record {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(payload), []byte{'\n'})
+	records := make([]Record, 0, len(lines))
+	for _, line := range lines {
+		var record Record
+		require.NoError(t, json.Unmarshal(line, &record))
+		records = append(records, record)
+	}
+	return records
+}

--- a/src/batch/coverage_test.go
+++ b/src/batch/coverage_test.go
@@ -407,6 +407,25 @@ func TestWriterErrorControlFlow(t *testing.T) {
 	require.ErrorContains(t, doWrite([]*opendiscogsmodel.Artist{{ID: 1}}, 0, mockDB).Err(), "chunk size")
 }
 
+func TestReferenceEntitiesUseDeterministicLockOrder(t *testing.T) {
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectExec(`INSERT INTO "genre"`).
+		WithArgs("Ambient", "Electronic").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(`INSERT INTO "style"`).
+		WithArgs("Dub", "Techno").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	order := NewOrder(context.Background(), 10, 1, "unused", db)
+
+	actual := writeReferenceEntities(
+		order,
+		[]*opendiscogsmodel.Genre{{Name: "Electronic"}, {Name: "Ambient"}},
+		[]*opendiscogsmodel.Style{{Name: "Techno"}, {Name: "Dub"}},
+	)
+
+	require.NoError(t, actual.Err())
+}
+
 func TestReleaseUpdateAndReferenceFilters(t *testing.T) {
 	expected := errors.New("fixture")
 	db := poisonedGorm(t, expected)

--- a/src/batch/reader.go
+++ b/src/batch/reader.go
@@ -13,7 +13,7 @@ func newReadCloser(filepath string, progressBarText string) (io.ReadCloser, erro
 	if err != nil {
 		return nil, fmt.Errorf("open import file %s: %w", filepath, err)
 	}
-	readCloser, err := reader.NewProgressBarGzipReadCloser(file, progressBarText)
+	readCloser, err := reader.NewProgressGzipReadCloser(file, progressBarText)
 	if err != nil {
 		_ = file.Close()
 		return nil, fmt.Errorf("open gzip import file %s: %w", filepath, err)

--- a/src/batch/writer.go
+++ b/src/batch/writer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"slices"
+	"strings"
 )
 
 func writeChunk(order Order, slices ...interface{}) result.Result {
@@ -19,6 +21,12 @@ func writeReferenceEntities(
 	genres []*model.Genre,
 	styles []*model.Style,
 ) result.Result {
+	slices.SortFunc(genres, func(left, right *model.Genre) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+	slices.SortFunc(styles, func(left, right *model.Style) int {
+		return strings.Compare(left.Name, right.Name)
+	})
 	for _, items := range []interface{}{genres, styles} {
 		if err := order.getDB().
 			Clauses(clause.OnConflict{DoNothing: true}).

--- a/src/database/gorm.go
+++ b/src/database/gorm.go
@@ -3,8 +3,6 @@ package database
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"regexp"
 	"time"
 
@@ -80,17 +78,8 @@ func GetConnectInSchema(dsn, schemaName string) (*gorm.DB, error) {
 	connectionConfig.RuntimeParams[searchPathParameter] = schema.SearchPath()
 	sqlDB := stdlib.OpenDB(*connectionConfig)
 
-	newLogger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags),
-		logger.Config{
-			SlowThreshold:             time.Second,
-			Colorful:                  true,
-			IgnoreRecordNotFoundError: false,
-			LogLevel:                  logger.Error,
-		})
-
 	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
-		Logger:                 newLogger,
+		Logger:                 logger.Discard,
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {

--- a/src/file/file.go
+++ b/src/file/file.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cavaliergopher/grab/v3"
+	"github.com/dsub-io/go-open-discogs-batch/internal/progress"
 	"github.com/dsub-io/go-open-discogs-batch/src/reader"
-	"github.com/schollz/progressbar/v3"
+	"golang.org/x/term"
 	"io"
 	"os"
 	"time"
@@ -245,40 +246,32 @@ func (h *handlerImpl) execGrabReq(req *grab.Request) error {
 	resp := client.Do(req)
 
 	// monitor
-	pb := getProgressBar(reader.GetFilename(req.Filename), resp.Size())
+	progressReporter := progress.NewReporter(
+		os.Stdout,
+		os.Stderr,
+		term.IsTerminal(int(os.Stderr.Fd())),
+		progress.StageDownload,
+		reader.GetFilename(req.Filename),
+		resp.Size(),
+	)
+	progressReporter.Start()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 Loop:
 	for {
 		select {
 		case <-ticker.C:
-			_ = pb.Set64(resp.BytesComplete())
+			progressReporter.Set(resp.BytesComplete())
 		case <-resp.Done:
-			_ = pb.Finish()
 			break Loop
 		}
 	}
-	fmt.Println()
 	if err := resp.Err(); err != nil {
+		progressReporter.Fail(resp.BytesComplete())
 		defer func() { _ = os.Remove(req.Filename) }()
 		return fmt.Errorf("failed to download %w", err)
 	}
+	progressReporter.Complete(resp.BytesComplete())
 	fmt.Printf("download completed for %+v (took: %.2fs)\n", req.Filename, time.Since(begin).Seconds())
 	return nil
-}
-
-func getProgressBar(filename string, size int64) *progressbar.ProgressBar {
-	pb := progressbar.NewOptions64(size,
-		progressbar.OptionEnableColorCodes(true),
-		progressbar.OptionShowBytes(true),
-		progressbar.OptionSetWidth(15),
-		progressbar.OptionSetDescription(fmt.Sprintf("[reset]writing %+v...", filename)),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "[green]=[reset]",
-			SaucerHead:    "[green]>[reset]",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}))
-	return pb
 }

--- a/src/reader/progressbar.go
+++ b/src/reader/progressbar.go
@@ -3,23 +3,32 @@ package reader
 import (
 	"compress/gzip"
 	"errors"
-	"github.com/schollz/progressbar/v3"
+	"github.com/dsub-io/go-open-discogs-batch/internal/progress"
+	"golang.org/x/term"
 	"io"
 	"os"
 	"strings"
-	"time"
 )
 
-func NewProgressBarGzipReadCloser(f *os.File, progressBarText string) (io.ReadCloser, error) {
+func NewProgressGzipReadCloser(f *os.File, progressText string) (io.ReadCloser, error) {
 	fileInfo, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
 
-	pb := getProgressBar(GetFilename(progressBarText), fileInfo.Size())
-	pbReader := progressbar.NewReader(f, pb)
-	reader, err := gzip.NewReader(&pbReader)
+	progressReporter := progress.NewReporter(
+		os.Stdout,
+		os.Stderr,
+		term.IsTerminal(int(os.Stderr.Fd())),
+		progress.StageSourceRead,
+		GetFilename(progressText),
+		fileInfo.Size(),
+	)
+	progressReporter.Start()
+	trackedSource := &progressReader{source: f, reporter: progressReporter}
+	reader, err := gzip.NewReader(trackedSource)
 	if err != nil {
+		progressReporter.Fail(trackedSource.completedBytes)
 		return nil, err
 	}
 	return &readCloserImpl{
@@ -28,26 +37,20 @@ func NewProgressBarGzipReadCloser(f *os.File, progressBarText string) (io.ReadCl
 	}, nil
 }
 
-func getProgressBar(text string, size int64) *progressbar.ProgressBar {
-	pb := progressbar.NewOptions64(size,
-		progressbar.OptionEnableColorCodes(false),
-		progressbar.OptionShowBytes(true),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetElapsedTime(true),
-		progressbar.OptionSetPredictTime(true),
-		progressbar.OptionThrottle(time.Millisecond*250),
-		progressbar.OptionSetWidth(15),
-		progressbar.OptionShowElapsedTimeOnFinish(),
-		progressbar.OptionSpinnerType(70),
-		progressbar.OptionSetDescription(text),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "[green]=[reset]",
-			SaucerHead:    "[green]>[reset]",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}))
-	return pb
+type progressReader struct {
+	source         io.Reader
+	reporter       *progress.Reporter
+	completedBytes int64
+}
+
+func (r *progressReader) Read(payload []byte) (int, error) {
+	readBytes, err := r.source.Read(payload)
+	r.completedBytes += int64(readBytes)
+	r.reporter.Set(r.completedBytes)
+	if err != nil && !errors.Is(err, io.EOF) {
+		r.reporter.Fail(r.completedBytes)
+	}
+	return readBytes, err
 }
 
 func GetFilename(filepath string) string {

--- a/src/reader/progressbar_test.go
+++ b/src/reader/progressbar_test.go
@@ -1,24 +1,36 @@
 package reader
 
 import (
+	"bytes"
+	"errors"
+	"github.com/dsub-io/go-open-discogs-batch/internal/progress"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 )
 
+var errProgressReader = errors.New("progress reader failure")
+
+type failingProgressSource struct{}
+
+func (failingProgressSource) Read([]byte) (int, error) {
+	return 0, errProgressReader
+}
+
 func TestGetFilename(t *testing.T) {
 	filename := GetFilename(path.Join("test", "this", "function", "as", "this.txt"))
 	assert.Equal(t, "this.txt", filename)
 }
 
-func TestNewProgressBarGzipReadCloser(t *testing.T) {
+func TestNewProgressGzipReadCloser(t *testing.T) {
 	f, err := os.Open("testdata/data.gz")
 	require.NoError(t, err)
 	text := "test-progress-bar"
-	r, err := NewProgressBarGzipReadCloser(f, text)
+	r, err := NewProgressGzipReadCloser(f, text)
 	require.NoError(t, err)
 
 	payload := make([]byte, 64)
@@ -30,26 +42,46 @@ func TestNewProgressBarGzipReadCloser(t *testing.T) {
 	require.Error(t, f.Close())
 }
 
-func TestNewProgressBarGzipReadCloserRejectsInvalidGzip(t *testing.T) {
+func TestNewProgressGzipReadCloserRejectsInvalidGzip(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "invalid.gz")
 	require.NoError(t, os.WriteFile(filePath, []byte("not gzip"), 0o600))
 	f, err := os.Open(filePath)
 	require.NoError(t, err)
 
-	reader, err := NewProgressBarGzipReadCloser(f, filePath)
+	reader, err := NewProgressGzipReadCloser(f, filePath)
 
 	require.Error(t, err)
 	require.Nil(t, reader)
 	require.NoError(t, f.Close())
 }
 
-func TestNewProgressBarGzipReadCloserRejectsUnreadableFileMetadata(t *testing.T) {
+func TestNewProgressGzipReadCloserRejectsUnreadableFileMetadata(t *testing.T) {
 	f, err := os.Open("testdata/data.gz")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	reader, err := NewProgressBarGzipReadCloser(f, "closed")
+	reader, err := NewProgressGzipReadCloser(f, "closed")
 
 	require.Error(t, err)
 	require.Nil(t, reader)
+}
+
+func TestProgressReaderReportsReadFailure(t *testing.T) {
+	var output bytes.Buffer
+	reporter := progress.NewReporter(
+		&output,
+		io.Discard,
+		false,
+		progress.StageSourceRead,
+		"broken",
+		1,
+	)
+	reporter.Start()
+	trackedReader := &progressReader{source: failingProgressSource{}, reporter: reporter}
+
+	readBytes, err := trackedReader.Read(make([]byte, 1))
+
+	require.Zero(t, readBytes)
+	require.ErrorIs(t, err, errProgressReader)
+	require.Contains(t, output.String(), `"state":"failed"`)
 }


### PR DESCRIPTION
## Summary

- sort shared genre and style reference inserts before every chunk write so concurrent workers acquire PostgreSQL uniqueness locks in one deterministic order
- keep interactive progress bars on stderr only when stderr is a TTY
- emit bounded line-delimited byte progress JSON on stdout for logs and pipelines
- suppress GORM SQL/ANSI dumps while preserving returned errors

## Production evidence

The first 2026-08 production import with `max-workers=4` completed Artist and Label, then PostgreSQL aborted a Master chunk with `SQLSTATE 40P01` while concurrent transactions inserted overlapping genre/style values in different orders.

Durable state after the failure:

- Artist: 10,163,318 items, 2,033 chunks, complete
- Label: 2,405,196 items, 482 chunks, complete
- Master: 30,000 items, 6 chunks, resumable
- Release: not started

The four dump catalog records and all downloaded files remain reusable. Retry therefore needs zero Discogs metadata requests and resumes from the committed Master ledger.

## Output impact

- non-TTY source progress changes from up to 4 carriage-return renders/second to at most 0.2 JSON records/second: 95% fewer progress writes
- non-TTY download progress changes from up to 2 renders/second to at most 0.2 JSON records/second: 90% fewer progress writes
- TTY users retain the interactive bar on stderr

## Validation

- `go vet ./...`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./...`
- total statement coverage: 100.0%
- `go test -tags=e2e -run '^(TestBatchE2E|TestImportExecutionCoordinator)$' -count=1 ./src/batch`
- Docker residue after tests: 0 containers, 0 test networks, 0 test volumes
