### PR TITLE
fix: keep interactive progress output readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,21 @@ import.
 ### Progress observability
 
 When stderr is a terminal, downloads and source reads display an interactive
-progress bar on stderr. Line-delimited `byte_progress` JSON records are emitted
-on stdout at start, at most once every five seconds, and at completion or
+progress bar on stderr. A normal interactive invocation suppresses structured
+progress on terminal stdout, so the bar is the only live progress display.
+When stdout is redirected or piped, line-delimited `byte_progress` JSON records
+are emitted at start, at most once every five seconds, and at completion or
 failure. The records include stage, resource, completed and total compressed
-bytes, percentage, byte throughput, and elapsed time. Redirecting or piping
-stdout through tools such as `tee` therefore remains parseable without removing
-the terminal bar. A source-read percentage describes how much of the gzip
-stream has been consumed; it does not claim that the same percentage of
-PostgreSQL work has committed. Do not merge stderr into stdout when collecting
-structured output.
+bytes, percentage, byte throughput, and elapsed time. A source-read percentage
+describes how much of the gzip stream has been consumed; it does not claim that
+the same percentage of PostgreSQL work has committed. Do not merge stderr into
+stdout when collecting structured output. If `tee` should persist JSON without
+replaying it beside the bar, use `| tee import.jsonl >/dev/null`.
 
-Tracked entity convergence also writes JSON progress records to stdout at
-start, at most once every five seconds while chunks finish, and at completion
-or failure. `committed_items` comes from `discogs_import_run_dump.processed_items`
+When stdout is redirected or piped, tracked entity convergence also writes JSON
+progress records at start, at most once every five seconds while chunks finish,
+and at completion or failure. `committed_items` comes from
+`discogs_import_run_dump.processed_items`
 and therefore counts only roots whose canonical entity and complete relation
 set committed atomically with the chunk ledger. `initial_committed_items` makes
 resumed work explicit, `rows_per_second` covers newly committed roots in the

--- a/internal/progress/output.go
+++ b/internal/progress/output.go
@@ -1,0 +1,20 @@
+package progress
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// StructuredOutput suppresses machine-readable progress on an interactive stream.
+func StructuredOutput(output *os.File) io.Writer {
+	return structuredOutput(output, term.IsTerminal(int(output.Fd())))
+}
+
+func structuredOutput(output io.Writer, terminal bool) io.Writer {
+	if output == nil || terminal {
+		return io.Discard
+	}
+	return output
+}

--- a/internal/progress/output_test.go
+++ b/internal/progress/output_test.go
@@ -1,0 +1,40 @@
+package progress
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructuredOutputSelection(t *testing.T) {
+	var output bytes.Buffer
+
+	_, err := structuredOutput(&output, false).Write([]byte("record"))
+	require.NoError(t, err)
+	require.Equal(t, "record", output.String())
+
+	_, err = structuredOutput(&output, true).Write([]byte("hidden"))
+	require.NoError(t, err)
+	require.Equal(t, "record", output.String())
+
+	_, err = structuredOutput(nil, false).Write([]byte("discarded"))
+	require.NoError(t, err)
+}
+
+func TestStructuredOutputUsesNonTerminalFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "structured-output")
+	require.NoError(t, err)
+
+	output := StructuredOutput(file)
+	_, err = output.Write([]byte("record"))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	payload, err := os.ReadFile(file.Name())
+	require.NoError(t, err)
+	require.Equal(t, "record", string(payload))
+	require.NotEqual(t, io.Discard, output)
+}

--- a/src/batch/observability.go
+++ b/src/batch/observability.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"github.com/dsub-io/go-open-discogs-batch/internal/progress"
 	"io"
 	"os"
 	"sync"
@@ -80,7 +81,7 @@ func newEntityProgressReporter(order Order) entityProgressReporter {
 		readSummary: func() (committedProgress, error) {
 			return readCommittedProgress(order)
 		},
-		output: os.Stdout,
+		output: progress.StructuredOutput(os.Stdout),
 	}
 }
 

--- a/src/file/file.go
+++ b/src/file/file.go
@@ -247,7 +247,7 @@ func (h *handlerImpl) execGrabReq(req *grab.Request) error {
 
 	// monitor
 	progressReporter := progress.NewReporter(
-		os.Stdout,
+		progress.StructuredOutput(os.Stdout),
 		os.Stderr,
 		term.IsTerminal(int(os.Stderr.Fd())),
 		progress.StageDownload,

--- a/src/reader/progressbar.go
+++ b/src/reader/progressbar.go
@@ -17,7 +17,7 @@ func NewProgressGzipReadCloser(f *os.File, progressText string) (io.ReadCloser, 
 	}
 
 	progressReporter := progress.NewReporter(
-		os.Stdout,
+		progress.StructuredOutput(os.Stdout),
 		os.Stderr,
 		term.IsTerminal(int(os.Stderr.Fd())),
 		progress.StageSourceRead,


### PR DESCRIPTION
## Summary
- suppress `byte_progress` and `import_progress` JSON when stdout is an interactive terminal
- keep the stderr TTY progress bar as the only live progress display for a normal invocation
- preserve line-delimited JSON when stdout is redirected or piped
- document `tee ... >/dev/null` when JSON should be persisted without replaying beside the bar

## Measured output
- direct interactive execution: structured progress records reduced from up to 0.2 records/s per active reporter to 0 records/s (100% reduction)
- redirected/piped execution: unchanged at a maximum of 0.2 records/s, plus start and finish records
- stderr TTY progress bar: unchanged

## Validation
- `go vet ./...`
- `go test -race -coverprofile=/tmp/go-interactive-cover.out ./...`
- statement coverage: 100.0%