### PR TITLE
fix: enforce canonical dump recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  merge_group:
   push:
     branches:
       - main
@@ -51,10 +52,7 @@ jobs:
           fi
 
       - name: Verify module metadata
-        run: |
-          set -euo pipefail
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum
+        run: go mod tidy -diff
 
       - name: Vet packages
         run: go vet ./...
@@ -64,23 +62,27 @@ jobs:
 
       - name: Enforce coverage gate
         shell: bash
-        env:
-          MINIMUM_COVERAGE: '100.0'
         run: |
           set -euo pipefail
           total="$(
             go tool cover -func=coverage.out |
               awk '/^total:/ { gsub("%", "", $3); print $3 }'
           )"
-          awk -v total="$total" -v minimum="$MINIMUM_COVERAGE" 'BEGIN {
-            if (total + 0 < minimum) {
-              printf "coverage %.1f%% is below %.1f%%\n", total, minimum
-              exit 1
-            }
-            printf "coverage %.1f%% meets %.1f%% gate\n", total, minimum
-          }'
+          if [[ -z "$total" ]]; then
+            echo "::error::Coverage profile has no total."
+            exit 1
+          fi
+          uncovered="$(
+            awk 'NR > 1 && $2 > 0 && $3 == 0 { print }' coverage.out
+          )"
+          if [[ -n "$uncovered" ]]; then
+            printf 'coverage %s%% has uncovered statements:\n%s\n' \
+              "$total" "$uncovered"
+            exit 1
+          fi
+          printf 'coverage %s%% has no uncovered statements\n' "$total"
 
-      - name: Verify test Docker cleanup
+      - name: Remove owned test resources and verify no residue
         if: ${{ always() }}
         shell: bash
         run: scripts/verify-test-docker-cleanup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     name: Build, test, race, and coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      OPEN_DISCOGS_TEST_RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -77,3 +79,8 @@ jobs:
             }
             printf "coverage %.1f%% meets %.1f%% gate\n", total, minimum
           }'
+
+      - name: Verify test Docker cleanup
+        if: ${{ always() }}
+        shell: bash
+        run: scripts/verify-test-docker-cleanup.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: CodeQL
 
 on:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,6 +1,7 @@
 name: Conventional Commits
 
 on:
+  merge_group:
   pull_request:
     types:
       - opened
@@ -28,6 +29,8 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -57,6 +60,17 @@ jobs:
               failed=1
             fi
             range="$PR_BASE_SHA..$PR_HEAD_SHA"
+          elif [[ "$EVENT_NAME" == "merge_group" ]]; then
+            if [[ -z "$MERGE_GROUP_BASE_SHA" || -z "$MERGE_GROUP_HEAD_SHA" ]]; then
+              echo "::error::Merge group event is missing its commit range."
+              exit 1
+            fi
+            if ! git cat-file -e "$MERGE_GROUP_BASE_SHA^{commit}" 2>/dev/null ||
+              ! git cat-file -e "$MERGE_GROUP_HEAD_SHA^{commit}" 2>/dev/null; then
+              echo "::error::Merge group commit range is unavailable."
+              exit 1
+            fi
+            range="$MERGE_GROUP_BASE_SHA..$MERGE_GROUP_HEAD_SHA"
           elif [[ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]] &&
             git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null &&
             git merge-base --is-ancestor "$PUSH_BEFORE_SHA" "$PUSH_HEAD_SHA"; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,7 @@
 name: E2E
 
 on:
+  merge_group:
   workflow_dispatch:
   pull_request:
     types:
@@ -37,7 +38,7 @@ jobs:
           -count=1
           ./src/batch
 
-      - name: Verify test Docker cleanup
+      - name: Remove owned test resources and verify no residue
         if: ${{ always() }}
         shell: bash
         run: scripts/verify-test-docker-cleanup.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,8 @@ jobs:
     name: Discogs data E2E
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      OPEN_DISCOGS_TEST_RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -34,3 +36,8 @@ jobs:
           -run '^(TestBatchE2E|TestImportExecutionCoordinator)$'
           -count=1
           ./src/batch
+
+      - name: Verify test Docker cleanup
+        if: ${{ always() }}
+        shell: bash
+        run: scripts/verify-test-docker-cleanup.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,10 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release-created == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
+    env:
+      IMAGE_REPOSITORY: ghcr.io/dsub-io/go-open-discogs-batch
+      OPEN_DISCOGS_TEST_RUN_ID: gh-release-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
     permissions:
       contents: write
       packages: write
@@ -151,14 +154,76 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Test release source
-        run: go test ./...
+      - name: Verify release policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq empty release-please-config.json
+          for type in build chore ci docs refactor style test; do
+            jq -e \
+              --arg type "$type" \
+              'any(.["changelog-sections"][]; .type == $type and .hidden == true)' \
+              release-please-config.json >/dev/null
+          done
+
+      - name: Verify formatting
+        shell: bash
+        run: |
+          set -euo pipefail
+          unformatted="$(gofmt -l .)"
+          if [[ -n "$unformatted" ]]; then
+            printf 'The following files need gofmt:\n%s\n' "$unformatted"
+            exit 1
+          fi
+
+      - name: Verify module metadata
+        run: go mod tidy -diff
+
+      - name: Vet release packages
+        run: go vet ./...
+
+      - name: Test release with race detector and coverage
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Enforce exact release coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          total="$(
+            go tool cover -func=coverage.out |
+              awk '/^total:/ { gsub("%", "", $3); print $3 }'
+          )"
+          if [[ -z "$total" ]]; then
+            echo "::error::Coverage profile has no total."
+            exit 1
+          fi
+          uncovered="$(
+            awk 'NR > 1 && $2 > 0 && $3 == 0 { print }' coverage.out
+          )"
+          if [[ -n "$uncovered" ]]; then
+            printf 'coverage %s%% has uncovered statements:\n%s\n' \
+              "$total" "$uncovered"
+            exit 1
+          fi
+          printf 'coverage %s%% has no uncovered statements\n' "$total"
+
+      - name: Run release dump-to-PostgreSQL end-to-end tests
+        run: >-
+          go test -tags=e2e
+          -run '^(TestBatchE2E|TestImportExecutionCoordinator)$'
+          -count=1
+          ./src/batch
+
+      - name: Remove owned test resources and verify no residue
+        if: ${{ always() }}
+        shell: bash
+        run: scripts/verify-test-docker-cleanup.sh
 
       - name: Publish release binaries
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.17.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -176,7 +241,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Publish release container
+      - name: Publish versioned release container
         id: image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
@@ -187,30 +252,146 @@ jobs:
             VERSION=${{ needs.release-please.outputs.version }}
           tags: |
             ghcr.io/dsub-io/go-open-discogs-batch:${{ needs.release-please.outputs.version }}
-            ghcr.io/dsub-io/go-open-discogs-batch:latest
           labels: |
             org.opencontainers.image.source=https://github.com/dsub-io/go-open-discogs-batch
             org.opencontainers.image.revision=${{ needs.release-please.outputs.sha }}
             org.opencontainers.image.version=${{ needs.release-please.outputs.version }}
             org.opencontainers.image.licenses=MIT
 
-      - name: Verify published architectures
+      - name: Verify versioned image
+        shell: bash
+        env:
+          EXPECTED_IMAGE_LICENSES: MIT
+          EXPECTED_IMAGE_SOURCE: https://github.com/dsub-io/go-open-discogs-batch
+          EXPECTED_IMAGE_USER: 65532:65532
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          RELEASE_SHA: ${{ needs.release-please.outputs.sha }}
+          RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+          VERSIONED_IMAGE: ghcr.io/dsub-io/go-open-discogs-batch:${{ needs.release-please.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Buildx returned an invalid image digest."
+            exit 1
+          fi
+
+          manifest="$(
+            docker buildx imagetools inspect \
+              --format '{{json .Manifest}}' \
+              "$VERSIONED_IMAGE"
+          )"
+          published_digest="$(jq -er '.digest' <<<"$manifest")"
+          if [[ "$published_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "::error::Versioned image tag does not resolve to the Buildx digest."
+            exit 1
+          fi
+          jq -e '
+            def target_platform:
+              .platform.os == "linux" and
+              (.platform.architecture == "amd64" or .platform.architecture == "arm64");
+            def attestation:
+              (.annotations["vnd.docker.reference.type"] // "") == "attestation-manifest" and
+              .platform.os == "unknown" and
+              .platform.architecture == "unknown";
+            all(.manifests[]; target_platform or attestation) and
+            ([
+              .manifests[]
+              | select(target_platform)
+              | (.platform.os + "/" + .platform.architecture)
+            ] | sort) == ["linux/amd64", "linux/arm64"]
+          ' <<<"$manifest" >/dev/null
+
+          verify_platform_image() {
+            local platform="$1"
+            local platform_digest="$2"
+            local platform_image="${IMAGE_REPOSITORY}@${platform_digest}"
+            local image_licenses
+            local image_revision
+            local image_source
+            local image_user
+            local image_version
+            local reported_version
+
+            docker pull --platform "$platform" "$platform_image"
+
+            image_user="$(
+              docker image inspect "$platform_image" --format '{{.Config.User}}'
+            )"
+            if [[ "$image_user" != "$EXPECTED_IMAGE_USER" ]]; then
+              echo "::error::$platform image user is $image_user, expected $EXPECTED_IMAGE_USER."
+              return 1
+            fi
+
+            image_source="$(
+              docker image inspect "$platform_image" \
+                --format '{{ index .Config.Labels "org.opencontainers.image.source" }}'
+            )"
+            image_revision="$(
+              docker image inspect "$platform_image" \
+                --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+            )"
+            image_version="$(
+              docker image inspect "$platform_image" \
+                --format '{{ index .Config.Labels "org.opencontainers.image.version" }}'
+            )"
+            image_licenses="$(
+              docker image inspect "$platform_image" \
+                --format '{{ index .Config.Labels "org.opencontainers.image.licenses" }}'
+            )"
+            if [[ "$image_source" != "$EXPECTED_IMAGE_SOURCE" ||
+              "$image_revision" != "$RELEASE_SHA" ||
+              "$image_version" != "$RELEASE_VERSION" ||
+              "$image_licenses" != "$EXPECTED_IMAGE_LICENSES" ]]; then
+              echo "::error::$platform image OCI labels do not match the release."
+              return 1
+            fi
+
+            reported_version="$(
+              docker run --rm --network none --read-only \
+                --platform "$platform" \
+                "$platform_image" --version
+            )"
+            if [[ "$reported_version" != "go-open-discogs-batch $RELEASE_VERSION" ]]; then
+              echo "::error::$platform image reports unexpected version: $reported_version"
+              return 1
+            fi
+          }
+
+          while IFS=$'\t' read -r platform platform_digest; do
+            verify_platform_image "$platform" "$platform_digest"
+          done < <(
+            jq -r '
+              .manifests[]
+              | select(
+                  .platform.os == "linux" and
+                  (.platform.architecture == "amd64" or
+                   .platform.architecture == "arm64")
+                )
+              | [(.platform.os + "/" + .platform.architecture), .digest]
+              | @tsv
+            ' <<<"$manifest"
+          )
+
+      - name: Promote validated image to latest
         shell: bash
         env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         run: |
           set -euo pipefail
-          manifest="$(
-            docker buildx imagetools inspect --raw \
-              "ghcr.io/dsub-io/go-open-discogs-batch@${IMAGE_DIGEST}"
+          immutable_image="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+          latest_image="${IMAGE_REPOSITORY}:latest"
+
+          docker buildx imagetools create \
+            --tag "$latest_image" \
+            "$immutable_image"
+
+          latest_manifest="$(
+            docker buildx imagetools inspect \
+              --format '{{json .Manifest}}' \
+              "$latest_image"
           )"
-          jq -e '
-            ([
-              .manifests[].platform
-              | select(
-                  .os == "linux" and
-                  (.architecture == "amd64" or .architecture == "arm64")
-                )
-              | (.os + "/" + .architecture)
-            ] | unique) == ["linux/amd64", "linux/arm64"]
-          ' <<<"$manifest"
+          latest_digest="$(jq -er '.digest' <<<"$latest_manifest")"
+          if [[ "$latest_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "::error::Latest image does not resolve to the validated digest."
+            exit 1
+          fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ project_name: go-open-discogs-batch
 
 before:
   hooks:
-    - go mod tidy
+    - go mod tidy -diff
 
 builds:
   - main: .

--- a/README.md
+++ b/README.md
@@ -1,145 +1,15 @@
-# go-open-discogs-batch
+# Go OpenDiscogs Batch
 
-`go-open-discogs-batch` imports the public OpenDiscogs monthly dumps into
-PostgreSQL. It uses the canonical schema and generated Go models from
-[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model), so the Go
-and Java importers write the same database contract.
+Imports Discogs monthly public data dumps into PostgreSQL. Go and Java use the
+same schema published by
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model).
 
-This is an independent DSUB project. It is not affiliated with or endorsed by
-Discogs. The Discogs name identifies only the public data source.
+This project is independent from and not endorsed by Discogs.
 
-## Import behavior and safety
+## Quick start
 
-- The selected database schema, canonical migrations, tables, indexes, and dump catalog refresh run automatically.
-- Artist, label, master, and release select their newest available dump
-  independently unless an exact `--dump-month` is requested.
-- Every run records the selected dump dates, SHA-256 checksums, source URIs,
-  and stable identifiers as one immutable manifest.
-- A successful manifest is admitted and skipped before dump files are downloaded
-  or checksummed only while all of its entity dumps are still the current
-  checkpoints and no later failed or abandoned run has dirtied those entities.
-  `--force` reruns that same manifest without changing the normalized database
-  result.
-- A failed or abandoned run resumes only when the manifest, processor name and
-  version, entity/dump identity, and chunk size all match exactly. A different
-  manifest or `--force` starts at zero.
-- Each tracked convergence chunk writes its canonical roots, exact relations,
-  committed-chunk ledger, and item counter in one PostgreSQL transaction. A
-  retry skips only source ranges represented by valid committed chunk rows.
-- An older entity dump is rejected unless `--allow-downgrade` is supplied; the
-  override is recorded in import history.
-- PostgreSQL advisory locks cover both selected entities and their reference
-  dependencies. Master locks Artist and Master; Release locks Artist, Label,
-  Master, and Release because it also updates `master.main_release_id`.
-  Independent sets such as Artist and Label may still proceed together.
-- Downloads are retained by default. `--cleanup` deletes only the selected dump
-  files after a successful import or successful-manifest skip. Failed imports
-  retain their files for retry.
-
-If the upstream catalog refresh fails, the importer tries the catalog already
-stored in PostgreSQL. It fails if that catalog cannot satisfy the request.
-
-An exact `--dump-month` uses a complete matching PostgreSQL catalog entry before
-contacting Discogs. If any selected entity is missing, dumps from 2021 onward
-are resolved with one monthly checksum request; its filenames and SHA-256 values
-define all selected download URIs. Older dumps have irregular publication dates,
-so they require one annual catalog request and one checksum request. The importer
-stores every selected URI and checksum before downloading files. Retries of that
-pinned month reuse the stored catalog without another metadata request. A 429,
-5xx, timeout, or malformed response fails the refresh without speculative extra
-requests. Latest-per-entity selection still refreshes upstream first because the
-local database cannot prove that no newer dump exists.
-
-Catalog discovery and file downloads use the official `data.discogs.com` dump
-browser. Direct S3 bucket and object URLs are not part of this contract. The
-browser catalog exposes rounded display sizes, so new catalog rows store
-`size_bytes=0` instead of presenting an estimate as an exact byte count.
-Download progress uses the response `Content-Length` when supplied rather than
-this catalog field.
-
-### Durability and idempotency boundaries
-
-`SIGINT` and `SIGTERM` cancel download, parsing, and database work. The active
-chunk transaction rolls back, while run failure is recorded with a separate
-bounded completion context. `SIGKILL`, host loss, or a database disconnect can
-leave a run marked `running`; the next process acquires the entity locks, marks
-that abandoned run failed, and transfers its valid ledger in one transaction.
-If ledger transfer fails, the new run and copied rows roll back together and the
-source ledger remains authoritative.
-
-Every canonical and tracked chunk fences against the owning run row before it
-can commit. Once an abandoned run is marked failed, a delayed worker can no
-longer commit canonical data, progress, or entity completion. If an in-flight
-chunk obtains the fence first, abandonment waits for that atomic commit and the
-next run transfers the resulting ledger entry.
-
-An entity is complete only when chunk indexes cover the parsed stream without
-gaps, overlaps, or out-of-range indexes and both chunk and item totals match.
-The whole run becomes successful only after every selected entity is complete.
-Failed ledgers are retained until the current successful checkpoints, produced
-by the same processor version, supersede every entity/dump pair in the failed
-run. Historical success rows alone never authorize pruning. A failed ledger is
-also not resumed when a newer successful checkpoint with different dump or
-processor identity has overwritten one of its entity ranges. These rules
-prevent an Artist-only run from deleting the only valid resume state for a
-failed Artist+Release run or mixing ranges from different snapshots.
-
-Relations owned by each imported root are reconciled to the exact set in the
-dump: missing relations are deleted, changed mutable values are updated, and
-unchanged relation rows retain their identifiers. Root artist, label, master,
-and release rows are upserted; roots absent from a later dump are not currently
-deleted. The importer assumes official dump root identifiers are unique.
-The v1 schema still identifies several relation values with a 32-bit Java hash;
-a collision within one root can merge distinct values. The measured, online
-migration to collision-resistant identity is tracked in
-[`open-discogs-model#43`](https://github.com/dsub-io/open-discogs-model/issues/43).
-
-Atomicity is per chunk, not per monthly snapshot. Permanent full-dump staging is
-intentionally avoided because it would duplicate a catalog exceeding 200
-million records. Readers can therefore observe already committed chunks while
-an import is running. Deployments that require an all-at-once snapshot switch
-must put a separate versioned database or replica promotion boundary around the
-import.
-
-### Progress observability
-
-When stderr is a terminal, downloads and source reads display an interactive
-progress bar on stderr. A normal interactive invocation suppresses structured
-progress on terminal stdout, so the bar is the only live progress display.
-When stdout is redirected or piped, line-delimited `byte_progress` JSON records
-are emitted at start, at most once every five seconds, and at completion or
-failure. The records include stage, resource, completed and total compressed
-bytes, percentage, byte throughput, and elapsed time. A source-read percentage
-describes how much of the gzip stream has been consumed; it does not claim that
-the same percentage of PostgreSQL work has committed. Do not merge stderr into
-stdout when collecting structured output. If `tee` should persist JSON without
-replaying it beside the bar, use `| tee import.jsonl >/dev/null`.
-
-When stdout is redirected or piped, tracked entity convergence also writes JSON
-progress records at start, at most once every five seconds while chunks finish,
-and at completion or failure. `committed_items` comes from
-`discogs_import_run_dump.processed_items`
-and therefore counts only roots whose canonical entity and complete relation
-set committed atomically with the chunk ledger. `initial_committed_items` makes
-resumed work explicit, `rows_per_second` covers newly committed roots in the
-current process, and `last_committed_progress_at` supports stall detection.
-Each emitted sample performs one primary-key summary read, bounded to 0.2 reads
-per second per active entity plus the start and finish reads; it never scans the
-chunk ledger or entity tables.
-
-`committed_percent` is intentionally omitted while the stream total is unknown.
-It becomes `100` only after end-of-stream coverage validation records exact item
-and chunk totals. Pre-counting every XML root merely to display a speculative
-percentage would add a second full gzip/XML scan. There is no synthetic overall
-percentage across Artist, Label, Master, and Release because their relation
-fan-out and database cost differ substantially.
-
-## Requirements
-
-- PostgreSQL
-- Go 1.26 for source builds, or a published binary/container
-
-## Usage
+The PostgreSQL database must exist. The importer creates the selected schema,
+applies canonical migrations, downloads the dumps, and imports them.
 
 ```shell
 go-open-discogs-batch \
@@ -148,165 +18,139 @@ go-open-discogs-batch \
   --entities artist,label,master,release
 ```
 
-Use `--dump-month=2026-07` to require that exact month. Without it, each selected
-entity uses its own latest available dump.
+Without `--dump-month`, every selected entity uses its latest available dump.
+Use `--dump-month=2026-07` to require one exact month.
 
-The PostgreSQL database itself must already exist. A normal batch run needs no separate `init` command: it creates `--database-schema` when missing, then creates or migrates the canonical tables inside it. Creating a missing schema requires `CREATE` on the target database. For an existing schema, the batch role requires `USAGE` and `CREATE`, write access to imported tables, and ownership or equivalent DDL authority for migrations. If those privileges are intentionally unavailable, pre-create the schema with a DBA-managed role and grant the batch role the required schema and table privileges before running the importer.
+## Import contract
 
-When `--database-schema` / `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` is omitted, the importer uses `public` and emits a `WARN` on every startup. This is convenient for compatibility but can mix OpenDiscogs objects with unrelated public tables, so a dedicated name such as `open_discogs` is recommended. Schema names use portable PostgreSQL identifiers: 1–63 lowercase letters, digits, or underscores, starting with a letter or underscore.
+- Supported entities are `artist`, `label`, `master`, and `release`.
+- Downloads and XML parsing are streamed; a dump is never loaded as one
+  in-memory document.
+- A successful manifest is skipped before downloading when its entity
+  checkpoints are still current.
+- A compatible failed or interrupted run resumes committed chunks. `--force`
+  starts again from zero.
+- Each root and its complete relation set commit atomically with durable
+  progress.
+- Relations removed from a later representation of a root are deleted. Roots
+  absent from a complete dump are not deleted.
+- Older dumps are rejected unless `--allow-downgrade` is explicitly supplied.
+- Downloads remain on disk by default. `--cleanup` removes only files selected
+  by a successful import or successful-manifest skip.
 
-| Option | Environment variable | Default | Purpose |
+See [Import safety and recovery](docs/import-safety.md) for manifest selection,
+locking, convergence, interruption, and snapshot visibility.
+
+## Database and permissions
+
+The database itself is never created. A normal run creates a missing
+`--database-schema` and the canonical tables inside it; there is no separate
+`init` command.
+
+- Creating a schema requires `CREATE` on the database.
+- Migrating an existing schema requires `USAGE` and `CREATE` on that schema,
+  write access to imported tables, and DDL ownership or equivalent authority.
+- If the batch role cannot create or migrate schemas, a DBA must prepare and
+  grant the schema first.
+
+The default schema is `public`, and every such startup emits a warning. Prefer
+a dedicated schema such as `open_discogs`. Names must be 1–63 lowercase
+letters, digits, or underscores and begin with a letter or underscore.
+
+## Configuration
+
+Precedence is `CLI > ENV > default`.
+
+| CLI | Environment | Default | Meaning |
 | --- | --- | --- | --- |
-| `--database-url` | `OPEN_DISCOGS_BATCH_DATABASE_URL` | required | PostgreSQL URI including percent-encoded credentials |
-| `--database-schema` | `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` | `public` | Schema to create or migrate; `public` emits a startup warning |
-| `--entities`, `-e` | `OPEN_DISCOGS_BATCH_ENTITIES` | all four | Comma-separated `artist`, `label`, `master`, `release` |
-| `--dump-month`, `-m` | `OPEN_DISCOGS_BATCH_DUMP_MONTH` | latest per entity | Exact dump month in `yyyy-MM` form |
+| `--database-url` | `OPEN_DISCOGS_BATCH_DATABASE_URL` | required | PostgreSQL URI; percent-encode credentials |
+| `--database-schema` | `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` | `public` | Schema to create or migrate |
+| `--entities`, `-e` | `OPEN_DISCOGS_BATCH_ENTITIES` | all | Comma-separated entity list |
+| `--dump-month`, `-m` | `OPEN_DISCOGS_BATCH_DUMP_MONTH` | latest per entity | Exact month in `yyyy-MM` |
 | `--data-dir` | `OPEN_DISCOGS_BATCH_DATA_DIR` | `~/.cache/open-discogs-batch` | Download directory |
-| `--chunk-size`, `-b` | `OPEN_DISCOGS_BATCH_CHUNK_SIZE` | `5000` | Import chunk size |
-| `--max-workers` | `OPEN_DISCOGS_BATCH_MAX_WORKERS` | runtime CPU allocation | Maximum concurrent import workers |
-| `--cleanup`, `-c` | `OPEN_DISCOGS_BATCH_CLEANUP` | `false` | Delete downloads after success |
-| `--force`, `-f` | `OPEN_DISCOGS_BATCH_FORCE` | `false` | Rerun an already-successful manifest |
-| `--allow-downgrade` | `OPEN_DISCOGS_BATCH_ALLOW_DOWNGRADE` | `false` | Permit and audit older entity dumps |
-| `--help`, `-h` | — | — | Show help |
-| `--version`, `-v` | — | — | Show version |
+| `--chunk-size`, `-b` | `OPEN_DISCOGS_BATCH_CHUNK_SIZE` | `5000` | Roots per transaction chunk |
+| `--max-workers` | `OPEN_DISCOGS_BATCH_MAX_WORKERS` | runtime CPU allocation | Concurrent import workers |
+| `--cleanup`, `-c` | `OPEN_DISCOGS_BATCH_CLEANUP` | `false` | Delete selected dumps after success |
+| `--force`, `-f` | `OPEN_DISCOGS_BATCH_FORCE` | `false` | Reprocess a successful manifest |
+| `--allow-downgrade` | `OPEN_DISCOGS_BATCH_ALLOW_DOWNGRADE` | `false` | Permit and audit older dumps |
+| `--help`, `-h` | — | — | Show help without a database connection |
+| `--version`, `-v` | — | — | Show version without a database connection |
 
-Command-line options take precedence over environment variables, which take
-precedence over defaults. The two importer implementations accept this same
-public contract. Configuration files and the former `new`, `update`, `purge`,
-`dsn`, `types`, `year`, `month`, and `data` options are no longer supported.
+`--max-workers` is an application concurrency limit, not a CPU quota. When it
+is omitted, the Go runtime's CPU allocation is used without a percentage
+heuristic. Use container or scheduler CPU limits for a hard allocation.
 
-`--max-workers` is the exact upper bound on application-managed concurrent
-import workers. When omitted, it resolves to the CPU allocation used by the Go
-runtime; no percentage or physical-core heuristic is applied. It is not a hard
-CPU quota. Use the container or workload scheduler's CPU limit when the process
-itself must not exceed a CPU allocation.
+## Progress and logs
 
-## Large-import resource model
-
-Dump downloads, gzip decompression, and XML parsing are streamed; a dump is
-never loaded into memory as one document. Chunk submission blocks when
-`max-workers` chunks are active, so in-flight work cannot grow with the total
-dump size. The PostgreSQL pool is limited to `max-workers + 1`: one connection
-per possible writer plus the import coordinator's advisory-lock connection.
-
-Integer reference IDs use a segmented concurrent bit set. Each occupied range
-of 65,536 IDs allocates 8 KiB of bit storage, so dense IDs use one bit each.
-Dependencies for a partial import are streamed from PostgreSQL into these sets.
-Release-to-master changes use one set-based update per chunk instead of one SQL
-statement per release. Insert batches are also capped below PostgreSQL's 65,535
-bind-parameter limit even when a larger `--chunk-size` is requested.
-
-Peak working memory is driven by `chunk-size × max-workers × relation fan-out`,
-not by the total row count. Release records have the largest fan-out. For a
-large production import, set `--max-workers` explicitly to the smaller of the
-container CPU allocation and the number of database write connections reserved
-for this job, then tune `--chunk-size` separately from measured heap usage and
-database latency. Lower `chunk-size` when one expanded relation chunk is too
-large; lower `max-workers` when concurrent chunks or PostgreSQL are the
-constraint.
-
-### Measured ID-cache improvement
-
-On an Apple M2 Pro, the previous `sync.Map` ID set and the segmented bit set
-were compared with the same 1,000,000 sequential IDs using three iterations per
-sample and five samples. Median time fell from 234.656 ms to 9.257 ms (`25.4×`
-faster), allocated bytes fell from approximately 109.5 MB/op to 132.9 KB/op
-(`99.88%` lower), and allocations fell from 2,359,348 to 39 per operation. The
-release-to-master update also changes up to 5,000 row-by-row SQL statements at
-the default chunk size into one set-based statement. These figures isolate the
-measured operations; end-to-end import throughput still depends on dump shape,
-PostgreSQL, storage, and runtime limits.
-
-### Measured durable-import cost and skip improvement
-
-The tracked production path was measured before and after the recovery fixes
-against commit `2a1ddbd` on the same Apple M2 Pro, PostgreSQL 18.4 Alpine tmpfs
-container, four 3-record fixture dumps, `chunk-size=5`, `max-workers=2`, one
-import per sample, and 20 samples. Output was suppressed identically. Initial
-import latency changed from p50/p95/p99 `48.509/54.527/80.881 ms` to
-`73.922/77.397/88.551 ms` (`52.4%/41.9%/9.5%` higher). Median throughput changed
-from `0.167` to `0.109 MB/s` (`34.4%` lower), allocated bytes from 2,327,712 to
-2,454,276 B/op (`5.4%` higher), and allocations from 43,524 to 44,333/op (`1.9%`
-higher).
-
-Forced-repeat latency changed from p50/p95/p99 `38.864/43.826/44.841 ms` to
-`72.822/74.057/74.204 ms` (`87.4%/69.0%/65.5%` higher). Median throughput changed
-from `0.208` to `0.111 MB/s` (`46.6%` lower), allocated bytes from 2,340,796 to
-2,466,576 B/op (`5.4%` higher), and allocations from 44,597 to 45,990/op (`3.1%`
-higher). The added cost buys current-checkpoint validation and a database fence
-that prevents delayed workers from committing after abandonment. This tiny
-12-record fixture exaggerates fixed transaction cost and is not a full-dataset
-throughput estimate.
-
-Fresh tracked relation chunks use one SQL statement for the active-run fence,
-ledger insert, and summary update. Resumed chunks add one exact-ledger lookup.
-The Artist and Label canonical pre-seed phase adds one active-run fence per
-chunk because those roots must exist before forward relations are reconciled.
-
-The production no-op path was measured separately with the same successful
-manifest and a cached 64 MiB sparse file. Checksum-before-admission latency was
-p50/p95/p99 `38.917/50.768/58.719 ms`; admission-before-checksum was
-`1.776/2.728/3.038 ms`, a `95.4%/94.6%/94.8%` reduction and `21.9x` median
-speedup. Median allocations changed from 40,008 to 6,800 B/op (`83.0%` lower)
-and 113 to 106 allocations/op (`6.2%` lower), while 64 MiB of file I/O was
-avoided per invocation.
-
-Peak RSS was not reported from these microbenchmarks because it would include
-the test process and container lifecycle while the 12-record fixture is too
-small to represent production heap pressure. Allocation counts are reported
-instead; production sizing still requires a heap/RSS profile from a
-representative large dump under the intended `chunk-size` and `max-workers`.
-
-Reproduce the focused measurements with:
+Interactive terminals show one progress bar on stderr and suppress structured
+progress on terminal stdout. Redirected or piped stdout receives line-delimited
+JSON instead; carriage-return bars remain on stderr.
 
 ```shell
-go test ./src/batch -run '^$' \
-  -bench '^BenchmarkDurableBatchImport$' -benchtime=1x -count=20 -benchmem
-go test ./src/batch -run '^$' \
-  -bench '^BenchmarkCompletedManifestPreflight$' -benchtime=1x -count=20 -benchmem
+go-open-discogs-batch [options] | tee import.jsonl >/dev/null
 ```
+
+Byte progress measures download or compressed source consumption. Import
+progress reports only roots committed with their complete relation set.
+`committed_percent` is unavailable until end-of-stream validation establishes
+the exact total; the importer does not pre-scan large dumps merely to count
+roots.
+
+Do not merge stderr into stdout when collecting JSON.
 
 ## Container
 
-Release images are published from Release Please release commits:
+Release images support `linux/amd64` and `linux/arm64`.
 
 ```shell
-docker pull ghcr.io/dsub-io/go-open-discogs-batch:latest
-docker run --rm \
-  --cpus=4 \
+docker run --rm --cpus=4 \
   -e OPEN_DISCOGS_BATCH_DATABASE_URL='postgresql://user:password@db:5432/open_discogs' \
-  -e OPEN_DISCOGS_BATCH_DATABASE_SCHEMA='open_discogs' \
-  -e OPEN_DISCOGS_BATCH_ENTITIES='artist,label,master,release' \
+  -e OPEN_DISCOGS_BATCH_DATABASE_SCHEMA=open_discogs \
+  -e OPEN_DISCOGS_BATCH_ENTITIES=artist,label,master,release \
   -e OPEN_DISCOGS_BATCH_DATA_DIR=/data \
   -e OPEN_DISCOGS_BATCH_MAX_WORKERS=4 \
   -v open-discogs-data:/data \
   ghcr.io/dsub-io/go-open-discogs-batch:latest
 ```
 
-The image runs as a non-root user. Mount a writable volume when downloads must
-survive container removal. Setting `OPEN_DISCOGS_BATCH_CLEANUP=true` removes the
-selected files only after success.
+The image runs as non-root. Mount writable storage when downloads must survive
+container replacement. Inject the database URI through the deployment
+platform's secret mechanism.
 
-Versioned binaries are attached to the repository's GitHub Releases.
+Versioned binaries are available from GitHub Releases.
+
+## Resource sizing
+
+Peak application memory is driven by
+`chunk-size × max-workers × relation fan-out`, not total dump size. Release has
+the largest fan-out.
+
+1. Set `--max-workers` to the smaller of available CPU and database write
+   connections reserved for this job.
+2. Reduce `--chunk-size` when one expanded relation chunk uses too much memory.
+3. Reduce workers when concurrent chunks or PostgreSQL are the bottleneck.
+
+The PostgreSQL pool is bounded to `max-workers + 1`. Reference IDs use a
+segmented bit set, and writes stay below PostgreSQL's bind-parameter limit.
+Measured changes and reproduction commands are in
+[Performance](docs/performance.md).
 
 ## Development
+
+Source builds require Go 1.26. Integration tests require Docker and clean up
+their exact containers, networks, and volumes on success or failure.
 
 ```shell
 gofmt -w .
 go mod tidy
 go vet ./...
 go test -race -coverprofile=coverage.out -covermode=atomic ./...
-go test -run '^$' -bench 'IDSetLoadMillion' -benchmem ./src/cache
 ```
 
-Pull requests run formatting, module consistency, vet, race detection, unit and
-PostgreSQL integration tests, and a 100% statement coverage gate. The separate E2E workflow
-uses deterministic fixtures on GitHub-hosted `ubuntu-latest`; it does not depend
-on live Discogs availability.
-
-Pull request titles and commits must use Conventional Commits. Release Please
-publishes only release-relevant changes; documentation-only changes do not
-create a release.
+CI checks formatting, module consistency, vet, race detection, PostgreSQL
+integration behavior, deterministic dump E2E, and 100% statement coverage.
+Pull requests and commits use Conventional Commits. Release Please publishes
+release-relevant changes; documentation-only changes do not bump the version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Go OpenDiscogs Batch
 
-Stream Discogs monthly public data dumps into PostgreSQL with bounded memory
-and resumable, idempotent imports.
+Stream Discogs monthly public data dumps into PostgreSQL with bounded memory,
+durable progress, and idempotent recovery.
 
-Go and Java consume the same canonical schema published by
-[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model). This is
-an independent project and is not endorsed by Discogs.
+This release consumes canonical
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.0.
+Go and Java therefore apply the same migration bytes and import contracts. This
+is an independent project and is not endorsed by Discogs.
+
+> [!CAUTION]
+> **Production import is not approved yet.** Publish both batch implementations
+> against model v0.3.0 and complete cross-language migration, recovery, and
+> full-dump validation before starting or resuming a production import.
 
 - [Import safety and recovery](docs/import-safety.md)
 - [Performance measurements](docs/performance.md)
@@ -14,8 +20,8 @@ an independent project and is not endorsed by Discogs.
 ## Quick start
 
 The PostgreSQL database must already exist. The importer creates the selected
-schema when permitted, applies canonical migrations, downloads the dumps, and
-imports them.
+schema when permitted, applies canonical migrations, resolves and downloads the
+selected dumps, then imports them.
 
 ```shell
 go-open-discogs-batch \
@@ -25,85 +31,114 @@ go-open-discogs-batch \
 ```
 
 Omit `--dump-month` to select the latest dump for each entity independently.
-Use `--dump-month=2026-07` when every selected entity must come from that month.
+Use `--dump-month=2026-07` to require every selected entity from that month.
+Exact-month runs use a complete durable catalog without an upstream request;
+otherwise discovery performs the bounded request sequence documented in
+[Import safety and recovery](docs/import-safety.md#catalog-request-budget).
 
-## What an import guarantees
+## Import contract
 
-- Artist, label, master, and release dumps are decompressed and parsed as
-  streams; the full dump is never held in memory.
-- A compatible interrupted run resumes committed chunks. `--force` starts the
-  same manifest from zero.
-- A root and its complete relation set commit atomically with durable progress.
-- Removed relations are reconciled; roots absent from a newer dump are not
-  deleted.
-- Older dumps require `--allow-downgrade`. Downloads are retained unless a
-  successful run uses `--cleanup`.
+| Boundary | Behavior |
+| --- | --- |
+| Source | Monthly public dumps only; no Discogs API, live hydration, or user writes |
+| Memory | Dumps are decompressed and parsed as streams; the full dump is never held in memory |
+| Commit | A root, its supported relations, and durable chunk progress commit atomically |
+| Retry | Compatible interrupted runs resume verified chunks; `--force` restarts the same manifest from zero |
+| Convergence | Supported missing relations are removed; roots absent from a newer dump are not deleted |
+| Visibility | Readers can observe committed chunks; a complete monthly import is not an atomic snapshot switch |
+| Files | Failed-run downloads remain; `--cleanup` removes only this run's selected files after success |
 
-See [Import safety and recovery](docs/import-safety.md) for exact discovery,
-locking, interruption, convergence, and snapshot-visibility semantics.
+Older dumps require `--allow-downgrade`. See
+[Import safety and recovery](docs/import-safety.md) for admission, locking,
+interruption, and resume rules.
+
+### Release data scope
+
+| Release data | Current behavior |
+| --- | --- |
+| Imported | Core fields; release artists; labels and catalog numbers; companies; formats; genres and styles; identifiers; top-level tracks; videos; release-level credited artist ID and role |
+| Not imported | Series membership; per-track artists and extra artists; sub-track/index-track hierarchy; `anv`, `join`, and credit `tracks` metadata not represented by the canonical schema |
+| Images | The audited 2026-08 public release dump has no image elements; no separate image source is used |
+
+Downstream services must review the current
+[Discogs API Terms of Use](https://support.discogs.com/hc/en-us/articles/360009334593-API-Terms-of-Use)
+for every source they combine. A monthly snapshot cannot satisfy live API
+freshness by itself; attribution, refresh, caching, and redistribution remain
+the downstream operator's responsibility.
 
 ## Database setup
 
-There is no separate `init` command and the database itself is never created.
+PostgreSQL 15 or newer is required. There is no separate `init` command, and
+the importer never creates the database.
 
-| Target state | Required authority |
+| Target | Required authority |
 | --- | --- |
-| Schema does not exist | `CREATE` on the database |
-| Schema exists | `USAGE` and `CREATE` on the schema, table writes, and migration DDL authority |
-| Batch role cannot migrate | A DBA must prepare the schema and grants first |
+| Missing schema | `CREATE` on the database; the importer creates the selected schema |
+| Existing schema | `USAGE` and `CREATE` on the schema, table writes, and migration DDL authority |
+| Restricted batch role | A DBA prepares the schema, extension, and grants first |
 
-The default schema is `public` and produces a warning on every startup. Prefer
-a dedicated schema such as `open_discogs`. Schema names must be 1–63 lowercase
-letters, digits, or underscores and begin with a letter or underscore.
+Model v0.3.0 migrations are the only schema source of truth. Migration V007
+uses `CREATE EXTENSION IF NOT EXISTS pg_trgm`; allow the migration role to
+install this trusted extension or have a DBA pre-install it in a stable schema
+visible to the migration role. Catalog tables are still created only in the
+selected database schema.
+
+> [!WARNING]
+> Omitting `--database-schema` uses `public` and emits a warning on every
+> startup. Prefer a dedicated schema such as `open_discogs`.
+
+Schema names must be 1–63 lowercase letters, digits, or underscores and begin
+with a letter or underscore.
 
 ## Configuration
 
 Precedence is `CLI > ENV > default`.
 
-| CLI | Environment | Default | Purpose |
-| --- | --- | --- | --- |
-| `--database-url` | `OPEN_DISCOGS_BATCH_DATABASE_URL` | required | PostgreSQL URI; percent-encode credentials |
-| `--database-schema` | `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` | `public` | Schema to create or migrate |
-| `--entities`, `-e` | `OPEN_DISCOGS_BATCH_ENTITIES` | all | Comma-separated entity list |
-| `--dump-month`, `-m` | `OPEN_DISCOGS_BATCH_DUMP_MONTH` | latest per entity | Exact month in `yyyy-MM` |
-| `--data-dir` | `OPEN_DISCOGS_BATCH_DATA_DIR` | `~/.cache/open-discogs-batch` | Download directory |
-| `--chunk-size`, `-b` | `OPEN_DISCOGS_BATCH_CHUNK_SIZE` | `5000` | Roots per transaction chunk |
-| `--max-workers` | `OPEN_DISCOGS_BATCH_MAX_WORKERS` | runtime CPU allocation | Concurrent import workers |
-| `--cleanup`, `-c` | `OPEN_DISCOGS_BATCH_CLEANUP` | `false` | Remove selected dumps after success |
-| `--force`, `-f` | `OPEN_DISCOGS_BATCH_FORCE` | `false` | Reprocess a successful manifest |
-| `--allow-downgrade` | `OPEN_DISCOGS_BATCH_ALLOW_DOWNGRADE` | `false` | Permit and audit older dumps |
-| `--help`, `-h` | — | — | Show help without connecting to PostgreSQL |
-| `--version`, `-v` | — | — | Show version without connecting to PostgreSQL |
+| CLI | Environment | Type | Default | Required | Valid values / purpose |
+| --- | --- | --- | --- | --- | --- |
+| `--database-url` | `OPEN_DISCOGS_BATCH_DATABASE_URL` | URI | none | yes | `postgres[ql]://user:password@host[:port]/database`; percent-encode credentials |
+| `--database-schema` | `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` | string | `public` | no | 1–63 lowercase letters, digits, or underscores; starts with a letter or underscore |
+| `--entities`, `-e` | `OPEN_DISCOGS_BATCH_ENTITIES` | string list | all four | no | Non-empty subset of `artist,label,master,release` |
+| `--dump-month`, `-m` | `OPEN_DISCOGS_BATCH_DUMP_MONTH` | `yyyy-MM` | latest per entity | no | `2008-03` through the current calendar month |
+| `--data-dir` | `OPEN_DISCOGS_BATCH_DATA_DIR` | path | `~/.cache/open-discogs-batch` | no | Writable download directory |
+| `--chunk-size`, `-b` | `OPEN_DISCOGS_BATCH_CHUNK_SIZE` | integer | `5000` | no | `1..2,147,483,647`; roots per transaction chunk |
+| `--max-workers` | `OPEN_DISCOGS_BATCH_MAX_WORKERS` | integer | visible CPU count | no | `1..2,147,483,647`; concurrent import workers |
+| `--cleanup`, `-c` | `OPEN_DISCOGS_BATCH_CLEANUP` | boolean | `false` | no | Remove only selected dumps after successful import |
+| `--force`, `-f` | `OPEN_DISCOGS_BATCH_FORCE` | boolean | `false` | no | Reprocess an otherwise skippable successful manifest from zero |
+| `--allow-downgrade` | `OPEN_DISCOGS_BATCH_ALLOW_DOWNGRADE` | boolean | `false` | no | Permit and audit an older dump than the entity checkpoint |
+| `--help`, `-h` | — | action | `false` | no | Show help without connecting to PostgreSQL |
+| `--version`, `-v` | — | action | `false` | no | Show version without connecting to PostgreSQL |
 
-Keep credentials out of command history and inject the database URI through
-your platform's secret mechanism.
+Boolean ENV values accept `true/false`, `1/0`, `yes/no`, and `on/off`
+case-insensitively. `OPEN_DISCOGS_BATCH_ENTITIES` is comma-separated. Inject
+the database URI through a secret mechanism instead of command history.
 
-## Operate it
+## Operations
 
 ### Progress output
 
-An interactive terminal gets one progress bar on stderr. Redirected or piped
-stdout gets line-delimited JSON instead:
+| Destination | Output |
+| --- | --- |
+| Interactive stderr | One visual byte-progress bar for download or source read |
+| Non-terminal stdout | JSON progress records: `byte_progress` plus durable `import_progress` |
+| Terminal stdout | Structured records are suppressed |
 
-```shell
-go-open-discogs-batch [options] | tee import.jsonl >/dev/null
-```
+Byte progress describes transfer/read activity. Import progress reports
+durably committed roots, not merely parsed rows; its percentage appears only
+after an exact entity total is stored. Progress records are one JSON object per
+line, but ordinary lifecycle messages can also use stdout; do not treat the
+entire stream as a JSON-only document. Keep stderr separate from collectors.
 
-Do not merge stderr into stdout when collecting JSON. Import counters represent
-durably committed roots; a percentage appears only after the exact stream total
-has been established.
+### Resources
 
-### CPU and memory
+`--max-workers` limits import concurrency, not CPU usage. The default is the Go
+runtime's visible CPU count; no percentage heuristic is applied. Use container
+or scheduler limits for a hard CPU quota.
 
-`--max-workers` limits importer concurrency, not CPU usage. Omitted means the Go
-runtime's visible CPU allocation; no percentage heuristic is applied. Use
-container or scheduler CPU limits for a hard quota.
-
-Working memory is governed by `chunk-size × max-workers × relation fan-out`.
-Release has the highest fan-out. Start with workers no higher than the CPU and
-database connections reserved for the job, then reduce chunk size for memory
-pressure or workers for database contention. See [Performance measurements](docs/performance.md)
-for measured results and reproduction commands.
+Working memory grows with `chunk-size × max-workers × relation fan-out`.
+Release has the highest fan-out. The PostgreSQL pool allows at most
+`max-workers + 1` open connections: one per worker plus one coordinator. Agree
+that budget with the DBA and reduce chunk size or workers under pressure.
 
 ### Container
 
@@ -120,12 +155,15 @@ docker run --rm --cpus=4 \
   ghcr.io/dsub-io/go-open-discogs-batch:latest
 ```
 
-Mount writable storage when downloads must survive container replacement.
+Mount writable storage only when downloads must survive container replacement.
 
 ## Development
 
-Source builds require Go 1.26. Integration tests require Docker and remove the
-exact containers, networks, and volumes they create on success or failure.
+Source builds require Go 1.26. Integration tests label every owned Docker
+resource with a per-run identity and use tmpfs for PostgreSQL. In-process
+cleanup and CI's always-run teardown remove only those containers, networks,
+and volumes, then verify that residue is zero. Persistent test volumes and bind
+mounts are not allowed.
 
 ```shell
 gofmt -w .
@@ -135,7 +173,7 @@ go test -race -coverprofile=coverage.out -covermode=atomic ./...
 ```
 
 CI checks formatting, module consistency, vet, race detection, PostgreSQL and
-dump E2E behavior, and 100% statement coverage.
+dump E2E behavior, cleanup residue, and 100% statement coverage.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Go OpenDiscogs Batch
 
-Imports Discogs monthly public data dumps into PostgreSQL. Go and Java use the
-same schema published by
-[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model).
+Stream Discogs monthly public data dumps into PostgreSQL with bounded memory
+and resumable, idempotent imports.
 
-This project is independent from and not endorsed by Discogs.
+Go and Java consume the same canonical schema published by
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model). This is
+an independent project and is not endorsed by Discogs.
+
+- [Import safety and recovery](docs/import-safety.md)
+- [Performance measurements](docs/performance.md)
+- [Releases](https://github.com/dsub-io/go-open-discogs-batch/releases)
 
 ## Quick start
 
-The PostgreSQL database must exist. The importer creates the selected schema,
-applies canonical migrations, downloads the dumps, and imports them.
+The PostgreSQL database must already exist. The importer creates the selected
+schema when permitted, applies canonical migrations, downloads the dumps, and
+imports them.
 
 ```shell
 go-open-discogs-batch \
@@ -18,50 +24,43 @@ go-open-discogs-batch \
   --entities artist,label,master,release
 ```
 
-Without `--dump-month`, every selected entity uses its latest available dump.
-Use `--dump-month=2026-07` to require one exact month.
+Omit `--dump-month` to select the latest dump for each entity independently.
+Use `--dump-month=2026-07` when every selected entity must come from that month.
 
-## Import contract
+## What an import guarantees
 
-- Supported entities are `artist`, `label`, `master`, and `release`.
-- Downloads and XML parsing are streamed; a dump is never loaded as one
-  in-memory document.
-- A successful manifest is skipped before downloading when its entity
-  checkpoints are still current.
-- A compatible failed or interrupted run resumes committed chunks. `--force`
-  starts again from zero.
-- Each root and its complete relation set commit atomically with durable
-  progress.
-- Relations removed from a later representation of a root are deleted. Roots
-  absent from a complete dump are not deleted.
-- Older dumps are rejected unless `--allow-downgrade` is explicitly supplied.
-- Downloads remain on disk by default. `--cleanup` removes only files selected
-  by a successful import or successful-manifest skip.
+- Artist, label, master, and release dumps are decompressed and parsed as
+  streams; the full dump is never held in memory.
+- A compatible interrupted run resumes committed chunks. `--force` starts the
+  same manifest from zero.
+- A root and its complete relation set commit atomically with durable progress.
+- Removed relations are reconciled; roots absent from a newer dump are not
+  deleted.
+- Older dumps require `--allow-downgrade`. Downloads are retained unless a
+  successful run uses `--cleanup`.
 
-See [Import safety and recovery](docs/import-safety.md) for manifest selection,
-locking, convergence, interruption, and snapshot visibility.
+See [Import safety and recovery](docs/import-safety.md) for exact discovery,
+locking, interruption, convergence, and snapshot-visibility semantics.
 
-## Database and permissions
+## Database setup
 
-The database itself is never created. A normal run creates a missing
-`--database-schema` and the canonical tables inside it; there is no separate
-`init` command.
+There is no separate `init` command and the database itself is never created.
 
-- Creating a schema requires `CREATE` on the database.
-- Migrating an existing schema requires `USAGE` and `CREATE` on that schema,
-  write access to imported tables, and DDL ownership or equivalent authority.
-- If the batch role cannot create or migrate schemas, a DBA must prepare and
-  grant the schema first.
+| Target state | Required authority |
+| --- | --- |
+| Schema does not exist | `CREATE` on the database |
+| Schema exists | `USAGE` and `CREATE` on the schema, table writes, and migration DDL authority |
+| Batch role cannot migrate | A DBA must prepare the schema and grants first |
 
-The default schema is `public`, and every such startup emits a warning. Prefer
-a dedicated schema such as `open_discogs`. Names must be 1–63 lowercase
+The default schema is `public` and produces a warning on every startup. Prefer
+a dedicated schema such as `open_discogs`. Schema names must be 1–63 lowercase
 letters, digits, or underscores and begin with a letter or underscore.
 
 ## Configuration
 
 Precedence is `CLI > ENV > default`.
 
-| CLI | Environment | Default | Meaning |
+| CLI | Environment | Default | Purpose |
 | --- | --- | --- | --- |
 | `--database-url` | `OPEN_DISCOGS_BATCH_DATABASE_URL` | required | PostgreSQL URI; percent-encode credentials |
 | `--database-schema` | `OPEN_DISCOGS_BATCH_DATABASE_SCHEMA` | `public` | Schema to create or migrate |
@@ -70,37 +69,45 @@ Precedence is `CLI > ENV > default`.
 | `--data-dir` | `OPEN_DISCOGS_BATCH_DATA_DIR` | `~/.cache/open-discogs-batch` | Download directory |
 | `--chunk-size`, `-b` | `OPEN_DISCOGS_BATCH_CHUNK_SIZE` | `5000` | Roots per transaction chunk |
 | `--max-workers` | `OPEN_DISCOGS_BATCH_MAX_WORKERS` | runtime CPU allocation | Concurrent import workers |
-| `--cleanup`, `-c` | `OPEN_DISCOGS_BATCH_CLEANUP` | `false` | Delete selected dumps after success |
+| `--cleanup`, `-c` | `OPEN_DISCOGS_BATCH_CLEANUP` | `false` | Remove selected dumps after success |
 | `--force`, `-f` | `OPEN_DISCOGS_BATCH_FORCE` | `false` | Reprocess a successful manifest |
 | `--allow-downgrade` | `OPEN_DISCOGS_BATCH_ALLOW_DOWNGRADE` | `false` | Permit and audit older dumps |
-| `--help`, `-h` | — | — | Show help without a database connection |
-| `--version`, `-v` | — | — | Show version without a database connection |
+| `--help`, `-h` | — | — | Show help without connecting to PostgreSQL |
+| `--version`, `-v` | — | — | Show version without connecting to PostgreSQL |
 
-`--max-workers` is an application concurrency limit, not a CPU quota. When it
-is omitted, the Go runtime's CPU allocation is used without a percentage
-heuristic. Use container or scheduler CPU limits for a hard allocation.
+Keep credentials out of command history and inject the database URI through
+your platform's secret mechanism.
 
-## Progress and logs
+## Operate it
 
-Interactive terminals show one progress bar on stderr and suppress structured
-progress on terminal stdout. Redirected or piped stdout receives line-delimited
-JSON instead; carriage-return bars remain on stderr.
+### Progress output
+
+An interactive terminal gets one progress bar on stderr. Redirected or piped
+stdout gets line-delimited JSON instead:
 
 ```shell
 go-open-discogs-batch [options] | tee import.jsonl >/dev/null
 ```
 
-Byte progress measures download or compressed source consumption. Import
-progress reports only roots committed with their complete relation set.
-`committed_percent` is unavailable until end-of-stream validation establishes
-the exact total; the importer does not pre-scan large dumps merely to count
-roots.
+Do not merge stderr into stdout when collecting JSON. Import counters represent
+durably committed roots; a percentage appears only after the exact stream total
+has been established.
 
-Do not merge stderr into stdout when collecting JSON.
+### CPU and memory
 
-## Container
+`--max-workers` limits importer concurrency, not CPU usage. Omitted means the Go
+runtime's visible CPU allocation; no percentage heuristic is applied. Use
+container or scheduler CPU limits for a hard quota.
 
-Release images support `linux/amd64` and `linux/arm64`.
+Working memory is governed by `chunk-size × max-workers × relation fan-out`.
+Release has the highest fan-out. Start with workers no higher than the CPU and
+database connections reserved for the job, then reduce chunk size for memory
+pressure or workers for database contention. See [Performance measurements](docs/performance.md)
+for measured results and reproduction commands.
+
+### Container
+
+The non-root image supports `linux/amd64` and `linux/arm64`.
 
 ```shell
 docker run --rm --cpus=4 \
@@ -113,32 +120,12 @@ docker run --rm --cpus=4 \
   ghcr.io/dsub-io/go-open-discogs-batch:latest
 ```
 
-The image runs as non-root. Mount writable storage when downloads must survive
-container replacement. Inject the database URI through the deployment
-platform's secret mechanism.
-
-Versioned binaries are available from GitHub Releases.
-
-## Resource sizing
-
-Peak application memory is driven by
-`chunk-size × max-workers × relation fan-out`, not total dump size. Release has
-the largest fan-out.
-
-1. Set `--max-workers` to the smaller of available CPU and database write
-   connections reserved for this job.
-2. Reduce `--chunk-size` when one expanded relation chunk uses too much memory.
-3. Reduce workers when concurrent chunks or PostgreSQL are the bottleneck.
-
-The PostgreSQL pool is bounded to `max-workers + 1`. Reference IDs use a
-segmented bit set, and writes stay below PostgreSQL's bind-parameter limit.
-Measured changes and reproduction commands are in
-[Performance](docs/performance.md).
+Mount writable storage when downloads must survive container replacement.
 
 ## Development
 
-Source builds require Go 1.26. Integration tests require Docker and clean up
-their exact containers, networks, and volumes on success or failure.
+Source builds require Go 1.26. Integration tests require Docker and remove the
+exact containers, networks, and volumes they create on success or failure.
 
 ```shell
 gofmt -w .
@@ -147,12 +134,10 @@ go vet ./...
 go test -race -coverprofile=coverage.out -covermode=atomic ./...
 ```
 
-CI checks formatting, module consistency, vet, race detection, PostgreSQL
-integration behavior, deterministic dump E2E, and 100% statement coverage.
-Pull requests and commits use Conventional Commits. Release Please publishes
-release-relevant changes; documentation-only changes do not bump the version.
+CI checks formatting, module consistency, vet, race detection, PostgreSQL and
+dump E2E behavior, and 100% statement coverage.
 
 ## License
 
-MIT. See [LICENSE](LICENSE). The `state303` attribution must be retained as
-required by the license.
+MIT. See [LICENSE](LICENSE). Retain the `state303` attribution required by the
+license.

--- a/docs/import-safety.md
+++ b/docs/import-safety.md
@@ -1,0 +1,84 @@
+# Import safety and recovery
+
+This document defines the operational boundary behind the shorter README.
+
+## Dump discovery
+
+Artist, label, master, and release select their newest dumps independently
+unless `--dump-month` requests an exact month. Every run records dump dates,
+SHA-256 checksums, source URIs, and stable identifiers in one immutable
+manifest.
+
+An exact month first uses a complete matching PostgreSQL catalog entry. Missing
+entities from 2021 onward require one monthly checksum request; older irregular
+publication dates require one annual catalog request and one checksum request.
+Selected URIs and checksums are stored before file download. Retries reuse this
+pinned catalog. Latest-per-entity selection refreshes upstream because the
+local catalog cannot prove that no newer dump exists.
+
+Catalog and file access use the official `data.discogs.com` browser. Rounded
+catalog display sizes are stored as unknown (`size_bytes=0`); byte progress
+uses HTTP `Content-Length` or the exact local file size. A 429, 5xx, timeout, or
+malformed catalog response fails without speculative request retries. If a
+latest-catalog refresh fails, a locally stored catalog may be used only when it
+fully satisfies the request.
+
+## Admission and locking
+
+A successful manifest is skipped before file download and checksum work only
+while all selected entity dumps remain current checkpoints and no later failed
+or abandoned run has dirtied those entities.
+
+PostgreSQL advisory locks cover selected entities and their references:
+
+- Artist locks Artist.
+- Label locks Label.
+- Master locks Artist and Master.
+- Release locks Artist, Label, Master, and Release because it also updates
+  `master.main_release_id`.
+
+Independent sets such as Artist and Label may run together. Overlapping Go and
+Java imports cannot write concurrently.
+
+## Commit and convergence boundary
+
+For every tracked chunk, canonical roots, each root's exact relations, the
+committed-chunk ledger, and the processed-item counter share one PostgreSQL
+transaction. Missing relations are deleted, mutable values are updated, and
+unchanged rows retain their surrogate IDs. Root rows are upserted; roots absent
+from the complete dump are not currently deleted.
+
+An entity completes only when chunk indexes cover the parsed stream with no
+gaps, overlaps, or out-of-range indexes and item and chunk totals match. A run
+becomes successful only after every selected entity completes.
+
+The schema still uses signed 32-bit Java hashes for several relation identities.
+Distinct values can collide within one root. Migration to collision-resistant
+identity is tracked in
+[`open-discogs-model#43`](https://github.com/dsub-io/open-discogs-model/issues/43).
+
+## Interruption and resume
+
+`SIGINT` and `SIGTERM` cancel download, parsing, and database work. The active
+chunk rolls back; run failure is recorded with a separate bounded completion
+context. `SIGKILL`, host loss, or a database disconnect may leave a run marked
+`running`.
+
+After acquiring the required locks, the next process marks an abandoned run
+failed and transfers its valid ledger atomically. Resume requires the same
+manifest, processor name and version, entity and dump identity, and chunk size.
+If transfer fails, the new run rolls back and the source ledger remains
+authoritative.
+
+Every chunk fences on its owning run row. A delayed worker cannot commit after
+that run is abandoned. Failed ledgers remain until compatible current success
+checkpoints supersede every entity and dump pair they protect.
+
+## Snapshot visibility
+
+Atomicity is per chunk, not per monthly snapshot. Permanent full-dump staging
+is intentionally avoided because it would duplicate a catalog exceeding 200
+million records. Readers may observe committed chunks during an import.
+
+Deployments requiring an all-at-once switch must import into a separate
+versioned database or replica and promote it after validation.

--- a/docs/import-safety.md
+++ b/docs/import-safety.md
@@ -1,6 +1,19 @@
 # Import safety and recovery
 
-This document defines the operational boundary behind the shorter README.
+This is the detailed contract for dump selection, concurrent runs, commits,
+recovery, and reader visibility. For normal setup, start with the
+[README](../README.md).
+
+## At a glance
+
+| Event | Result |
+| --- | --- |
+| Same successful manifest | Skip before downloading while checkpoints remain current |
+| Compatible interrupted run | Resume only verified committed chunks |
+| Different manifest or `--force` | Start from zero |
+| Older entity dump | Reject unless `--allow-downgrade` is set |
+| Failed import | Keep downloaded files and durable progress |
+| Successful import with `--cleanup` | Remove only files selected by that import |
 
 ## Dump discovery
 
@@ -9,12 +22,17 @@ unless `--dump-month` requests an exact month. Every run records dump dates,
 SHA-256 checksums, source URIs, and stable identifiers in one immutable
 manifest.
 
-An exact month first uses a complete matching PostgreSQL catalog entry. Missing
-entities from 2021 onward require one monthly checksum request; older irregular
-publication dates require one annual catalog request and one checksum request.
+Discovery depends on the request:
+
+- An exact month first uses a complete matching PostgreSQL catalog entry.
+- Missing entities from 2021 onward require one monthly checksum request.
+- Older irregular publication dates require one annual catalog request and one
+  checksum request.
+- Latest-per-entity selection refreshes upstream because a local catalog cannot
+  prove that no newer dump exists.
+
 Selected URIs and checksums are stored before file download. Retries reuse this
-pinned catalog. Latest-per-entity selection refreshes upstream because the
-local catalog cannot prove that no newer dump exists.
+pinned catalog.
 
 Catalog and file access use the official `data.discogs.com` browser. Rounded
 catalog display sizes are stored as unknown (`size_bytes=0`); byte progress
@@ -31,22 +49,29 @@ or abandoned run has dirtied those entities.
 
 PostgreSQL advisory locks cover selected entities and their references:
 
-- Artist locks Artist.
-- Label locks Label.
-- Master locks Artist and Master.
-- Release locks Artist, Label, Master, and Release because it also updates
-  `master.main_release_id`.
+| Import | Locks |
+| --- | --- |
+| Artist | Artist |
+| Label | Label |
+| Master | Artist, Master |
+| Release | Artist, Label, Master, Release |
+
+Release takes the full set because it also updates `master.main_release_id`.
 
 Independent sets such as Artist and Label may run together. Overlapping Go and
 Java imports cannot write concurrently.
 
 ## Commit and convergence boundary
 
-For every tracked chunk, canonical roots, each root's exact relations, the
-committed-chunk ledger, and the processed-item counter share one PostgreSQL
-transaction. Missing relations are deleted, mutable values are updated, and
-unchanged rows retain their surrogate IDs. Root rows are upserted; roots absent
-from the complete dump are not currently deleted.
+For every tracked chunk, one PostgreSQL transaction contains:
+
+- canonical roots and each root's exact relation set;
+- the committed-chunk ledger entry;
+- the processed-item counter.
+
+Missing relations are deleted, mutable values are updated, and unchanged rows
+retain their surrogate IDs. Root rows are upserted; roots absent from the
+complete dump are not currently deleted.
 
 An entity completes only when chunk indexes cover the parsed stream with no
 gaps, overlaps, or out-of-range indexes and item and chunk totals match. A run
@@ -65,8 +90,14 @@ context. `SIGKILL`, host loss, or a database disconnect may leave a run marked
 `running`.
 
 After acquiring the required locks, the next process marks an abandoned run
-failed and transfers its valid ledger atomically. Resume requires the same
-manifest, processor name and version, entity and dump identity, and chunk size.
+failed and transfers its valid ledger atomically. Resume requires an exact
+match on:
+
+- manifest;
+- processor name and version;
+- entity and dump identity;
+- chunk size.
+
 If transfer fails, the new run rolls back and the source ledger remains
 authoritative.
 

--- a/docs/import-safety.md
+++ b/docs/import-safety.md
@@ -1,51 +1,53 @@
 # Import safety and recovery
 
-This is the detailed contract for dump selection, concurrent runs, commits,
-recovery, and reader visibility. For normal setup, start with the
-[README](../README.md).
+This is the operational contract for dump discovery, admission, commits,
+recovery, and reader visibility. The schema contract is canonical
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.0,
+shared with the Java importer.
 
-## At a glance
+> [!CAUTION]
+> Production import is not approved yet. Release both importers against model
+> v0.3.0 and finish cross-language migration, recovery, and full-dump validation
+> before starting or resuming one.
+
+## Decision table
 
 | Event | Result |
 | --- | --- |
-| Same successful manifest | Skip before downloading while checkpoints remain current |
-| Compatible interrupted run | Resume only verified committed chunks |
+| Same successful manifest | Skip before download only while selected checkpoints remain current and no later failed or abandoned run has dirtied them |
+| Compatible interrupted run | Resume verified committed chunks |
 | Different manifest or `--force` | Start from zero |
 | Older entity dump | Reject unless `--allow-downgrade` is set |
-| Failed import | Keep downloaded files and durable progress |
+| Failed import | Keep downloads and durable progress |
 | Successful import with `--cleanup` | Remove only files selected by that import |
 
-## Dump discovery
+## Catalog request budget
 
 Artist, label, master, and release select their newest dumps independently
-unless `--dump-month` requests an exact month. Every run records dump dates,
+unless `--dump-month` requests an exact month. Every run pins dump dates,
 SHA-256 checksums, source URIs, and stable identifiers in one immutable
-manifest.
+manifest before download.
 
-Discovery depends on the request:
+| Selection | Complete durable catalog | Upstream requests when needed |
+| --- | --- | --- |
+| Exact month, 2021 or newer | Reuse it; **0 requests** | Exactly **1** direct monthly checksum-manifest request |
+| Exact month, before 2021 | Reuse it; **0 requests** | Exactly **1** annual catalog request plus **1 checksum request per distinct selected dump date** |
+| Latest per entity | Refresh because local state cannot prove newest | Exactly **1** root-index request, **1** latest-year catalog request, and **1 checksum request per distinct selected dump date** |
 
-- An exact month first uses a complete matching PostgreSQL catalog entry.
-- Missing entities from 2021 onward require one monthly checksum request.
-- Older irregular publication dates require one annual catalog request and one
-  checksum request.
-- Latest-per-entity selection refreshes upstream because a local catalog cannot
-  prove that no newer dump exists.
+A document is requested once; HTTP 429, 5xx, timeout, and malformed content do
+not trigger speculative retries. If latest discovery fails, a durable catalog
+is accepted only when it contains a complete selection. Exact-month discovery
+fails after its single bounded refresh attempt.
 
-Selected URIs and checksums are stored before file download. Retries reuse this
-pinned catalog.
-
-Catalog and file access use the official `data.discogs.com` browser. Rounded
-catalog display sizes are stored as unknown (`size_bytes=0`); byte progress
-uses HTTP `Content-Length` or the exact local file size. A 429, 5xx, timeout, or
-malformed catalog response fails without speculative request retries. If a
-latest-catalog refresh fails, a locally stored catalog may be used only when it
-fully satisfies the request.
+Selected URIs and checksums are persisted before file download, so a retry
+reuses the pinned catalog. Rounded HTML sizes are stored as unknown
+(`size_bytes=0`); byte progress uses an exact HTTP `Content-Length` or local
+file size when available.
 
 ## Admission and locking
 
-A successful manifest is skipped before file download and checksum work only
-while all selected entity dumps remain current checkpoints and no later failed
-or abandoned run has dirtied those entities.
+A successful manifest is skippable only while every selected entity remains
+the current checkpoint and no newer failed or abandoned run has dirtied it.
 
 PostgreSQL advisory locks cover selected entities and their references:
 
@@ -56,60 +58,75 @@ PostgreSQL advisory locks cover selected entities and their references:
 | Master | Artist, Master |
 | Release | Artist, Label, Master, Release |
 
-Release takes the full set because it also updates `master.main_release_id`.
+Release takes all locks because it also updates `master.main_release_id`.
+Independent sets such as Artist and Label may run together; overlapping Go and
+Java imports cannot write concurrently. Schema migration takes the same shared
+lock family, so migration cannot race an active importer.
 
-Independent sets such as Artist and Label may run together. Overlapping Go and
-Java imports cannot write concurrently.
+A partial Master or Release import is admitted only when each omitted reference
+entity has a compatible successful checkpoint. A missing checkpoint, a stale
+checkpoint, or a same-date dump reissued with a different checksum fails before
+the batch writes data. Selecting the dependency in the same run satisfies this
+preflight.
 
-## Commit and convergence boundary
+## Atomicity and idempotency
 
-For every tracked chunk, one PostgreSQL transaction contains:
+For each tracked chunk, one PostgreSQL transaction contains:
 
-- canonical roots and each root's exact relation set;
+- canonical root rows and each root's exact supported relation set;
 - the committed-chunk ledger entry;
 - the processed-item counter.
 
-Missing relations are deleted, mutable values are updated, and unchanged rows
-retain their surrogate IDs. Root rows are upserted; roots absent from the
-complete dump are not currently deleted.
+The model v0.3.0 import contract is part of resume and success compatibility.
+An older successful Release contract cannot suppress the corrected Release
+import semantics published by that model.
 
-An entity completes only when chunk indexes cover the parsed stream with no
-gaps, overlaps, or out-of-range indexes and item and chunk totals match. A run
-becomes successful only after every selected entity completes.
+Missing supported relations are deleted, mutable values are updated, and
+unchanged rows retain their surrogate IDs. Exact relation duplicates collapse
+by canonical PostgreSQL conflict keys; conflicting payloads for one key fail
+before SQL instead of applying first- or last-write-wins. Root rows are
+upserted, but roots absent from the complete dump are not deleted.
 
-The schema still uses signed 32-bit Java hashes for several relation identities.
-Distinct values can collide within one root. Migration to collision-resistant
-identity is tracked in
+An entity completes only when chunk indexes cover the parsed stream without
+gaps, overlaps, or out-of-range values and all item and chunk totals match. A
+run succeeds only after every selected entity completes.
+
+Several relation identities still use signed 32-bit Java hashes. Distinct
+values can collide within one root; collision-resistant identity is tracked in
 [`open-discogs-model#43`](https://github.com/dsub-io/open-discogs-model/issues/43).
 
 ## Interruption and resume
 
 `SIGINT` and `SIGTERM` cancel download, parsing, and database work. The active
-chunk rolls back; run failure is recorded with a separate bounded completion
-context. `SIGKILL`, host loss, or a database disconnect may leave a run marked
+chunk rolls back; run failure is recorded through a separate bounded completion
+context. `SIGKILL`, host loss, or database loss may leave a run marked
 `running`.
 
-After acquiring the required locks, the next process marks an abandoned run
-failed and transfers its valid ledger atomically. Resume requires an exact
+After taking the required locks, the next process marks an abandoned run failed
+and atomically transfers its valid ledger. Resume requires an exact compatible
 match on:
 
-- manifest;
+- manifest and per-entity import contract revision;
 - processor name and version;
 - entity and dump identity;
 - chunk size.
 
 If transfer fails, the new run rolls back and the source ledger remains
-authoritative.
+authoritative. Each chunk fences on its owning run row, so a delayed worker
+cannot commit after abandonment. Failed ledgers remain until compatible current
+success checkpoints supersede every protected entity/dump pair.
 
-Every chunk fences on its owning run row. A delayed worker cannot commit after
-that run is abandoned. Failed ledgers remain until compatible current success
-checkpoints supersede every entity and dump pair they protect.
-
-## Snapshot visibility
+## Visibility and cleanup
 
 Atomicity is per chunk, not per monthly snapshot. Permanent full-dump staging
-is intentionally avoided because it would duplicate a catalog exceeding 200
-million records. Readers may observe committed chunks during an import.
+is avoided because it would duplicate a catalog exceeding 200 million records.
+Readers may observe committed chunks during import. Deployments requiring an
+all-at-once switch must import into a separate versioned database or replica,
+validate it, and then promote it.
 
-Deployments requiring an all-at-once switch must import into a separate
-versioned database or replica and promote it after validation.
+Downloaded data cleanup and test infrastructure cleanup are separate:
+
+- `--cleanup` removes only manifest-selected dump files after durable success.
+- Integration tests use per-run Docker labels and PostgreSQL tmpfs. In-process
+  cleanup and CI's always-run teardown remove only owned containers, networks,
+  and volumes, then verify zero residue.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,7 +1,9 @@
 # Performance measurements
 
 These measurements isolate named changes. They are not estimates of full-dump
-throughput on other hardware.
+throughput on other hardware. See the [README](../README.md) for sizing guidance
+and [Import safety and recovery](import-safety.md) for the guarantees whose cost
+is measured here.
 
 ## Reference ID cache
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,15 +1,25 @@
 # Performance measurements
 
-These measurements isolate named changes. They are not estimates of full-dump
-throughput on other hardware. See the [README](../README.md) for sizing guidance
-and [Import safety and recovery](import-safety.md) for the guarantees whose cost
-is measured here.
+These are bounded measurements of named changes, not forecasts for a full dump
+or different hardware. They also do not approve a production import: both
+batch implementations still require release and cross-language validation
+against canonical `open-discogs-model` v0.3.0.
+
+## Results at a glance
+
+| Change | Measured outcome | Scope |
+| --- | --- | --- |
+| Reference ID cache | 25.4× lower median time; 99.88% fewer allocated bytes | 1,000,000 sequential IDs |
+| Durable import contract | Higher fixed latency and allocation | 12-record PostgreSQL fixture |
+| Successful-manifest preflight | 95.4% lower p50; avoided 64 MiB file I/O | Cached sparse file |
+
+Do not compare rows across these harnesses. Their inputs, paths, and units are
+different.
 
 ## Reference ID cache
 
-On an Apple M2 Pro, the previous `sync.Map` and the segmented bit set were
-compared with 1,000,000 sequential IDs, three iterations per sample and five
-samples.
+On an Apple M2 Pro, the previous `sync.Map` and segmented bit set were compared
+with 1,000,000 sequential IDs, three iterations per sample, and five samples.
 
 | Metric | Before | After | Change |
 | --- | ---: | ---: | ---: |
@@ -18,7 +28,8 @@ samples.
 | Allocations/op | 2,359,348 | 39 | 99.998% lower |
 
 Release-to-master updates also changed up to 5,000 row-by-row statements at the
-default chunk size into one set-based statement.
+default chunk size into one set-based statement. That is a statement-count
+fact; no latency improvement was measured for this change.
 
 ## Durable import cost
 
@@ -39,7 +50,7 @@ The added fixed cost buys active-run fencing, exact chunk-ledger commits,
 coverage validation, and stale-relation reconciliation. A 12-record fixture
 exaggerates this cost and cannot represent a full import.
 
-## Successful-manifest skip
+## Successful-manifest preflight
 
 The same successful manifest and a cached 64 MiB sparse file compared checksum
 before admission with admission before checksum.
@@ -51,16 +62,30 @@ before admission with admission before checksum.
 | Allocations/op | 113 | 106 | 6.2% lower |
 | Avoided file I/O | — | 64 MiB/invocation | — |
 
-Peak RSS was not reported because the microbenchmark process includes test and
-container lifecycle overhead while the fixture is too small to represent
+Peak RSS is not reported: the microbenchmark process includes test and
+container lifecycle overhead, while the fixture is too small to represent
 production memory.
 
-## Reproduction
+## Reproduce
 
 ```shell
 go test ./src/batch -run '^$' \
-  -bench '^BenchmarkDurableBatchImport$' -benchtime=1x -count=20 -benchmem
+  -bench '^(BenchmarkBatchImport|BenchmarkDurableBatchImport)$' \
+  -benchtime=1x -count=20 -benchmem
 go test ./src/batch -run '^$' \
   -bench '^BenchmarkCompletedManifestPreflight$' -benchtime=1x -count=20 -benchmem
-go test -run '^$' -bench 'IDSetLoadMillion' -benchmem ./src/cache
+go test ./src/cache -run '^$' \
+  -bench '^(BenchmarkIDSetLoadMillion|BenchmarkSyncMapIDSetLoadMillion)$' \
+  -benchtime=3x -count=5 -benchmem
 ```
+
+Each command includes both comparison paths or implementations. The cache
+command matches the recorded three iterations and five samples. Exact published
+numbers still require the stated Apple M2 Pro and PostgreSQL 18.4 tmpfs
+environment, equivalent system load, and the same Go toolchain. Results from
+another machine are new measurements, not a reproduction of these tables.
+
+These fixtures do not measure a production-sized dump, cold storage, network
+download, or peak process RSS. The preflight benchmark uses a sparse file and
+the import benchmark uses 12 records; neither may be extrapolated to the
+200-million-row deployment.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,64 @@
+# Performance measurements
+
+These measurements isolate named changes. They are not estimates of full-dump
+throughput on other hardware.
+
+## Reference ID cache
+
+On an Apple M2 Pro, the previous `sync.Map` and the segmented bit set were
+compared with 1,000,000 sequential IDs, three iterations per sample and five
+samples.
+
+| Metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Median time | 234.656 ms | 9.257 ms | 25.4× faster |
+| Allocated bytes/op | 109.5 MB | 132.9 KB | 99.88% lower |
+| Allocations/op | 2,359,348 | 39 | 99.998% lower |
+
+Release-to-master updates also changed up to 5,000 row-by-row statements at the
+default chunk size into one set-based statement.
+
+## Durable import cost
+
+Commit `2a1ddbd` and the recovery implementation were measured on the same
+Apple M2 Pro with PostgreSQL 18.4 Alpine on tmpfs, four 3-record fixtures,
+`chunk-size=5`, `max-workers=2`, one import per sample, and 20 samples.
+
+| Path | Metric | Before | After | Change |
+| --- | --- | ---: | ---: | ---: |
+| Initial | p50/p95/p99 | 48.509/54.527/80.881 ms | 73.922/77.397/88.551 ms | +52.4%/+41.9%/+9.5% |
+| Initial | median throughput | 0.167 MB/s | 0.109 MB/s | 34.4% lower |
+| Initial | allocated bytes/op | 2,327,712 | 2,454,276 | 5.4% higher |
+| Forced repeat | p50/p95/p99 | 38.864/43.826/44.841 ms | 72.822/74.057/74.204 ms | +87.4%/+69.0%/+65.5% |
+| Forced repeat | median throughput | 0.208 MB/s | 0.111 MB/s | 46.6% lower |
+| Forced repeat | allocated bytes/op | 2,340,796 | 2,466,576 | 5.4% higher |
+
+The added fixed cost buys active-run fencing, exact chunk-ledger commits,
+coverage validation, and stale-relation reconciliation. A 12-record fixture
+exaggerates this cost and cannot represent a full import.
+
+## Successful-manifest skip
+
+The same successful manifest and a cached 64 MiB sparse file compared checksum
+before admission with admission before checksum.
+
+| Metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| p50/p95/p99 | 38.917/50.768/58.719 ms | 1.776/2.728/3.038 ms | 95.4%/94.6%/94.8% lower |
+| Median allocations | 40,008 B/op | 6,800 B/op | 83.0% lower |
+| Allocations/op | 113 | 106 | 6.2% lower |
+| Avoided file I/O | — | 64 MiB/invocation | — |
+
+Peak RSS was not reported because the microbenchmark process includes test and
+container lifecycle overhead while the fixture is too small to represent
+production memory.
+
+## Reproduction
+
+```shell
+go test ./src/batch -run '^$' \
+  -bench '^BenchmarkDurableBatchImport$' -benchtime=1x -count=20 -benchmem
+go test ./src/batch -run '^$' \
+  -bench '^BenchmarkCompletedManifestPreflight$' -benchtime=1x -count=20 -benchmem
+go test -run '^$' -bench 'IDSetLoadMillion' -benchmem ./src/cache
+```

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsub-io/open-discogs-model v0.2.2
+	github.com/dsub-io/open-discogs-model v0.3.0
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dsub-io/open-discogs-model v0.2.2 h1:/BvSrMTEZryWGgcn8F0jDGEVCbT9950Rbt+X02nQL2s=
-github.com/dsub-io/open-discogs-model v0.2.2/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
+github.com/dsub-io/open-discogs-model v0.3.0 h1:F6V2W5FQ9DaIsFmkPrIfZi2ffJWbQTY37VmlRNxoi1Q=
+github.com/dsub-io/open-discogs-model v0.3.0/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=

--- a/internal/testutils/testcontainer.go
+++ b/internal/testutils/testcontainer.go
@@ -3,6 +3,8 @@ package testutils
 import (
 	"context"
 	"fmt"
+	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -28,7 +30,22 @@ const (
 	postgresWaitLog       = `database system is ready to accept connections`
 	testOwnerLabelKey     = "io.dsub.test-owner"
 	testOwnerLabelValue   = "go-open-discogs-batch"
+	testRunIDEnv          = "OPEN_DISCOGS_TEST_RUN_ID"
+	testRunIDLabelKey     = "io.dsub.test-run"
+	testRunIDLocalPrefix  = "local"
+	testRunIDMaxLength    = 128
 	postgresDataDirectory = "/var/lib/postgresql"
+)
+
+var (
+	createPostgresContainer = startPostgresContainer
+	localTestRunID          = fmt.Sprintf(
+		"%s-%d-%d",
+		testRunIDLocalPrefix,
+		os.Getpid(),
+		time.Now().UTC().UnixNano(),
+	)
+	testRunIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
 )
 
 type Database struct {
@@ -53,8 +70,6 @@ type postgresContainer interface {
 	Host(context.Context) (string, error)
 	MappedPort(context.Context, string) (network.Port, error)
 }
-
-var createPostgresContainer = startPostgresContainer
 
 func startPostgresContainer(
 	ctx context.Context,
@@ -93,6 +108,11 @@ func GetDatabase(t testing.TB, db DatabaseType) Database {
 
 func setupPostgres(t testReporter) Database {
 	t.Helper()
+	testRunID, err := currentTestRunID()
+	if err != nil {
+		t.Fatalf("resolve PostgreSQL test run identity: %v", err)
+		return Database{}
+	}
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{},
@@ -106,6 +126,7 @@ func setupPostgres(t testReporter) Database {
 		ExposedPorts: []string{postgresPort},
 		Labels: map[string]string{
 			testOwnerLabelKey: testOwnerLabelValue,
+			testRunIDLabelKey: testRunID,
 		},
 		Tmpfs: map[string]string{
 			postgresDataDirectory: "rw,noexec,nosuid,size=512m",
@@ -131,6 +152,21 @@ func setupPostgres(t testReporter) Database {
 		return Database{}
 	}
 	return database
+}
+
+func currentTestRunID() (string, error) {
+	testRunID := os.Getenv(testRunIDEnv)
+	if testRunID == "" {
+		testRunID = localTestRunID
+	}
+	if len(testRunID) > testRunIDMaxLength || !testRunIDPattern.MatchString(testRunID) {
+		return "", fmt.Errorf(
+			"%s must be 1-%d characters using letters, digits, dot, underscore, or hyphen",
+			testRunIDEnv,
+			testRunIDMaxLength,
+		)
+	}
+	return testRunID, nil
 }
 
 func reportPostgresTermination(t testReporter, dbContainer postgresContainer) {

--- a/internal/testutils/testcontainer_test.go
+++ b/internal/testutils/testcontainer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -73,6 +74,69 @@ func validPostgresContainerStub() *postgresContainerStub {
 		host:       "127.0.0.1",
 		port:       network.MustParsePort("15432/tcp"),
 	}
+}
+
+func TestCurrentTestRunID(t *testing.T) {
+	t.Setenv(testRunIDEnv, "")
+	actual, err := currentTestRunID()
+	require.NoError(t, err)
+	require.Equal(t, localTestRunID, actual)
+
+	t.Setenv(testRunIDEnv, "ci-123.4_job")
+	actual, err = currentTestRunID()
+	require.NoError(t, err)
+	require.Equal(t, "ci-123.4_job", actual)
+
+	for _, invalid := range []string{
+		"contains/slash",
+		" contains-space",
+		strings.Repeat("a", testRunIDMaxLength+1),
+	} {
+		t.Setenv(testRunIDEnv, invalid)
+		_, err = currentTestRunID()
+		require.ErrorContains(t, err, testRunIDEnv)
+	}
+}
+
+func TestSetupPostgresAppliesExactOwnershipLabels(t *testing.T) {
+	originalCreate := createPostgresContainer
+	t.Cleanup(func() { createPostgresContainer = originalCreate })
+	t.Setenv(testRunIDEnv, "focused-test-run")
+	reporter := &reporterStub{}
+
+	createPostgresContainer = func(
+		_ context.Context,
+		req testcontainers.ContainerRequest,
+	) (postgresContainer, error) {
+		require.Equal(t, testOwnerLabelValue, req.Labels[testOwnerLabelKey])
+		require.Equal(t, "focused-test-run", req.Labels[testRunIDLabelKey])
+		return validPostgresContainerStub(), nil
+	}
+
+	require.NotEqual(t, Database{}, setupPostgres(reporter))
+	require.Empty(t, reporter.fatals)
+	require.Len(t, reporter.cleanups, 1)
+	reporter.cleanups[0]()
+}
+
+func TestSetupPostgresRejectsInvalidRunIdentityBeforeStartingContainer(t *testing.T) {
+	originalCreate := createPostgresContainer
+	t.Cleanup(func() { createPostgresContainer = originalCreate })
+	t.Setenv(testRunIDEnv, "invalid/run")
+	reporter := &reporterStub{}
+	started := false
+	createPostgresContainer = func(
+		context.Context,
+		testcontainers.ContainerRequest,
+	) (postgresContainer, error) {
+		started = true
+		return validPostgresContainerStub(), nil
+	}
+
+	require.Equal(t, Database{}, setupPostgres(reporter))
+	require.False(t, started)
+	require.Len(t, reporter.fatals, 1)
+	require.Empty(t, reporter.cleanups)
 }
 
 func TestSetupPostgresReportsStartAndResolutionFailures(t *testing.T) {

--- a/scripts/verify-test-docker-cleanup.sh
+++ b/scripts/verify-test-docker-cleanup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly owner_label_key='io.dsub.test-owner'
+readonly owner_label_value='go-open-discogs-batch'
+readonly run_label_key='io.dsub.test-run'
+readonly run_id_env='OPEN_DISCOGS_TEST_RUN_ID'
+readonly run_id_max_length=128
+
+run_id="${OPEN_DISCOGS_TEST_RUN_ID:-}"
+if [[ -z "$run_id" ]]; then
+  printf '%s must be set for Docker cleanup verification\n' "$run_id_env" >&2
+  exit 2
+fi
+if (( ${#run_id} > run_id_max_length )) ||
+  [[ ! "$run_id" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
+  printf '%s has an invalid value\n' "$run_id_env" >&2
+  exit 2
+fi
+
+readonly owner_filter="label=${owner_label_key}=${owner_label_value}"
+readonly run_filter="label=${run_label_key}=${run_id}"
+
+containers="$(
+  docker container ls --all --quiet \
+    --filter "$owner_filter" \
+    --filter "$run_filter"
+)"
+networks="$(
+  docker network ls --quiet \
+    --filter "$owner_filter" \
+    --filter "$run_filter"
+)"
+volumes="$(
+  docker volume ls --quiet \
+    --filter "$owner_filter" \
+    --filter "$run_filter"
+)"
+
+status=0
+if [[ -n "$containers" ]]; then
+  printf 'test Docker containers remain for run %s:\n%s\n' "$run_id" "$containers" >&2
+  status=1
+fi
+if [[ -n "$networks" ]]; then
+  printf 'test Docker networks remain for run %s:\n%s\n' "$run_id" "$networks" >&2
+  status=1
+fi
+if [[ -n "$volumes" ]]; then
+  printf 'test Docker volumes remain for run %s:\n%s\n' "$run_id" "$volumes" >&2
+  status=1
+fi
+
+if (( status != 0 )); then
+  exit "$status"
+fi
+
+printf 'test Docker cleanup verified for run %s: 0 containers, 0 networks, 0 volumes\n' "$run_id"

--- a/scripts/verify-test-docker-cleanup.sh
+++ b/scripts/verify-test-docker-cleanup.sh
@@ -20,34 +20,115 @@ fi
 
 readonly owner_filter="label=${owner_label_key}=${owner_label_value}"
 readonly run_filter="label=${run_label_key}=${run_id}"
+readonly expected_labels="${owner_label_value}|${run_id}"
 
-containers="$(
+list_containers() {
   docker container ls --all --quiet \
     --filter "$owner_filter" \
     --filter "$run_filter"
-)"
-networks="$(
+}
+
+list_networks() {
   docker network ls --quiet \
     --filter "$owner_filter" \
     --filter "$run_filter"
-)"
-volumes="$(
+}
+
+list_volumes() {
   docker volume ls --quiet \
     --filter "$owner_filter" \
     --filter "$run_filter"
-)"
+}
+
+inspect_labels() {
+  local resource_type="$1"
+  local resource_id="$2"
+
+  case "$resource_type" in
+    container)
+      docker container inspect --format \
+        '{{ index .Config.Labels "io.dsub.test-owner" }}|{{ index .Config.Labels "io.dsub.test-run" }}' \
+        "$resource_id"
+      ;;
+    network)
+      docker network inspect --format \
+        '{{ index .Labels "io.dsub.test-owner" }}|{{ index .Labels "io.dsub.test-run" }}' \
+        "$resource_id"
+      ;;
+    volume)
+      docker volume inspect --format \
+        '{{ index .Labels "io.dsub.test-owner" }}|{{ index .Labels "io.dsub.test-run" }}' \
+        "$resource_id"
+      ;;
+    *)
+      printf 'unsupported Docker resource type: %s\n' "$resource_type" >&2
+      return 2
+      ;;
+  esac
+}
+
+remove_owned_resource() {
+  local resource_type="$1"
+  local resource_id="$2"
+  local actual_labels
+
+  if ! actual_labels="$(inspect_labels "$resource_type" "$resource_id")"; then
+    printf 'refusing to remove uninspectable Docker %s %s\n' \
+      "$resource_type" "$resource_id" >&2
+    return 1
+  fi
+  if [[ "$actual_labels" != "$expected_labels" ]]; then
+    printf 'refusing to remove Docker %s %s with labels %s\n' \
+      "$resource_type" "$resource_id" "$actual_labels" >&2
+    return 1
+  fi
+
+  case "$resource_type" in
+    container)
+      docker container rm --force "$resource_id" >/dev/null
+      ;;
+    network)
+      docker network rm "$resource_id" >/dev/null
+      ;;
+    volume)
+      docker volume rm "$resource_id" >/dev/null
+      ;;
+  esac
+}
 
 status=0
+while IFS= read -r resource_id; do
+  [[ -z "$resource_id" ]] && continue
+  remove_owned_resource container "$resource_id" || status=1
+done < <(list_containers)
+
+while IFS= read -r resource_id; do
+  [[ -z "$resource_id" ]] && continue
+  remove_owned_resource network "$resource_id" || status=1
+done < <(list_networks)
+
+while IFS= read -r resource_id; do
+  [[ -z "$resource_id" ]] && continue
+  remove_owned_resource volume "$resource_id" || status=1
+done < <(list_volumes)
+
+containers="$(list_containers)"
+networks="$(list_networks)"
+volumes="$(list_volumes)"
+
 if [[ -n "$containers" ]]; then
-  printf 'test Docker containers remain for run %s:\n%s\n' "$run_id" "$containers" >&2
+  printf 'owned test Docker containers remain for run %s:\n%s\n' \
+    "$run_id" "$containers" >&2
   status=1
 fi
 if [[ -n "$networks" ]]; then
-  printf 'test Docker networks remain for run %s:\n%s\n' "$run_id" "$networks" >&2
+  printf 'owned test Docker networks remain for run %s:\n%s\n' \
+    "$run_id" "$networks" >&2
   status=1
 fi
 if [[ -n "$volumes" ]]; then
-  printf 'test Docker volumes remain for run %s:\n%s\n' "$run_id" "$volumes" >&2
+  printf 'owned test Docker volumes remain for run %s:\n%s\n' \
+    "$run_id" "$volumes" >&2
   status=1
 fi
 

--- a/src/batch/ci_gate_regression_test.go
+++ b/src/batch/ci_gate_regression_test.go
@@ -1,0 +1,676 @@
+package batch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+	opendiscogsschema "github.com/dsub-io/open-discogs-model/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullableRelationDeleteErrorPreservesNilKeyBoundary(t *testing.T) {
+	expected := errors.New("fixture")
+	db := poisonedGorm(t, expected)
+	item := &opendiscogsmodel.LabelReleaseItem{
+		ReleaseItemID:    1,
+		LabelID:          2,
+		CategoryNotation: nil,
+	}
+	actual := reconcileIntegerNullableTextKeyRelation(
+		NewOrder(context.Background(), 1, 1, "unused", db),
+		labelReleaseItemRelation,
+		true,
+		[]int32{item.ReleaseItemID},
+		[]*opendiscogsmodel.LabelReleaseItem{item},
+		func(value *opendiscogsmodel.LabelReleaseItem) int32 { return value.ReleaseItemID },
+		func(value *opendiscogsmodel.LabelReleaseItem) int32 { return value.LabelID },
+		func(value *opendiscogsmodel.LabelReleaseItem) *string { return value.CategoryNotation },
+	)
+	require.ErrorIs(t, actual.Err(), expected)
+}
+
+func TestRunDDLPropagatesLiquibaseAndLegacyAdoptionFailures(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	expected := errors.New("fixture")
+
+	t.Run("Liquibase lock", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		keys := expectAllMigrationLocks(t, mock)
+		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta(
+			"create table if not exists " + schema.Qualify(liquibaseLockTable),
+		)).WillReturnError(expected)
+		mock.ExpectRollback()
+		expectAllMigrationUnlocks(mock, keys)
+
+		require.ErrorContains(
+			t,
+			runDDL(db, migrationFixture("select 1"), schema),
+			"create Liquibase migration lock table",
+		)
+	})
+
+	t.Run("legacy contract", func(t *testing.T) {
+		originalLoad := loadLegacyLiquibaseCompatibility
+		loadLegacyLiquibaseCompatibility = func() (
+			opendiscogsschema.LegacyLiquibaseManifest,
+			error,
+		) {
+			return opendiscogsschema.LegacyLiquibaseManifest{}, expected
+		}
+		t.Cleanup(func() { loadLegacyLiquibaseCompatibility = originalLoad })
+
+		db, mock, _ := newMockGorm(t)
+		keys := expectAllMigrationLocks(t, mock)
+		expectLiquibaseMigrationLock(mock, schema)
+		expectMigrationLedger(t, mock, schema)
+		expectLiquibaseMigrationUnlock(mock, schema)
+		expectAllMigrationUnlocks(mock, keys)
+
+		require.ErrorContains(
+			t,
+			runDDL(db, migrationFixture("select 1"), schema),
+			"load legacy Liquibase compatibility contract",
+		)
+	})
+}
+
+func TestLiquibaseMigrationLockErrorBoundaries(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	expected := errors.New("fixture")
+	tests := []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+		want  string
+	}{
+		{
+			name: "create table",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "create Liquibase migration lock table",
+		},
+		{
+			name: "initialize row",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into .*databasechangeloglock").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "initialize Liquibase migration lock",
+		},
+		{
+			name: "reserve row",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectQuery("select locked from .*databasechangeloglock").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "reserve Liquibase migration lock",
+		},
+		{
+			name: "missing row",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectQuery("select locked from .*databasechangeloglock").
+					WillReturnRows(sqlmock.NewRows([]string{"locked"}))
+				mock.ExpectRollback()
+			},
+			want: "lock row 1 is missing",
+		},
+		{
+			name: "already locked",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectQuery("select locked from .*databasechangeloglock").
+					WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(true))
+				mock.ExpectRollback()
+			},
+			want: "already held",
+		},
+		{
+			name: "acquire update",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectQuery("select locked from .*databasechangeloglock").
+					WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(false))
+				mock.ExpectExec("update .*databasechangeloglock").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "acquire Liquibase migration lock",
+		},
+		{
+			name: "acquire race",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("create table if not exists").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec("insert into .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectQuery("select locked from .*databasechangeloglock").
+					WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(false))
+				mock.ExpectExec("update .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectRollback()
+			},
+			want: "changed while being acquired",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, _ := newMockGorm(t)
+			test.setup(mock)
+			_, err := acquireLiquibaseMigrationLock(db, schema)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+
+	require.NoError(t, (*liquibaseMigrationLock)(nil).release())
+	require.NoError(t, (&liquibaseMigrationLock{}).release())
+
+	t.Run("release query", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectExec("update .*databasechangeloglock").WillReturnError(expected)
+		err := (&liquibaseMigrationLock{db: db, schema: schema, acquired: true}).release()
+		require.ErrorContains(t, err, "release Liquibase migration lock")
+	})
+
+	t.Run("release ownership", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectExec("update .*databasechangeloglock").WillReturnResult(sqlmock.NewResult(0, 0))
+		err := (&liquibaseMigrationLock{db: db, schema: schema, acquired: true}).release()
+		require.ErrorContains(t, err, "ownership changed before release")
+	})
+}
+
+func TestReadLegacyLiquibaseRowsErrorBoundaries(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	expected := errors.New("fixture")
+
+	t.Run("inspect", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("select exists.*information_schema.tables").WillReturnError(expected)
+		_, err := readLegacyLiquibaseRows(db, schema)
+		require.ErrorContains(t, err, "inspect legacy Liquibase history")
+	})
+
+	t.Run("read", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("select exists.*information_schema.tables").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		mock.ExpectQuery("select id, author, filename").WillReturnError(expected)
+		_, err := readLegacyLiquibaseRows(db, schema)
+		require.ErrorContains(t, err, "read legacy Liquibase history")
+	})
+}
+
+func TestValidateLegacyLiquibaseRowsRejectsUntrustedHistory(t *testing.T) {
+	t.Run("unsupported prefix", func(t *testing.T) {
+		manifest, canonical, _, schema := legacyValidationFixture(t, database.DefaultSchemaName, 4)
+		_, _, err := validateLegacyLiquibaseRows(manifest, schema, canonical, nil)
+		require.ErrorContains(t, err, "not a supported release prefix")
+	})
+
+	tests := []struct {
+		name       string
+		schemaName string
+		mutate     func(*opendiscogsschema.LegacyLiquibaseManifest, *[]canonicalMigration, *[]legacyLiquibaseRow)
+		want       string
+	}{
+		{
+			name:       "canonical prefix length",
+			schemaName: database.DefaultSchemaName,
+			mutate: func(_ *opendiscogsschema.LegacyLiquibaseManifest, canonical *[]canonicalMigration, _ *[]legacyLiquibaseRow) {
+				*canonical = (*canonical)[:3]
+			},
+			want: "not a canonical artifact prefix",
+		},
+		{
+			name:       "canonical mismatch",
+			schemaName: database.DefaultSchemaName,
+			mutate: func(_ *opendiscogsschema.LegacyLiquibaseManifest, canonical *[]canonicalMigration, _ *[]legacyLiquibaseRow) {
+				(*canonical)[0].checksum = "changed"
+			},
+			want: "does not match the canonical artifact",
+		},
+		{
+			name:       "missing schema mode",
+			schemaName: database.DefaultSchemaName,
+			mutate: func(manifest *opendiscogsschema.LegacyLiquibaseManifest, _ *[]canonicalMigration, _ *[]legacyLiquibaseRow) {
+				manifest.Migrations[0].LegacyChangeSets = nil
+			},
+			want: "untrusted Liquibase identity",
+		},
+		{
+			name:       "identity",
+			schemaName: database.DefaultSchemaName,
+			mutate: func(_ *opendiscogsschema.LegacyLiquibaseManifest, _ *[]canonicalMigration, rows *[]legacyLiquibaseRow) {
+				(*rows)[0].Author = "other"
+			},
+			want: "untrusted Liquibase identity",
+		},
+		{
+			name:       "execution type",
+			schemaName: database.DefaultSchemaName,
+			mutate: func(_ *opendiscogsschema.LegacyLiquibaseManifest, _ *[]canonicalMigration, rows *[]legacyLiquibaseRow) {
+				(*rows)[0].ExecutionType = "FAILED"
+			},
+			want: "unsupported execution type",
+		},
+		{
+			name:       "exact checksum",
+			schemaName: database.DefaultSchemaName,
+			mutate: func(_ *opendiscogsschema.LegacyLiquibaseManifest, _ *[]canonicalMigration, rows *[]legacyLiquibaseRow) {
+				(*rows)[0].Checksum = "9:00000000000000000000000000000000"
+			},
+			want: "Liquibase checksum changed",
+		},
+		{
+			name:       "parameterized checksum",
+			schemaName: "open_discogs",
+			mutate: func(_ *opendiscogsschema.LegacyLiquibaseManifest, _ *[]canonicalMigration, rows *[]legacyLiquibaseRow) {
+				(*rows)[0].Checksum = "invalid"
+			},
+			want: "invalid parameterized checksum",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manifest, canonical, rows, schema := legacyValidationFixture(t, test.schemaName, 4)
+			test.mutate(&manifest, &canonical, &rows)
+			_, _, err := validateLegacyLiquibaseRows(manifest, schema, canonical, rows)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestVerifyLegacySchemaContractErrorBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+	manifest, _, _, schema := legacyValidationFixture(t, database.DefaultSchemaName, 4)
+	contract, found := manifest.SchemaContract("V004")
+	require.True(t, found)
+	verifier, err := opendiscogsschema.LegacyLiquibaseContract(contract.Verifier.Name)
+	require.NoError(t, err)
+
+	t.Run("missing prefix", func(t *testing.T) {
+		db, _, _ := newMockGorm(t)
+		require.ErrorContains(
+			t,
+			verifyLegacySchemaContract(db, schema, opendiscogsschema.LegacyLiquibaseManifest{}, 4),
+			"contract for prefix V004 is unavailable",
+		)
+	})
+
+	t.Run("server version", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("show server_version_num").WillReturnError(expected)
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, manifest, 4), "read PostgreSQL version")
+	})
+
+	t.Run("unsupported PostgreSQL", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("show server_version_num").
+			WillReturnRows(sqlmock.NewRows([]string{"server_version_num"}).AddRow(190000))
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, manifest, 4), "does not support PostgreSQL 19")
+	})
+
+	t.Run("verifier resource", func(t *testing.T) {
+		broken := manifest
+		broken.SchemaContracts = append(
+			[]opendiscogsschema.LegacySchemaContract(nil),
+			manifest.SchemaContracts...,
+		)
+		broken.SchemaContracts[0].Verifier.Name = "missing.sql"
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("show server_version_num").
+			WillReturnRows(sqlmock.NewRows([]string{"server_version_num"}).AddRow(180000))
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, broken, 4), "load legacy schema verifier")
+	})
+
+	t.Run("search path", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectQuery("show server_version_num").
+			WillReturnRows(sqlmock.NewRows([]string{"server_version_num"}).AddRow(180000))
+		mock.ExpectExec("set local search_path").WillReturnError(expected)
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, manifest, 4), "select legacy schema")
+	})
+
+	t.Run("fingerprint query", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		expectLegacyVerifierPrelude(mock)
+		mock.ExpectQuery(regexp.QuoteMeta(string(verifier))).WillReturnError(expected)
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, manifest, 4), "calculate legacy schema fingerprint")
+	})
+
+	t.Run("null fingerprint", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		expectLegacyVerifierPrelude(mock)
+		mock.ExpectQuery(regexp.QuoteMeta(string(verifier))).
+			WillReturnRows(sqlmock.NewRows([]string{"fingerprint"}).AddRow(nil))
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, manifest, 4), "returned null")
+	})
+
+	t.Run("fingerprint mismatch", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		expectLegacyVerifierPrelude(mock)
+		mock.ExpectQuery(regexp.QuoteMeta(string(verifier))).
+			WillReturnRows(sqlmock.NewRows([]string{"fingerprint"}).AddRow("fixture"))
+		require.ErrorContains(t, verifyLegacySchemaContract(db, schema, manifest, 4), "fingerprint mismatch")
+	})
+}
+
+func TestAdoptLegacyLiquibaseHistoryErrorBoundaries(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	expected := errors.New("fixture")
+	manifest, canonical, rows, _ := legacyValidationFixture(t, database.DefaultSchemaName, 4)
+	require.NotEmpty(t, manifest.Migrations)
+
+	t.Run("load contract", func(t *testing.T) {
+		originalLoad := loadLegacyLiquibaseCompatibility
+		loadLegacyLiquibaseCompatibility = func() (opendiscogsschema.LegacyLiquibaseManifest, error) {
+			return opendiscogsschema.LegacyLiquibaseManifest{}, expected
+		}
+		t.Cleanup(func() { loadLegacyLiquibaseCompatibility = originalLoad })
+		require.ErrorContains(t, adoptLegacyLiquibaseHistory(nil, schema, canonical), "load legacy")
+	})
+
+	tests := []struct {
+		name  string
+		setup func(sqlmock.Sqlmock)
+		want  string
+	}{
+		{
+			name: "ledger lock",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("lock table .*open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "lock shared migration ledger",
+		},
+		{
+			name: "ledger count",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectLegacyAdoptionStart(mock)
+				mock.ExpectQuery("select count.*open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "count shared migration ledger",
+		},
+		{
+			name: "history inspection",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectLegacyAdoptionStart(mock)
+				mock.ExpectQuery("select count.*open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+				mock.ExpectQuery("select exists.*information_schema.tables").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "inspect legacy Liquibase history",
+		},
+		{
+			name: "partial ledger",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectLegacyAdoptionStart(mock)
+				mock.ExpectQuery("select count.*open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+				expectLegacyRows(mock, schema, rows)
+				mock.ExpectRollback()
+			},
+			want: "refusing partial adoption",
+		},
+		{
+			name: "validation",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectLegacyAdoptionStart(mock)
+				mock.ExpectQuery("select count.*open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+				expectLegacyRows(mock, schema, rows[:1])
+				mock.ExpectRollback()
+			},
+			want: "not a supported release prefix",
+		},
+		{
+			name: "adopt insert",
+			setup: func(mock sqlmock.Sqlmock) {
+				expectLegacyAdoptionStart(mock)
+				mock.ExpectQuery("select count.*open_discogs_schema_migration").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+				expectLegacyRows(mock, schema, rows)
+				mock.ExpectExec("insert into .*open_discogs_schema_migration").WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "adopt legacy migration V001",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, _ := newMockGorm(t)
+			test.setup(mock)
+			require.ErrorContains(t, adoptLegacyLiquibaseHistory(db, schema, canonical), test.want)
+		})
+	}
+
+	t.Run("existing complete ledger", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		expectLegacyAdoptionStart(mock)
+		mock.ExpectQuery("select count.*open_discogs_schema_migration").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(4))
+		expectLegacyRows(mock, schema, rows)
+		mock.ExpectCommit()
+		require.NoError(t, adoptLegacyLiquibaseHistory(db, schema, canonical))
+	})
+
+	t.Run("schema proof verification failure", func(t *testing.T) {
+		proofRows := append([]legacyLiquibaseRow(nil), rows...)
+		proofRows[0].ExecutionType = string(opendiscogsschema.LegacyExecutionTypeMarkRan)
+		db, mock, _ := newMockGorm(t)
+		expectLegacyAdoptionStart(mock)
+		mock.ExpectQuery("select count.*open_discogs_schema_migration").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		expectLegacyRows(mock, schema, proofRows)
+		mock.ExpectQuery("show server_version_num").WillReturnError(expected)
+		mock.ExpectRollback()
+
+		require.ErrorContains(
+			t,
+			adoptLegacyLiquibaseHistory(db, schema, canonical),
+			"read PostgreSQL version for legacy schema verification",
+		)
+	})
+
+	t.Run("schema proof adoption", func(t *testing.T) {
+		const fingerprint = "fixture"
+		digest := sha256.Sum256([]byte(fingerprint))
+		schemaProofManifest := manifest
+		schemaProofManifest.SchemaContracts = append(
+			[]opendiscogsschema.LegacySchemaContract(nil),
+			manifest.SchemaContracts...,
+		)
+		for contractIndex := range schemaProofManifest.SchemaContracts {
+			contract := &schemaProofManifest.SchemaContracts[contractIndex]
+			if contract.Prefix != "V004" {
+				continue
+			}
+			contract.ExpectedFingerprints = append(
+				[]opendiscogsschema.LegacySchemaFingerprint(nil),
+				contract.ExpectedFingerprints...,
+			)
+			for fingerprintIndex := range contract.ExpectedFingerprints {
+				if contract.ExpectedFingerprints[fingerprintIndex].PostgreSQLMajor == 18 {
+					contract.ExpectedFingerprints[fingerprintIndex].SHA256 = hex.EncodeToString(digest[:])
+				}
+			}
+		}
+
+		proofRows := append([]legacyLiquibaseRow(nil), rows...)
+		proofRows[0].ExecutionType = string(opendiscogsschema.LegacyExecutionTypeMarkRan)
+		originalCompatibilityLoader := loadLegacyLiquibaseCompatibility
+		originalContractLoader := loadLegacyLiquibaseContract
+		loadLegacyLiquibaseCompatibility = func() (opendiscogsschema.LegacyLiquibaseManifest, error) {
+			return schemaProofManifest, nil
+		}
+		loadLegacyLiquibaseContract = func(string) ([]byte, error) {
+			return []byte("select 'fixture'"), nil
+		}
+		t.Cleanup(func() {
+			loadLegacyLiquibaseCompatibility = originalCompatibilityLoader
+			loadLegacyLiquibaseContract = originalContractLoader
+		})
+
+		db, mock, _ := newMockGorm(t)
+		expectLegacyAdoptionStart(mock)
+		mock.ExpectQuery("select count.*open_discogs_schema_migration").
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		expectLegacyRows(mock, schema, proofRows)
+		expectLegacyVerifierPrelude(mock)
+		mock.ExpectQuery(regexp.QuoteMeta("select 'fixture'")).
+			WillReturnRows(sqlmock.NewRows([]string{"fingerprint"}).AddRow(fingerprint))
+		for range canonical {
+			mock.ExpectExec("insert into .*open_discogs_schema_migration").
+				WillReturnResult(sqlmock.NewResult(0, 1))
+		}
+		mock.ExpectCommit()
+		require.NoError(t, adoptLegacyLiquibaseHistory(db, schema, canonical))
+	})
+}
+
+func TestImportCoordinatorContractResolutionAndConsolidationFailures(t *testing.T) {
+	t.Run("resolve entity revision", func(t *testing.T) {
+		original, found := currentImportContractRevisions[artistEntityType]
+		require.True(t, found)
+		delete(currentImportContractRevisions, artistEntityType)
+		t.Cleanup(func() { currentImportContractRevisions[artistEntityType] = original })
+
+		coordinator := NewImportExecutionCoordinator(nil, "version")
+		_, err := coordinator.Prepare(
+			context.Background(),
+			[]*opendiscogsmodel.DiscogsDump{importDump(artistEntityType, "2026-07-01", "a")},
+			5,
+			false,
+			false,
+		)
+		require.ErrorContains(t, err, "contract revision is unavailable")
+	})
+
+	t.Run("consolidate successful checkpoints", func(t *testing.T) {
+		expected := errors.New("fixture")
+		dump := importDump(artistEntityType, "2026-07-01", "a")
+		_, mock, sqlDB := newMockGorm(t)
+		expectEntityLock(mock)
+		mock.ExpectBegin()
+		expectMarkAbandoned(mock)
+		expectNoCheckpoint(mock)
+		expectInsertedDump(mock, dump)
+		mock.ExpectQuery("select candidate_run.id").WithArgs(sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{
+				"id", "compatible_entity_count", "selected_entity_count", "incompatible_entity_types",
+			}).AddRow(nil, 1, 1, ""))
+		mock.ExpectQuery("insert into discogs_import_run").
+			WithArgs(sqlmock.AnyArg(), processorName, "version").
+			WillReturnError(expected)
+		mock.ExpectRollback()
+		expectEntityUnlock(mock)
+
+		_, err := NewImportExecutionCoordinator(sqlDB, "version").Prepare(
+			context.Background(),
+			[]*opendiscogsmodel.DiscogsDump{dump},
+			5,
+			false,
+			false,
+		)
+		require.ErrorContains(t, err, "record consolidated successful import run")
+	})
+}
+
+func legacyValidationFixture(
+	t *testing.T,
+	schemaName string,
+	prefixLength int,
+) (
+	opendiscogsschema.LegacyLiquibaseManifest,
+	[]canonicalMigration,
+	[]legacyLiquibaseRow,
+	database.Schema,
+) {
+	t.Helper()
+	manifest, err := opendiscogsschema.LegacyLiquibaseCompatibility()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(manifest.Migrations), prefixLength)
+	schema := requireMigrationSchema(t, schemaName)
+	mode := opendiscogsschema.LegacySchemaModeCustom
+	if schemaName == database.DefaultSchemaName {
+		mode = opendiscogsschema.LegacySchemaModePublic
+	}
+	canonical := make([]canonicalMigration, prefixLength)
+	rows := make([]legacyLiquibaseRow, prefixLength)
+	for index, migration := range manifest.Migrations[:prefixLength] {
+		canonical[index] = canonicalMigration{
+			version:  migration.CanonicalFilename,
+			checksum: migration.CanonicalSHA256,
+		}
+		for _, changeSet := range migration.LegacyChangeSets {
+			if changeSet.SchemaMode != mode {
+				continue
+			}
+			checksum := changeSet.Checksum
+			if changeSet.ChecksumPolicy == opendiscogsschema.LegacyChecksumPolicySchemaParameterized {
+				checksum = "9:00000000000000000000000000000000"
+			}
+			rows[index] = legacyLiquibaseRow{
+				ID:            changeSet.ID,
+				Author:        changeSet.Author,
+				Filename:      changeSet.Filename,
+				ExecutionType: string(opendiscogsschema.LegacyExecutionTypeExecuted),
+				Checksum:      checksum,
+			}
+			break
+		}
+		require.NotEmpty(t, rows[index].ID)
+	}
+	return manifest, canonical, rows, schema
+}
+
+func expectLegacyAdoptionStart(mock sqlmock.Sqlmock) {
+	mock.ExpectBegin()
+	mock.ExpectExec("lock table .*open_discogs_schema_migration").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func expectLegacyRows(
+	mock sqlmock.Sqlmock,
+	schema database.Schema,
+	rows []legacyLiquibaseRow,
+) {
+	mock.ExpectQuery("select exists.*information_schema.tables").
+		WithArgs(schema.Name(), liquibaseChangeLogTable).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	result := sqlmock.NewRows([]string{"id", "author", "filename", "execution_type", "checksum"})
+	for _, row := range rows {
+		result.AddRow(row.ID, row.Author, row.Filename, row.ExecutionType, row.Checksum)
+	}
+	mock.ExpectQuery("select id, author, filename").
+		WithArgs(legacyChangeSetIDPrefix + "%").
+		WillReturnRows(result)
+}
+
+func expectLegacyVerifierPrelude(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("show server_version_num").
+		WillReturnRows(sqlmock.NewRows([]string{"server_version_num"}).AddRow(180000))
+	mock.ExpectExec("set local search_path").WillReturnResult(sqlmock.NewResult(0, 0))
+}

--- a/src/batch/convergence.go
+++ b/src/batch/convergence.go
@@ -27,6 +27,13 @@ type twoIntegerKeyRelation struct {
 	secondKeyColumn string
 }
 
+type integerNullableTextKeyRelation struct {
+	table             string
+	parentColumn      string
+	integerKeyColumn  string
+	nullableKeyColumn string
+}
+
 func reconcileIntegerRelation[T comparable](
 	order Order,
 	relation integerRelation,
@@ -158,6 +165,67 @@ func reconcileTwoIntegerKeyRelation[T comparable](
 		postgresArray(parents),
 		postgresArray(firstKeys),
 		postgresArray(secondKeys),
+	)
+	if deleted.Error != nil {
+		return result.NewResult(0, fmt.Errorf("delete stale %s rows: %w", relation.table, deleted.Error))
+	}
+	written := doWrite(incoming, order.getChunkSize(), order.getDB())
+	return result.NewResult(int(deleted.RowsAffected), nil).Sum(written)
+}
+
+func reconcileIntegerNullableTextKeyRelation[T comparable](
+	order Order,
+	relation integerNullableTextKeyRelation,
+	deleteStale bool,
+	rootIDs []int32,
+	incoming []T,
+	parentID func(T) int32,
+	integerKey func(T) int32,
+	nullableTextKey func(T) *string,
+) result.Result {
+	if !deleteStale {
+		return doWrite(incoming, order.getChunkSize(), order.getDB())
+	}
+	parents := make([]int32, 0, len(incoming))
+	integerKeys := make([]int32, 0, len(incoming))
+	textKeys := make([]string, 0, len(incoming))
+	hasTextKeys := make([]bool, 0, len(incoming))
+	for _, item := range incoming {
+		parents = append(parents, parentID(item))
+		integerKeys = append(integerKeys, integerKey(item))
+		textKey := nullableTextKey(item)
+		hasTextKeys = append(hasTextKeys, textKey != nil)
+		if textKey == nil {
+			textKeys = append(textKeys, "")
+		} else {
+			textKeys = append(textKeys, *textKey)
+		}
+	}
+	deleted := order.getDB().Exec(
+		fmt.Sprintf(
+			`delete from %s current
+			  where current.%s = any(?::integer[])
+			    and not exists (
+			        select 1
+			          from unnest(?::integer[], ?::integer[], ?::text[], ?::boolean[])
+			               incoming(parent_id, integer_key, text_key, has_text_key)
+			         where incoming.parent_id = current.%s
+			           and incoming.integer_key = current.%s
+			           and incoming.has_text_key = (current.%s is not null)
+			           and (not incoming.has_text_key or incoming.text_key = current.%s)
+			    )`,
+			relation.table,
+			relation.parentColumn,
+			relation.parentColumn,
+			relation.integerKeyColumn,
+			relation.nullableKeyColumn,
+			relation.nullableKeyColumn,
+		),
+		postgresArray(rootIDs),
+		postgresArray(parents),
+		postgresArray(integerKeys),
+		postgresArray(textKeys),
+		postgresArray(hasTextKeys),
 	)
 	if deleted.Error != nil {
 		return result.NewResult(0, fmt.Errorf("delete stale %s rows: %w", relation.table, deleted.Error))

--- a/src/batch/database_error_test.go
+++ b/src/batch/database_error_test.go
@@ -90,6 +90,8 @@ func TestRunDDLPropagatesMigrationFailure(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
 	mock.ExpectRollback()
 	require.ErrorContains(t, runDDL(db, fstest.MapFS{
@@ -105,9 +107,21 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 		want  string
 	}{
 		{
+			name: "ledger lock failure",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+					WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "lock shared migration ledger",
+		},
+		{
 			name: "ledger query failure",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
 				mock.ExpectRollback()
 			},
@@ -117,6 +131,8 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "changed checksum",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("old"))
 				mock.ExpectRollback()
@@ -127,6 +143,8 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "migration execution failure",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
 				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnError(expected)
@@ -138,6 +156,8 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 			name: "ledger insert failure",
 			setup: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
 				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
 				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnResult(sqlmock.NewResult(0, 0))
@@ -162,6 +182,8 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 		require.NoError(t, schemaErr)
 		db, mock, _ := newMockGorm(t)
 		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
 			WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("same"))
 		mock.ExpectCommit()

--- a/src/batch/database_error_test.go
+++ b/src/batch/database_error_test.go
@@ -2,13 +2,16 @@ package batch
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/hex"
 	"errors"
 	"io/fs"
 	"regexp"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
@@ -46,61 +49,736 @@ func newMockGorm(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		mock.ExpectClose()
+		for range sqlDB.Stats().OpenConnections {
+			mock.ExpectClose()
+		}
 		require.NoError(t, sqlDB.Close())
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 	return db, mock, sqlDB
 }
 
+type migrationGlobFailureFS struct {
+	err error
+}
+
+func (failure migrationGlobFailureFS) Open(string) (fs.File, error) {
+	return nil, fs.ErrNotExist
+}
+
+func (failure migrationGlobFailureFS) Glob(string) ([]string, error) {
+	return nil, failure.err
+}
+
+type unsupportedMigrationConnPool struct{}
+
+func (unsupportedMigrationConnPool) PrepareContext(context.Context, string) (*sql.Stmt, error) {
+	return nil, errors.New("unsupported")
+}
+
+func (unsupportedMigrationConnPool) ExecContext(
+	context.Context,
+	string,
+	...interface{},
+) (sql.Result, error) {
+	return nil, errors.New("unsupported")
+}
+
+func (unsupportedMigrationConnPool) QueryContext(
+	context.Context,
+	string,
+	...interface{},
+) (*sql.Rows, error) {
+	return nil, errors.New("unsupported")
+}
+
+func (unsupportedMigrationConnPool) QueryRowContext(
+	context.Context,
+	string,
+	...interface{},
+) *sql.Row {
+	return new(sql.Row)
+}
+
+func requireMigrationSchema(t *testing.T, name string) database.Schema {
+	t.Helper()
+	schema, err := database.ParseSchema(name)
+	require.NoError(t, err)
+	return schema
+}
+
+func migrationFixture(contents string) fstest.MapFS {
+	return fstest.MapFS{
+		"001.sql": &fstest.MapFile{Data: []byte(contents)},
+	}
+}
+
+func migrationChecksum(contents string) string {
+	sum := sha256.Sum256([]byte(contents))
+	return hex.EncodeToString(sum[:])
+}
+
+func requiredMigrationLockKeys(t *testing.T) []int32 {
+	t.Helper()
+	entityTypes, err := opendiscogsmanifest.RequiredLockEntityTypes([]string{"release"})
+	require.NoError(t, err)
+	keys := make([]int32, 0, len(entityTypes))
+	for _, entityType := range entityTypes {
+		key, keyErr := opendiscogsmanifest.EntityLockKey(entityType)
+		require.NoError(t, keyErr)
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func expectMigrationLock(mock sqlmock.Sqlmock, key int32, acquired bool) {
+	mock.ExpectQuery(regexp.QuoteMeta(migrationImportLockSQL)).
+		WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, key).
+		WillReturnRows(sqlmock.NewRows([]string{"acquired"}).AddRow(acquired))
+}
+
+func expectAllMigrationLocks(t *testing.T, mock sqlmock.Sqlmock) []int32 {
+	t.Helper()
+	keys := requiredMigrationLockKeys(t)
+	for _, key := range keys {
+		expectMigrationLock(mock, key, true)
+	}
+	return keys
+}
+
+func expectMigrationUnlock(mock sqlmock.Sqlmock, key int32, released bool) {
+	mock.ExpectQuery(regexp.QuoteMeta(migrationImportUnlockSQL)).
+		WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, key).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(released))
+}
+
+func expectAllMigrationUnlocks(mock sqlmock.Sqlmock, keys []int32) {
+	for index := len(keys) - 1; index >= 0; index-- {
+		expectMigrationUnlock(mock, keys[index], true)
+	}
+}
+
+func expectLiquibaseMigrationLock(mock sqlmock.Sqlmock, schema database.Schema) {
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(
+		"create table if not exists " + schema.Qualify(liquibaseLockTable),
+	)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"insert into " + schema.Qualify(liquibaseLockTable) +
+			" (id, locked) values ($1, false) on conflict (id) do nothing",
+	)).WithArgs(liquibaseLockID).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select locked from " + schema.Qualify(liquibaseLockTable) +
+			" where id = $1 for update nowait",
+	)).WithArgs(liquibaseLockID).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(false))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"update "+schema.Qualify(liquibaseLockTable)+
+			" set locked = true, lockgranted = now(), lockedby = $1 where id = $2 and not locked",
+	)).WithArgs(liquibaseMigrationLockOwner, liquibaseLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+}
+
+func expectNoLegacyLiquibaseHistory(mock sqlmock.Sqlmock, schema database.Schema) {
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(
+		"lock table " + schema.Qualify(migrationTable) + " in exclusive mode",
+	)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select count(*) from " + schema.Qualify(migrationTable),
+	)).WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select exists(select 1 from information_schema.tables where table_schema = $1 and table_name = $2)",
+	)).WithArgs(schema.Name(), liquibaseChangeLogTable).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectCommit()
+}
+
+func expectLiquibaseMigrationUnlock(mock sqlmock.Sqlmock, schema database.Schema) {
+	mock.ExpectExec(regexp.QuoteMeta(
+		"update "+schema.Qualify(liquibaseLockTable)+
+			" set locked = false, lockgranted = null, lockedby = null where id = $1 and locked and lockedby = $2",
+	)).WithArgs(liquibaseLockID, liquibaseMigrationLockOwner).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func expectMigrationLedger(t *testing.T, mock sqlmock.Sqlmock, schema database.Schema) {
+	t.Helper()
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`select pg_try_advisory_xact_lock(hashtextextended(current_database() || ':' || $1, 0))`,
+	)).WithArgs(migrationBootstrapLockName + ":" + schema.Name()).
+		WillReturnRows(sqlmock.NewRows([]string{"acquired"}).AddRow(true))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"create table if not exists " + schema.Qualify(migrationTable),
+	)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+}
+
+func expectMigrationInventory(
+	mock sqlmock.Sqlmock,
+	schema database.Schema,
+	rows *sqlmock.Rows,
+) {
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select version, checksum from " + schema.Qualify(migrationTable) + " order by version",
+	)).WillReturnRows(rows)
+}
+
+func expectTrigramExtensionSchema(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
+	mock.ExpectQuery(regexp.QuoteMeta(trigramExtensionSchemaSQL)).
+		WillReturnRows(rows)
+}
+
+func expectMigrationSearchPath(mock sqlmock.Sqlmock, searchPath string) {
+	mock.ExpectExec(regexp.QuoteMeta("set local search_path to " + searchPath)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func emptyTrigramExtensionRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"name", "identifier"})
+}
+
+func trigramExtensionRows(name, identifier string) *sqlmock.Rows {
+	return emptyTrigramExtensionRows().AddRow(name, identifier)
+}
+
+func requireBoundedMigrationResult(t *testing.T, operation func() error) error {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() {
+		result <- operation()
+	}()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("migration operation did not complete within two seconds")
+		return nil
+	}
+}
+
 func TestRunDDLErrorBoundaries(t *testing.T) {
-	schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
-	require.NoError(t, schemaErr)
 	originalLoad := loadSchemaMigrations
 	t.Cleanup(func() { loadSchemaMigrations = originalLoad })
 	expected := errors.New("fixture")
+
 	loadSchemaMigrations = func() (fs.FS, error) { return nil, expected }
 	require.ErrorContains(t, RunDDL(nil), "load shared schema migrations")
 	loadSchemaMigrations = originalLoad
 	require.ErrorContains(t, RunDDLInSchema(nil, "Invalid"), "database-schema")
 
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
 	db, mock, _ := newMockGorm(t)
-	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
-		WillReturnError(expected)
-	require.ErrorContains(t, runDDL(db, fstest.MapFS{}, schema), "create schema migration ledger")
-}
-
-func TestRunDDLReadFailure(t *testing.T) {
-	schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
-	require.NoError(t, schemaErr)
-	db, mock, _ := newMockGorm(t)
-	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	migrations := fstest.MapFS{
-		"001-broken.sql": &fstest.MapFile{Mode: fs.ModeDir},
-	}
-	require.ErrorContains(t, runDDL(db, migrations, schema), "read shared migration")
-}
-
-func TestRunDDLPropagatesMigrationFailure(t *testing.T) {
-	schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
-	require.NoError(t, schemaErr)
-	db, mock, _ := newMockGorm(t)
-	expected := errors.New("fixture")
-	mock.ExpectExec(regexp.QuoteMeta(`create table if not exists "public"."open_discogs_schema_migration"`)).
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	keys := expectAllMigrationLocks(t, mock)
+	expectLiquibaseMigrationLock(mock, schema)
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`select pg_try_advisory_xact_lock(hashtextextended(current_database() || ':' || $1, 0))`,
+	)).WithArgs(migrationBootstrapLockName + ":" + schema.Name()).
+		WillReturnRows(sqlmock.NewRows([]string{"acquired"}).AddRow(true))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"create table if not exists " + schema.Qualify(migrationTable),
+	)).
+		WillReturnError(expected)
 	mock.ExpectRollback()
-	require.ErrorContains(t, runDDL(db, fstest.MapFS{
-		"001.sql": &fstest.MapFile{Data: []byte("select 1")},
-	}, schema), "read migration ledger")
+	expectLiquibaseMigrationUnlock(mock, schema)
+	expectAllMigrationUnlocks(mock, keys)
+	require.ErrorContains(
+		t,
+		runDDL(db, migrationFixture("select 1"), schema),
+		"create schema migration ledger",
+	)
+}
+
+func TestReadCanonicalMigrationsFailBeforeDatabaseAccess(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	expected := errors.New("fixture")
+
+	require.ErrorContains(
+		t,
+		runDDL(nil, migrationGlobFailureFS{err: expected}, schema),
+		"list shared schema migrations",
+	)
+	require.ErrorContains(
+		t,
+		runDDL(nil, fstest.MapFS{}, schema),
+		"migration inventory is empty",
+	)
+	require.ErrorContains(t, runDDL(nil, fstest.MapFS{
+		"001-broken.sql": &fstest.MapFile{Mode: fs.ModeDir},
+	}, schema), "read shared migration")
+}
+
+func TestReadCanonicalMigrationsSortsChecksumsAndScopesSchema(t *testing.T) {
+	schema := requireMigrationSchema(t, "open_discogs")
+	firstSQL := "create table public.first(id integer)"
+	secondSQL := "create table public.second(id integer)"
+	migrations, err := readCanonicalMigrations(fstest.MapFS{
+		"V002__second.sql": &fstest.MapFile{Data: []byte(secondSQL)},
+		"V001__first.sql":  &fstest.MapFile{Data: []byte(firstSQL)},
+	}, schema)
+	require.NoError(t, err)
+	require.Equal(t, []canonicalMigration{
+		{
+			version:  "V001__first.sql",
+			checksum: migrationChecksum(firstSQL),
+			sql:      `create table "open_discogs".first(id integer)`,
+		},
+		{
+			version:  "V002__second.sql",
+			checksum: migrationChecksum(secondSQL),
+			sql:      `create table "open_discogs".second(id integer)`,
+		},
+	}, migrations)
+}
+
+func TestRunDDLUsesReservedConnectionWithSingleConnectionPool(t *testing.T) {
+	const contents = "create table public.fixture(id integer)"
+	schema := requireMigrationSchema(t, "open_discogs")
+	db, mock, sqlDB := newMockGorm(t)
+	sqlDB.SetMaxOpenConns(1)
+	keys := expectAllMigrationLocks(t, mock)
+	expectLiquibaseMigrationLock(mock, schema)
+	expectMigrationLedger(t, mock, schema)
+	expectNoLegacyLiquibaseHistory(mock, schema)
+	expectMigrationInventory(
+		mock,
+		schema,
+		sqlmock.NewRows([]string{"version", "checksum"}),
+	)
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(
+		"lock table " + schema.Qualify(migrationTable) + " in exclusive mode",
+	)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select checksum from " + schema.Qualify(migrationTable) + " where version = $1",
+	)).WithArgs("001.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
+	expectTrigramExtensionSchema(mock, emptyTrigramExtensionRows())
+	expectMigrationSearchPath(mock, `"public", "open_discogs"`)
+	mock.ExpectExec(regexp.QuoteMeta(
+		`create table "open_discogs".fixture(id integer)`,
+	)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"insert into "+schema.Qualify(migrationTable)+" (version, checksum) values ($1, $2)",
+	)).WithArgs("001.sql", migrationChecksum(contents)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	expectLiquibaseMigrationUnlock(mock, schema)
+	expectAllMigrationUnlocks(mock, keys)
+
+	require.NoError(t, requireBoundedMigrationResult(
+		t,
+		func() error { return runDDL(db, migrationFixture(contents), schema) },
+	))
+}
+
+func TestRunDDLPropagatesMigrationAndReleaseFailures(t *testing.T) {
+	const contents = "select 1"
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	db, mock, _ := newMockGorm(t)
+	expectedMigration := errors.New("migration fixture")
+	expectedRelease := errors.New("release fixture")
+	keys := expectAllMigrationLocks(t, mock)
+	expectLiquibaseMigrationLock(mock, schema)
+	expectMigrationLedger(t, mock, schema)
+	expectNoLegacyLiquibaseHistory(mock, schema)
+	expectMigrationInventory(
+		mock,
+		schema,
+		sqlmock.NewRows([]string{"version", "checksum"}),
+	)
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(
+		"lock table " + schema.Qualify(migrationTable) + " in exclusive mode",
+	)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"select checksum from " + schema.Qualify(migrationTable) + " where version = $1",
+	)).WithArgs("001.sql").WillReturnError(expectedMigration)
+	mock.ExpectRollback()
+	expectLiquibaseMigrationUnlock(mock, schema)
+	for index := len(keys) - 1; index >= 0; index-- {
+		expectation := mock.ExpectQuery(regexp.QuoteMeta(migrationImportUnlockSQL)).
+			WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, keys[index])
+		if index == len(keys)-1 {
+			expectation.WillReturnError(expectedRelease)
+		} else {
+			expectation.WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(true))
+		}
+	}
+
+	err := runDDL(db, migrationFixture(contents), schema)
+	require.ErrorIs(t, err, expectedMigration)
+	require.ErrorIs(t, err, expectedRelease)
+}
+
+func TestRunDDLRejectsActiveImportAndInvalidLedger(t *testing.T) {
+	const contents = "select 1"
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+
+	t.Run("active import", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		keys := requiredMigrationLockKeys(t)
+		expectMigrationLock(mock, keys[0], false)
+
+		err := runDDL(db, migrationFixture(contents), schema)
+		require.ErrorContains(t, err, "artist import is active")
+	})
+
+	t.Run("database ledger ahead", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		keys := expectAllMigrationLocks(t, mock)
+		expectLiquibaseMigrationLock(mock, schema)
+		expectMigrationLedger(t, mock, schema)
+		expectNoLegacyLiquibaseHistory(mock, schema)
+		expectMigrationInventory(
+			mock,
+			schema,
+			sqlmock.NewRows([]string{"version", "checksum"}).
+				AddRow("001.sql", migrationChecksum(contents)).
+				AddRow("002.sql", "newer"),
+		)
+		expectLiquibaseMigrationUnlock(mock, schema)
+		expectAllMigrationUnlocks(mock, keys)
+
+		err := runDDL(db, migrationFixture(contents), schema)
+		require.ErrorContains(t, err, "newer than this batch artifact")
+	})
+}
+
+func TestEnsureMigrationLedgerTryLockBoundaries(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	expected := errors.New("fixture")
+
+	for _, test := range []struct {
+		name       string
+		rows       *sqlmock.Rows
+		queryError error
+		create     bool
+		want       string
+	}{
+		{
+			name:   "acquired",
+			rows:   sqlmock.NewRows([]string{"acquired"}).AddRow(true),
+			create: true,
+		},
+		{
+			name: "not acquired",
+			rows: sqlmock.NewRows([]string{"acquired"}).AddRow(false),
+			want: "another schema migrator is active",
+		},
+		{
+			name: "no row",
+			rows: sqlmock.NewRows([]string{"acquired"}),
+			want: "another schema migrator is active",
+		},
+		{
+			name:       "query error",
+			queryError: expected,
+			want:       "lock schema migration bootstrap",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, _ := newMockGorm(t)
+			mock.ExpectBegin()
+			query := mock.ExpectQuery(regexp.QuoteMeta(
+				`select pg_try_advisory_xact_lock(hashtextextended(current_database() || ':' || $1, 0))`,
+			)).
+				WithArgs(migrationBootstrapLockName + ":" + schema.Name())
+			if test.queryError != nil {
+				query.WillReturnError(test.queryError)
+			} else {
+				query.WillReturnRows(test.rows)
+			}
+			if test.create {
+				mock.ExpectExec(regexp.QuoteMeta(
+					"create table if not exists " + schema.Qualify(migrationTable),
+				)).WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectCommit()
+			} else {
+				mock.ExpectRollback()
+			}
+
+			err := requireBoundedMigrationResult(t, func() error {
+				return ensureMigrationLedger(db, schema)
+			})
+			if test.want == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.want)
+			}
+		})
+	}
+}
+
+func TestMigrationImportLockErrorBoundaries(t *testing.T) {
+	expected := errors.New("fixture")
+	require.ErrorContains(t, func() error {
+		_, err := acquireMigrationImportLocks(nil)
+		return err
+	}(), "database connection is nil")
+
+	t.Run("resolve database", func(t *testing.T) {
+		db, _, _ := newMockGorm(t)
+		pool := unsupportedMigrationConnPool{}
+		db.ConnPool = pool
+		db.Statement.ConnPool = pool
+		_, err := acquireMigrationImportLocks(db)
+		require.ErrorContains(t, err, "resolve schema migration database")
+	})
+
+	t.Run("required lock type resolution", func(t *testing.T) {
+		original := requiredMigrationLockTypes
+		requiredMigrationLockTypes = func([]string) ([]string, error) {
+			return nil, expected
+		}
+		t.Cleanup(func() { requiredMigrationLockTypes = original })
+
+		db, _, _ := newMockGorm(t)
+		_, err := acquireMigrationImportLocks(db)
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "resolve schema migration import locks")
+	})
+
+	t.Run("entity lock key resolution", func(t *testing.T) {
+		originalTypes := requiredMigrationLockTypes
+		originalKey := migrationEntityLockKey
+		requiredMigrationLockTypes = func([]string) ([]string, error) {
+			return []string{"artist", "invalid"}, nil
+		}
+		migrationEntityLockKey = func(entityType string) (int32, error) {
+			if entityType == "artist" {
+				return 101, nil
+			}
+			return 0, expected
+		}
+		t.Cleanup(func() {
+			requiredMigrationLockTypes = originalTypes
+			migrationEntityLockKey = originalKey
+		})
+
+		db, mock, _ := newMockGorm(t)
+		expectMigrationLock(mock, 101, true)
+		expectMigrationUnlock(mock, 101, true)
+		_, err := acquireMigrationImportLocks(db)
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "resolve invalid schema migration lock")
+	})
+
+	t.Run("reserve connection", func(t *testing.T) {
+		sqlDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+			DisableAutomaticPing:   true,
+			SkipDefaultTransaction: true,
+		})
+		require.NoError(t, err)
+		mock.ExpectClose()
+		require.NoError(t, sqlDB.Close())
+		_, err = acquireMigrationImportLocks(db)
+		require.ErrorContains(t, err, "reserve schema migration lock connection")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	for _, test := range []struct {
+		name       string
+		lockResult *sqlmock.Rows
+		lockError  error
+		want       string
+	}{
+		{
+			name:       "active import",
+			lockResult: sqlmock.NewRows([]string{"acquired"}).AddRow(false),
+			want:       "label import is active",
+		},
+		{
+			name:      "lock query",
+			lockError: expected,
+			want:      "acquire label schema migration lock",
+		},
+		{
+			name:       "lock query returned no row",
+			lockResult: sqlmock.NewRows([]string{"acquired"}),
+			want:       "acquire label schema migration lock",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, _ := newMockGorm(t)
+			keys := requiredMigrationLockKeys(t)
+			expectMigrationLock(mock, keys[0], true)
+			expectation := mock.ExpectQuery(regexp.QuoteMeta(migrationImportLockSQL)).
+				WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, keys[1])
+			if test.lockError != nil {
+				expectation.WillReturnError(test.lockError)
+			} else {
+				expectation.WillReturnRows(test.lockResult)
+			}
+			expectMigrationUnlock(mock, keys[0], true)
+			_, err := acquireMigrationImportLocks(db)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestMigrationImportLockReleaseBoundaries(t *testing.T) {
+	var absent *migrationImportLocks
+	require.NoError(t, absent.release())
+	require.NoError(t, (&migrationImportLocks{}).release())
+	absent.discardConnection()
+	(&migrationImportLocks{}).discardConnection()
+
+	t.Run("unlock success uses reverse order", func(t *testing.T) {
+		_, mock, sqlDB := newMockGorm(t)
+		connection, err := sqlDB.Conn(context.Background())
+		require.NoError(t, err)
+		keys := []int32{1, 2}
+		expectMigrationUnlock(mock, keys[1], true)
+		expectMigrationUnlock(mock, keys[0], true)
+		locks := &migrationImportLocks{
+			connection: connection,
+			db:         &gorm.DB{},
+			keys:       keys,
+		}
+		require.NoError(t, locks.release())
+		require.Empty(t, locks.keys)
+		require.Nil(t, locks.connection)
+		require.Nil(t, locks.db)
+		require.NoError(t, locks.release())
+	})
+
+	for _, test := range []struct {
+		name       string
+		rows       *sqlmock.Rows
+		queryError error
+		want       string
+	}{
+		{
+			name: "unlock returned false",
+			rows: sqlmock.NewRows([]string{"released"}).AddRow(false),
+			want: "advisory lock was not held",
+		},
+		{
+			name: "unlock returned no row",
+			rows: sqlmock.NewRows([]string{"released"}),
+			want: "sql: no rows in result set",
+		},
+		{
+			name:       "unlock query failed",
+			queryError: errors.New("unlock fixture"),
+			want:       "unlock fixture",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, sqlDB := newMockGorm(t)
+			sqlDB.SetMaxOpenConns(1)
+			connection, err := sqlDB.Conn(context.Background())
+			require.NoError(t, err)
+			query := mock.ExpectQuery(regexp.QuoteMeta(migrationImportUnlockSQL)).
+				WithArgs(opendiscogsmanifest.AdvisoryLockNamespace, int32(1))
+			if test.queryError != nil {
+				query.WillReturnError(test.queryError)
+			} else {
+				query.WillReturnRows(test.rows)
+			}
+			locks := &migrationImportLocks{connection: connection, db: db, keys: []int32{1}}
+			err = locks.release()
+			require.ErrorContains(t, err, test.want)
+			require.Nil(t, locks.connection)
+			require.Nil(t, locks.db)
+			require.Zero(t, sqlDB.Stats().OpenConnections, "bad physical connection must be discarded")
+		})
+	}
+
+	t.Run("connection already closed", func(t *testing.T) {
+		_, _, sqlDB := newMockGorm(t)
+		connection, err := sqlDB.Conn(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, connection.Close())
+		locks := &migrationImportLocks{connection: connection}
+		require.ErrorIs(t, locks.release(), sql.ErrConnDone)
+		require.Nil(t, locks.connection)
+	})
+}
+
+func TestValidateMigrationLedger(t *testing.T) {
+	schema := requireMigrationSchema(t, database.DefaultSchemaName)
+	migrations := []canonicalMigration{
+		{version: "V001__first.sql", checksum: "first"},
+		{version: "V002__second.sql", checksum: "second"},
+	}
+
+	for _, test := range []struct {
+		name string
+		rows *sqlmock.Rows
+		want string
+	}{
+		{
+			name: "empty prefix",
+			rows: sqlmock.NewRows([]string{"version", "checksum"}),
+		},
+		{
+			name: "exact prefix",
+			rows: sqlmock.NewRows([]string{"version", "checksum"}).
+				AddRow("V001__first.sql", "first"),
+		},
+		{
+			name: "artifact behind database",
+			rows: sqlmock.NewRows([]string{"version", "checksum"}).
+				AddRow("V001__first.sql", "first").
+				AddRow("V002__second.sql", "second").
+				AddRow("V003__third.sql", "third"),
+			want: "newer than this batch artifact",
+		},
+		{
+			name: "history gap",
+			rows: sqlmock.NewRows([]string{"version", "checksum"}).
+				AddRow("V001__first.sql", "first").
+				AddRow("V003__third.sql", "third"),
+			want: "not a canonical prefix",
+		},
+		{
+			name: "checksum mismatch",
+			rows: sqlmock.NewRows([]string{"version", "checksum"}).
+				AddRow("V001__first.sql", "changed"),
+			want: "checksum changed",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, _ := newMockGorm(t)
+			expectMigrationInventory(mock, schema, test.rows)
+			err := validateMigrationLedger(db, schema, migrations)
+			if test.want == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.want)
+			}
+		})
+	}
+
+	t.Run("query failure", func(t *testing.T) {
+		db, mock, _ := newMockGorm(t)
+		expected := errors.New("fixture")
+		mock.ExpectQuery(regexp.QuoteMeta(
+			"select version, checksum from " + schema.Qualify(migrationTable) + " order by version",
+		)).WillReturnError(expected)
+		require.ErrorContains(
+			t,
+			validateMigrationLedger(db, schema, migrations),
+			"read shared migration inventory",
+		)
+	})
 }
 
 func TestApplyMigrationErrorBoundaries(t *testing.T) {
 	expected := errors.New("fixture")
+	const (
+		version  = "001.sql"
+		checksum = "new"
+		sqlText  = "invalid SQL"
+	)
 	tests := []struct {
 		name  string
 		setup func(sqlmock.Sqlmock)
@@ -122,7 +800,9 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
 					WillReturnResult(sqlmock.NewResult(0, 0))
-				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration" where version = $1`)).
+					WithArgs(version).
+					WillReturnError(expected)
 				mock.ExpectRollback()
 			},
 			want: "read migration ledger",
@@ -133,7 +813,8 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
 					WillReturnResult(sqlmock.NewResult(0, 0))
-				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration" where version = $1`)).
+					WithArgs(version).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("old"))
 				mock.ExpectRollback()
 			},
@@ -145,12 +826,30 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
 					WillReturnResult(sqlmock.NewResult(0, 0))
-				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration" where version = $1`)).
+					WithArgs(version).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
-				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnError(expected)
+				expectTrigramExtensionSchema(mock, emptyTrigramExtensionRows())
+				expectMigrationSearchPath(mock, `"public"`)
+				mock.ExpectExec(regexp.QuoteMeta(sqlText)).WillReturnError(expected)
 				mock.ExpectRollback()
 			},
 			want: "apply shared migration",
+		},
+		{
+			name: "search path inspection failure",
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration" where version = $1`)).
+					WithArgs(version).
+					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
+				mock.ExpectQuery(regexp.QuoteMeta(trigramExtensionSchemaSQL)).
+					WillReturnError(expected)
+				mock.ExpectRollback()
+			},
+			want: "inspect pg_trgm extension schema",
 		},
 		{
 			name: "ledger insert failure",
@@ -158,10 +857,15 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 				mock.ExpectBegin()
 				mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
 					WillReturnResult(sqlmock.NewResult(0, 0))
-				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
+				mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration" where version = $1`)).
+					WithArgs(version).
 					WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
-				mock.ExpectExec(regexp.QuoteMeta("invalid SQL")).WillReturnResult(sqlmock.NewResult(0, 0))
-				mock.ExpectExec(regexp.QuoteMeta(`insert into "public"."open_discogs_schema_migration"`)).WillReturnError(expected)
+				expectTrigramExtensionSchema(mock, emptyTrigramExtensionRows())
+				expectMigrationSearchPath(mock, `"public"`)
+				mock.ExpectExec(regexp.QuoteMeta(sqlText)).WillReturnResult(sqlmock.NewResult(0, 0))
+				mock.ExpectExec(regexp.QuoteMeta(`insert into "public"."open_discogs_schema_migration" (version, checksum) values ($1, $2)`)).
+					WithArgs(version, checksum).
+					WillReturnError(expected)
 				mock.ExpectRollback()
 			},
 			want: "record shared migration",
@@ -169,25 +873,124 @@ func TestApplyMigrationErrorBoundaries(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
-			require.NoError(t, schemaErr)
+			schema := requireMigrationSchema(t, database.DefaultSchemaName)
 			db, mock, _ := newMockGorm(t)
 			test.setup(mock)
-			require.ErrorContains(t, applyMigration(db, schema, "001.sql", "new", "invalid SQL"), test.want)
+			require.ErrorContains(t, applyMigration(db, schema, version, checksum, sqlText), test.want)
 		})
 	}
 
 	t.Run("already applied checksum", func(t *testing.T) {
-		schema, schemaErr := database.ParseSchema(database.DefaultSchemaName)
-		require.NoError(t, schemaErr)
+		schema := requireMigrationSchema(t, database.DefaultSchemaName)
 		db, mock, _ := newMockGorm(t)
 		mock.ExpectBegin()
 		mock.ExpectExec(regexp.QuoteMeta(`lock table "public"."open_discogs_schema_migration" in exclusive mode`)).
 			WillReturnResult(sqlmock.NewResult(0, 0))
-		mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration"`)).
-			WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow("same"))
+		mock.ExpectQuery(regexp.QuoteMeta(`select checksum from "public"."open_discogs_schema_migration" where version = $1`)).
+			WithArgs(version).
+			WillReturnRows(sqlmock.NewRows([]string{"checksum"}).AddRow(checksum))
 		mock.ExpectCommit()
-		require.NoError(t, applyMigration(db, schema, "001.sql", "same", "unused"))
+		require.NoError(t, applyMigration(db, schema, version, checksum, "unused"))
+	})
+
+	t.Run("new migration in custom schema", func(t *testing.T) {
+		schema := requireMigrationSchema(t, "open_discogs")
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta(
+			`lock table "open_discogs"."open_discogs_schema_migration" in exclusive mode`,
+		)).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery(regexp.QuoteMeta(
+			`select checksum from "open_discogs"."open_discogs_schema_migration" where version = $1`,
+		)).WithArgs(version).WillReturnRows(sqlmock.NewRows([]string{"checksum"}))
+		expectTrigramExtensionSchema(mock, emptyTrigramExtensionRows())
+		expectMigrationSearchPath(mock, `"public", "open_discogs"`)
+		mock.ExpectExec(regexp.QuoteMeta(`create table "open_discogs".fixture(id integer)`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(
+			`insert into "open_discogs"."open_discogs_schema_migration" (version, checksum) values ($1, $2)`,
+		)).WithArgs(version, checksum).WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+		require.NoError(t, applyMigration(
+			db,
+			schema,
+			version,
+			checksum,
+			`create table "open_discogs".fixture(id integer)`,
+		))
+	})
+}
+
+func TestSetMigrationSearchPath(t *testing.T) {
+	t.Run("extension absent", func(t *testing.T) {
+		schema := requireMigrationSchema(t, "open_discogs")
+		db, mock, _ := newMockGorm(t)
+		expectTrigramExtensionSchema(mock, emptyTrigramExtensionRows())
+		expectMigrationSearchPath(mock, `"public", "open_discogs"`)
+
+		require.NoError(t, setMigrationSearchPath(db, schema))
+	})
+
+	t.Run("extension in external schema", func(t *testing.T) {
+		schema := requireMigrationSchema(t, "open_discogs")
+		db, mock, _ := newMockGorm(t)
+		expectTrigramExtensionSchema(
+			mock,
+			trigramExtensionRows("extensions", `"extensions"`),
+		)
+		expectMigrationSearchPath(mock, `"extensions", "open_discogs", "public"`)
+
+		require.NoError(t, setMigrationSearchPath(db, schema))
+	})
+
+	t.Run("extension in target schema", func(t *testing.T) {
+		schema := requireMigrationSchema(t, "user")
+		db, mock, _ := newMockGorm(t)
+		expectTrigramExtensionSchema(
+			mock,
+			trigramExtensionRows("user", `"user"`),
+		)
+		expectMigrationSearchPath(mock, `"user", "public"`)
+
+		require.NoError(t, setMigrationSearchPath(db, schema))
+	})
+
+	t.Run("public schema is not duplicated", func(t *testing.T) {
+		schema := requireMigrationSchema(t, database.DefaultSchemaName)
+		db, mock, _ := newMockGorm(t)
+		expectTrigramExtensionSchema(
+			mock,
+			trigramExtensionRows(database.DefaultSchemaName, `"public"`),
+		)
+		expectMigrationSearchPath(mock, `"public"`)
+
+		require.NoError(t, setMigrationSearchPath(db, schema))
+	})
+
+	t.Run("extension inspection failure", func(t *testing.T) {
+		schema := requireMigrationSchema(t, "open_discogs")
+		db, mock, _ := newMockGorm(t)
+		expected := errors.New("fixture")
+		mock.ExpectQuery(regexp.QuoteMeta(trigramExtensionSchemaSQL)).
+			WillReturnError(expected)
+
+		err := setMigrationSearchPath(db, schema)
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "inspect pg_trgm extension schema")
+	})
+
+	t.Run("set local failure", func(t *testing.T) {
+		schema := requireMigrationSchema(t, "open_discogs")
+		db, mock, _ := newMockGorm(t)
+		expected := errors.New("fixture")
+		expectTrigramExtensionSchema(mock, emptyTrigramExtensionRows())
+		mock.ExpectExec(regexp.QuoteMeta(
+			`set local search_path to "public", "open_discogs"`,
+		)).WillReturnError(expected)
+
+		err := setMigrationSearchPath(db, schema)
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "set schema migration search path")
 	})
 }
 
@@ -548,7 +1351,9 @@ func expectNoCheckpoint(mock sqlmock.Sqlmock) {
 func expectNoSuccessfulRun(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery("select candidate_run.id").
 		WithArgs(sqlmock.AnyArg()).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "compatible_entity_count", "selected_entity_count", "incompatible_entity_types",
+		}).AddRow(nil, 0, 0, ""))
 }
 
 func expectInsertedDump(mock sqlmock.Sqlmock, dump *opendiscogsmodel.DiscogsDump) {
@@ -581,7 +1386,7 @@ func expectInsertedRun(mock sqlmock.Sqlmock, resumedFrom interface{}) {
 
 func expectInsertedRunDump(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("insert into discogs_import_run_dump").
-		WithArgs(int64(2), "artist", int64(1), 5).
+		WithArgs(int64(2), "artist", int64(1), 5, importContractRevision(1)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 }
 
@@ -716,6 +1521,7 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
+				expectInsertedDump(mock, dump)
 				mock.ExpectQuery("select candidate_run.id").WithArgs(sqlmock.AnyArg()).WillReturnError(expected)
 				mock.ExpectRollback()
 				expectEntityUnlock(mock)
@@ -729,7 +1535,12 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				mock.ExpectQuery("select candidate_run.id").WithArgs(sqlmock.AnyArg()).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(9))
+				expectInsertedDump(mock, dump)
+				mock.ExpectQuery("select candidate_run.id").WithArgs(sqlmock.AnyArg()).WillReturnRows(
+					sqlmock.NewRows([]string{
+						"id", "compatible_entity_count", "selected_entity_count", "incompatible_entity_types",
+					}).AddRow(9, 1, 1, ""),
+				)
 				mock.ExpectCommit().WillReturnError(expected)
 				expectEntityUnlock(mock)
 			},
@@ -742,7 +1553,6 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				expectNoSuccessfulRun(mock)
 				mock.ExpectQuery("insert into discogs_dump").WithArgs(
 					dump.ETag, dump.DumpDate, dump.EntityType, dump.ChecksumSHA256, dump.SizeBytes, dump.URI,
 				).WillReturnError(expected)
@@ -758,8 +1568,8 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				expectNoSuccessfulRun(mock)
 				expectInsertedDump(mock, dump)
+				expectNoSuccessfulRun(mock)
 				mock.ExpectQuery("select import_run.id").WithArgs(sqlmock.AnyArg(), processorName, "version", 1, 5).WillReturnError(expected)
 				mock.ExpectRollback()
 				expectEntityUnlock(mock)
@@ -773,8 +1583,8 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				expectNoSuccessfulRun(mock)
 				expectInsertedDump(mock, dump)
+				expectNoSuccessfulRun(mock)
 				expectNoResumableRun(mock)
 				mock.ExpectQuery("insert into discogs_import_run").WithArgs(
 					sqlmock.AnyArg(), false, false, processorName, "version", sqlmock.AnyArg(),
@@ -791,11 +1601,13 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				expectNoSuccessfulRun(mock)
 				expectInsertedDump(mock, dump)
+				expectNoSuccessfulRun(mock)
 				expectNoResumableRun(mock)
 				expectInsertedRun(mock, sqlmock.AnyArg())
-				mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(int64(2), "artist", int64(1), 5).WillReturnError(expected)
+				mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(
+					int64(2), "artist", int64(1), 5, importContractRevision(1),
+				).WillReturnError(expected)
 				mock.ExpectRollback()
 				expectEntityUnlock(mock)
 			},
@@ -808,8 +1620,8 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				expectNoSuccessfulRun(mock)
 				expectInsertedDump(mock, dump)
+				expectNoSuccessfulRun(mock)
 				mock.ExpectQuery("select import_run.id").WithArgs(sqlmock.AnyArg(), processorName, "version", 1, 5).
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(7))
 				expectInsertedRun(mock, sqlmock.AnyArg())
@@ -827,8 +1639,8 @@ func TestImportCoordinatorAdmissionFailures(t *testing.T) {
 				mock.ExpectBegin()
 				expectMarkAbandoned(mock)
 				expectNoCheckpoint(mock)
-				expectNoSuccessfulRun(mock)
 				expectInsertedDump(mock, dump)
+				expectNoSuccessfulRun(mock)
 				expectNoResumableRun(mock)
 				expectInsertedRun(mock, sqlmock.AnyArg())
 				expectInsertedRunDump(mock)

--- a/src/batch/ddl.go
+++ b/src/batch/ddl.go
@@ -73,6 +73,11 @@ func runDDL(db *gorm.DB, migrations fs.FS, schema database.Schema) error {
 
 func applyMigration(db *gorm.DB, schema database.Schema, version, checksum, sql string) error {
 	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(
+			"lock table " + schema.Qualify(migrationTable) + " in exclusive mode",
+		).Error; err != nil {
+			return fmt.Errorf("lock shared migration ledger: %w", err)
+		}
 		var appliedChecksum string
 		result := tx.Raw(
 			"select checksum from "+schema.Qualify(migrationTable)+" where version = ?",

--- a/src/batch/ddl.go
+++ b/src/batch/ddl.go
@@ -1,21 +1,53 @@
 package batch
 
 import (
+	"context"
 	"crypto/sha256"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	opendiscogsmanifest "github.com/dsub-io/open-discogs-model/manifest"
 	opendiscogsschema "github.com/dsub-io/open-discogs-model/schema"
 	"gorm.io/gorm"
 )
 
-const migrationTable = "open_discogs_schema_migration"
+const (
+	migrationTable             = "open_discogs_schema_migration"
+	migrationBootstrapLockName = "open-discogs-schema-migration"
+	migrationImportLockSQL     = "select pg_try_advisory_lock($1, $2)"
+	migrationImportUnlockSQL   = "select pg_advisory_unlock($1, $2)"
+	trigramExtensionSchemaSQL  = "select namespace.nspname as name, quote_ident(namespace.nspname) as identifier from pg_extension extension join pg_namespace namespace on namespace.oid = extension.extnamespace where extension.extname = 'pg_trgm'"
+	migrationBootstrapLockSQL  = "select pg_try_advisory_xact_lock(hashtextextended(current_database() || ':' || ?, 0))"
+)
 
 var loadSchemaMigrations = opendiscogsschema.Migrations
+var requiredMigrationLockTypes = opendiscogsmanifest.RequiredLockEntityTypes
+var migrationEntityLockKey = opendiscogsmanifest.EntityLockKey
+
+type canonicalMigration struct {
+	version  string
+	checksum string
+	sql      string
+}
+
+type migrationImportLocks struct {
+	connection *sql.Conn
+	db         *gorm.DB
+	keys       []int32
+}
+
+type migrationExtensionSchema struct {
+	Name       string
+	Identifier string
+}
 
 // RunDDL applies the versioned PostgreSQL migrations embedded in open-discogs-model.
 // Applied checksums are persisted so a released migration can never change silently.
@@ -36,39 +68,230 @@ func RunDDLInSchema(db *gorm.DB, schemaName string) error {
 	return runDDL(db, migrations, schema)
 }
 
-func runDDL(db *gorm.DB, migrations fs.FS, schema database.Schema) error {
-	names, _ := fs.Glob(migrations, "*.sql")
-	sort.Strings(names)
+func runDDL(db *gorm.DB, migrations fs.FS, schema database.Schema) (runErr error) {
+	loaded, err := readCanonicalMigrations(migrations, schema)
+	if err != nil {
+		return err
+	}
+	locks, err := acquireMigrationImportLocks(db)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		runErr = errors.Join(runErr, locks.release())
+	}()
 
-	if err := db.Exec(fmt.Sprintf(`
-		create table if not exists %s
-		(
-		    version     varchar(255) primary key,
-		    checksum    char(64) not null,
-		    applied_at  timestamp not null default now()
-		)`, schema.Qualify(migrationTable))).Error; err != nil {
+	migrationDB := locks.db
+	liquibaseLock, err := acquireLiquibaseMigrationLock(migrationDB, schema)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		runErr = errors.Join(runErr, liquibaseLock.release())
+	}()
+	if err := ensureMigrationLedger(migrationDB, schema); err != nil {
 		return fmt.Errorf("create schema migration ledger: %w", err)
 	}
+	if err := adoptLegacyLiquibaseHistory(migrationDB, schema, loaded); err != nil {
+		return err
+	}
+	if err := validateMigrationLedger(migrationDB, schema, loaded); err != nil {
+		return err
+	}
 
-	for _, name := range names {
-		contents, readErr := fs.ReadFile(migrations, name)
-		if readErr != nil {
-			return fmt.Errorf("read shared migration %s: %w", name, readErr)
-		}
-		sum := sha256.Sum256(contents)
-		checksum := hex.EncodeToString(sum[:])
-
+	for _, migration := range loaded {
 		if err := applyMigration(
-			db,
+			migrationDB,
 			schema,
-			filepath.Base(name),
-			checksum,
-			schema.ScopeCanonicalSQL(string(contents)),
+			migration.version,
+			migration.checksum,
+			migration.sql,
 		); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func readCanonicalMigrations(
+	migrations fs.FS,
+	schema database.Schema,
+) ([]canonicalMigration, error) {
+	names, err := fs.Glob(migrations, "*.sql")
+	if err != nil {
+		return nil, fmt.Errorf("list shared schema migrations: %w", err)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return nil, fmt.Errorf("shared schema migration inventory is empty")
+	}
+	loaded := make([]canonicalMigration, 0, len(names))
+	for _, name := range names {
+		contents, readErr := fs.ReadFile(migrations, name)
+		if readErr != nil {
+			return nil, fmt.Errorf("read shared migration %s: %w", name, readErr)
+		}
+		sum := sha256.Sum256(contents)
+		loaded = append(loaded, canonicalMigration{
+			version:  filepath.Base(name),
+			checksum: hex.EncodeToString(sum[:]),
+			sql:      schema.ScopeCanonicalSQL(string(contents)),
+		})
+	}
+	return loaded, nil
+}
+
+func acquireMigrationImportLocks(db *gorm.DB) (*migrationImportLocks, error) {
+	if db == nil {
+		return nil, fmt.Errorf("acquire schema migration import locks: database connection is nil")
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema migration database: %w", err)
+	}
+	connection, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("reserve schema migration lock connection: %w", err)
+	}
+	// Context forces GORM to clone Statement. Without that clone, replacing ConnPool here also
+	// mutates the caller and leaves the importer bound to this connection after it is returned.
+	migrationDB := db.Session(&gorm.Session{NewDB: true, Context: context.Background()})
+	migrationDB.ConnPool = connection
+	migrationDB.Statement.ConnPool = connection
+	locks := &migrationImportLocks{connection: connection, db: migrationDB}
+	lockTypes, err := requiredMigrationLockTypes([]string{"release"})
+	if err != nil {
+		_ = connection.Close()
+		return nil, fmt.Errorf("resolve schema migration import locks: %w", err)
+	}
+	for _, entityType := range lockTypes {
+		key, keyErr := migrationEntityLockKey(entityType)
+		if keyErr != nil {
+			_ = locks.release()
+			return nil, fmt.Errorf("resolve %s schema migration lock: %w", entityType, keyErr)
+		}
+		var acquired bool
+		queryErr := connection.QueryRowContext(
+			context.Background(),
+			migrationImportLockSQL,
+			opendiscogsmanifest.AdvisoryLockNamespace,
+			key,
+		).Scan(&acquired)
+		if queryErr != nil {
+			_ = locks.release()
+			return nil, fmt.Errorf("acquire %s schema migration lock: %w", entityType, queryErr)
+		}
+		if !acquired {
+			_ = locks.release()
+			return nil, fmt.Errorf(
+				"cannot migrate schema while an %s import is active; stop every Go and Java importer and retry",
+				entityType,
+			)
+		}
+		locks.keys = append(locks.keys, key)
+	}
+	return locks, nil
+}
+
+func (locks *migrationImportLocks) release() error {
+	if locks == nil || locks.connection == nil {
+		return nil
+	}
+	var releaseErrors []error
+	for index := len(locks.keys) - 1; index >= 0; index-- {
+		var released bool
+		if err := locks.connection.QueryRowContext(
+			context.Background(),
+			migrationImportUnlockSQL,
+			opendiscogsmanifest.AdvisoryLockNamespace,
+			locks.keys[index],
+		).Scan(&released); err != nil {
+			releaseErrors = append(releaseErrors, fmt.Errorf("release schema migration import lock: %w", err))
+		} else if !released {
+			releaseErrors = append(
+				releaseErrors,
+				fmt.Errorf("schema migration advisory lock was not held: %d", locks.keys[index]),
+			)
+		}
+	}
+	locks.keys = nil
+	if len(releaseErrors) > 0 {
+		locks.discardConnection()
+	}
+	if err := locks.connection.Close(); err != nil {
+		releaseErrors = append(releaseErrors, fmt.Errorf("close schema migration lock connection: %w", err))
+	}
+	locks.connection = nil
+	locks.db = nil
+	return errors.Join(releaseErrors...)
+}
+
+func (locks *migrationImportLocks) discardConnection() {
+	if locks == nil || locks.connection == nil {
+		return
+	}
+	_ = locks.connection.Raw(func(any) error { return driver.ErrBadConn })
+}
+
+func validateMigrationLedger(
+	db *gorm.DB,
+	schema database.Schema,
+	migrations []canonicalMigration,
+) error {
+	var applied []struct {
+		Version  string
+		Checksum string
+	}
+	if err := db.Raw(
+		"select version, checksum from " + schema.Qualify(migrationTable) + " order by version",
+	).Scan(&applied).Error; err != nil {
+		return fmt.Errorf("read shared migration inventory: %w", err)
+	}
+	if len(applied) > len(migrations) {
+		return fmt.Errorf("database schema contains migrations newer than this batch artifact")
+	}
+	for index, row := range applied {
+		expected := migrations[index]
+		if row.Version != expected.version {
+			return fmt.Errorf(
+				"database migration history is not a canonical prefix: position=%d database=%s artifact=%s",
+				index,
+				row.Version,
+				expected.version,
+			)
+		}
+		if row.Checksum != expected.checksum {
+			return fmt.Errorf(
+				"shared migration %s checksum changed: database=%s artifact=%s",
+				row.Version,
+				row.Checksum,
+				expected.checksum,
+			)
+		}
+	}
+	return nil
+}
+
+func ensureMigrationLedger(db *gorm.DB, schema database.Schema) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		var acquired bool
+		if err := tx.Raw(
+			migrationBootstrapLockSQL,
+			migrationBootstrapLockName+":"+schema.Name(),
+		).Scan(&acquired).Error; err != nil {
+			return fmt.Errorf("lock schema migration bootstrap: %w", err)
+		}
+		if !acquired {
+			return fmt.Errorf("another schema migrator is active for schema %s", schema.Name())
+		}
+		return tx.Exec(fmt.Sprintf(`
+			create table if not exists %s
+			(
+			    version     varchar(255) primary key,
+			    checksum    char(64) not null,
+			    applied_at  timestamp not null default now()
+			)`, schema.Qualify(migrationTable))).Error
+	})
 }
 
 func applyMigration(db *gorm.DB, schema database.Schema, version, checksum, sql string) error {
@@ -98,6 +321,9 @@ func applyMigration(db *gorm.DB, schema database.Schema, version, checksum, sql 
 			return nil
 		}
 
+		if err := setMigrationSearchPath(tx, schema); err != nil {
+			return err
+		}
 		if err := tx.Exec(sql).Error; err != nil {
 			return fmt.Errorf("apply shared migration %s: %w", version, err)
 		}
@@ -110,4 +336,32 @@ func applyMigration(db *gorm.DB, schema database.Schema, version, checksum, sql 
 		}
 		return nil
 	})
+}
+
+func setMigrationSearchPath(tx *gorm.DB, schema database.Schema) error {
+	pathNames := make(map[string]struct{}, 3)
+	path := make([]string, 0, 3)
+	appendPath := func(name, identifier string) {
+		if _, exists := pathNames[name]; exists {
+			return
+		}
+		pathNames[name] = struct{}{}
+		path = append(path, identifier)
+	}
+	var extensionSchema migrationExtensionSchema
+	result := tx.Raw(trigramExtensionSchemaSQL).Scan(&extensionSchema)
+	if result.Error != nil {
+		return fmt.Errorf("inspect pg_trgm extension schema: %w", result.Error)
+	}
+	if result.RowsAffected > 0 {
+		appendPath(extensionSchema.Name, extensionSchema.Identifier)
+	} else {
+		appendPath(database.DefaultSchemaName, `"`+database.DefaultSchemaName+`"`)
+	}
+	appendPath(schema.Name(), schema.Identifier())
+	appendPath(database.DefaultSchemaName, `"`+database.DefaultSchemaName+`"`)
+	if err := tx.Exec("set local search_path to " + strings.Join(path, ", ")).Error; err != nil {
+		return fmt.Errorf("set schema migration search path: %w", err)
+	}
+	return nil
 }

--- a/src/batch/ddl_integration_test.go
+++ b/src/batch/ddl_integration_test.go
@@ -1,0 +1,268 @@
+package batch
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	opendiscogsschema "github.com/dsub-io/open-discogs-model/schema"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const legacyCustomChecksumFixture = "9:00000000000000000000000000000000"
+
+func openMigrationPostgreSQL(t *testing.T) *gorm.DB {
+	t.Helper()
+	postgres := testutils.GetDatabase(t, testutils.Postgres)
+	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, postgres))
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, sqlDB.Close())
+	})
+	return db
+}
+
+func ensureMigrationTestSchema(t *testing.T, db *gorm.DB, name string) database.Schema {
+	t.Helper()
+	schema := requireMigrationSchema(t, name)
+	_, err := database.EnsureSchema(db, schema)
+	require.NoError(t, err)
+	return schema
+}
+
+func requireCanonicalMigrationLedger(t *testing.T, db *gorm.DB, schema database.Schema) {
+	t.Helper()
+	migrationFS, err := loadSchemaMigrations()
+	require.NoError(t, err)
+	expected, err := readCanonicalMigrations(migrationFS, schema)
+	require.NoError(t, err)
+
+	var actual []struct {
+		Version  string
+		Checksum string
+	}
+	require.NoError(t, db.Raw(
+		"select version, checksum from "+schema.Qualify(migrationTable)+" order by version",
+	).Scan(&actual).Error)
+	require.Len(t, actual, len(expected))
+	for index, migration := range expected {
+		require.Equal(t, migration.version, actual[index].Version)
+		require.Equal(t, migration.checksum, actual[index].Checksum)
+	}
+}
+
+func requirePostgreSQLRelation(
+	t *testing.T,
+	db *gorm.DB,
+	schema database.Schema,
+	relation string,
+) {
+	t.Helper()
+	var exists bool
+	require.NoError(t, db.Raw(
+		"select to_regclass(?) is not null",
+		schema.Name()+"."+relation,
+	).Scan(&exists).Error)
+	require.True(t, exists, "%s.%s must exist", schema.Name(), relation)
+}
+
+func requireBoundedPostgreSQLMigration(
+	t *testing.T,
+	db *gorm.DB,
+	schema database.Schema,
+) {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() {
+		result <- RunDDLInSchema(db, schema.Name())
+	}()
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+		t.Fatal("schema migration did not complete with a single pooled connection")
+	}
+}
+
+func requireTrigramExtensionSchema(t *testing.T, db *gorm.DB, expected string) {
+	t.Helper()
+	var actual migrationExtensionSchema
+	require.NoError(t, db.Raw(trigramExtensionSchemaSQL).Scan(&actual).Error)
+	require.Equal(t, expected, actual.Name)
+}
+
+func seedCustomLegacyLiquibasePrefix(
+	t *testing.T,
+	db *gorm.DB,
+	schema database.Schema,
+	prefixLength int,
+) {
+	t.Helper()
+	migrationFS, err := loadSchemaMigrations()
+	require.NoError(t, err)
+	migrations, err := readCanonicalMigrations(migrationFS, schema)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(migrations), prefixLength)
+	for _, migration := range migrations[:prefixLength] {
+		require.NoError(t, db.Exec(migration.sql).Error)
+	}
+	require.NoError(t, db.Exec(`
+		create table `+schema.Qualify(liquibaseChangeLogTable)+` (
+			id varchar(255) not null,
+			author varchar(255) not null,
+			filename varchar(255) not null,
+			exectype varchar(10) not null,
+			md5sum varchar(35)
+		)`).Error)
+	manifest, err := opendiscogsschema.LegacyLiquibaseCompatibility()
+	require.NoError(t, err)
+	for _, migration := range manifest.Migrations[:prefixLength] {
+		var changeSet *opendiscogsschema.LegacyChangeSet
+		for index := range migration.LegacyChangeSets {
+			candidate := &migration.LegacyChangeSets[index]
+			if candidate.SchemaMode == opendiscogsschema.LegacySchemaModeCustom {
+				changeSet = candidate
+				break
+			}
+		}
+		require.NotNil(t, changeSet)
+		require.NoError(t, db.Exec(
+			"insert into "+schema.Qualify(liquibaseChangeLogTable)+
+				" (id, author, filename, exectype, md5sum) values (?, ?, ?, ?, ?)",
+			changeSet.ID,
+			changeSet.Author,
+			changeSet.Filename,
+			string(opendiscogsschema.LegacyExecutionTypeExecuted),
+			legacyCustomChecksumFixture,
+		).Error)
+	}
+}
+
+func TestPostgreSQLMigrationContracts(t *testing.T) {
+	db := openMigrationPostgreSQL(t)
+
+	t.Run("keeps shared extension after first custom schema is dropped", func(t *testing.T) {
+		first := ensureMigrationTestSchema(t, db, "migration_first")
+		second := ensureMigrationTestSchema(t, db, "migration_second")
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		sqlDB.SetMaxOpenConns(1)
+
+		requireBoundedPostgreSQLMigration(t, db, first)
+		requireBoundedPostgreSQLMigration(t, db, second)
+		sqlDB.SetMaxOpenConns(4)
+
+		requireCanonicalMigrationLedger(t, db, first)
+		requireCanonicalMigrationLedger(t, db, second)
+		for _, schema := range []database.Schema{first, second} {
+			requirePostgreSQLRelation(t, db, schema, "artist")
+			requirePostgreSQLRelation(t, db, schema, "ix_artist_name_trgm")
+		}
+
+		requireTrigramExtensionSchema(t, db, database.DefaultSchemaName)
+		require.NoError(t, db.Exec("drop schema "+first.Identifier()+" cascade").Error)
+		requireTrigramExtensionSchema(t, db, database.DefaultSchemaName)
+		requirePostgreSQLRelation(t, db, second, "ix_artist_name_trgm")
+		requirePostgreSQLRelation(t, db, second, "ix_release_item_title_trgm")
+	})
+
+	t.Run("serializes the same new migration", func(t *testing.T) {
+		schema := ensureMigrationTestSchema(t, db, "migration_concurrent")
+		require.NoError(t, ensureMigrationLedger(db, schema))
+		const (
+			version = "V900__concurrent_fixture.sql"
+			sqlText = `create table "migration_concurrent".fixture(id integer)`
+		)
+		checksum := migrationChecksum(sqlText)
+		start := make(chan struct{})
+		errors := make(chan error, 2)
+		var waitGroup sync.WaitGroup
+		for range 2 {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				<-start
+				errors <- applyMigration(db, schema, version, checksum, sqlText)
+			}()
+		}
+		close(start)
+		waitGroup.Wait()
+		close(errors)
+		for err := range errors {
+			require.NoError(t, err)
+		}
+
+		requirePostgreSQLRelation(t, db, schema, "fixture")
+		var ledgerRows int64
+		require.NoError(t, db.Raw(
+			"select count(*) from "+schema.Qualify(migrationTable)+" where version = ?",
+			version,
+		).Scan(&ledgerRows).Error)
+		require.EqualValues(t, 1, ledgerRows)
+	})
+
+	t.Run("rejects migration while an import lock is active", func(t *testing.T) {
+		active, err := acquireMigrationImportLocks(db)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, active.release())
+		})
+
+		blocked, err := acquireMigrationImportLocks(db)
+		require.Nil(t, blocked)
+		require.ErrorContains(t, err, "artist import is active")
+
+		require.NoError(t, active.release())
+		reacquired, err := acquireMigrationImportLocks(db)
+		require.NoError(t, err)
+		require.NoError(t, reacquired.release())
+	})
+
+	t.Run("adopts a verified custom Liquibase V007 prefix", func(t *testing.T) {
+		schema := ensureMigrationTestSchema(t, db, "migration_legacy_v007")
+		seedCustomLegacyLiquibasePrefix(t, db, schema, 7)
+
+		require.NoError(t, RunDDLInSchema(db, schema.Name()))
+		requireCanonicalMigrationLedger(t, db, schema)
+
+		var locked bool
+		require.NoError(t, db.Raw(
+			"select locked from "+schema.Qualify(liquibaseLockTable)+" where id = ?",
+			liquibaseLockID,
+		).Scan(&locked).Error)
+		require.False(t, locked)
+
+		var revisionColumn bool
+		require.NoError(t, db.Raw(
+			`select exists (
+				select 1 from information_schema.columns
+				where table_schema = ?
+				  and table_name = 'discogs_import_run_dump'
+				  and column_name = 'import_contract_revision'
+			)`,
+			schema.Name(),
+		).Scan(&revisionColumn).Error)
+		require.True(t, revisionColumn)
+
+		var adoptedChecksums []string
+		require.NoError(t, db.Raw(
+			"select checksum from "+schema.Qualify(migrationTable)+
+				" order by version limit ?",
+			7,
+		).Scan(&adoptedChecksums).Error)
+		require.Len(t, adoptedChecksums, 7)
+		for _, checksum := range adoptedChecksums {
+			require.Len(t, strings.TrimSpace(checksum), 64)
+		}
+	})
+}

--- a/src/batch/dependency_preflight.go
+++ b/src/batch/dependency_preflight.go
@@ -1,0 +1,224 @@
+package batch
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	opendiscogsmanifest "github.com/dsub-io/open-discogs-model/manifest"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+)
+
+const (
+	dependencyCheckpointQuery = `
+select checkpoint.dump_date,
+       checkpoint.checksum_sha256,
+       expected.dump_date,
+       expected.checksum_sha256
+  from discogs_import_checkpoint checkpoint
+  left join lateral (
+        select dump.dump_date,
+               dump.checksum_sha256
+          from discogs_dump dump
+         where dump.entity_type = $1
+           and dump.dump_date < $2
+         order by dump.dump_date desc, dump.id desc
+         limit 1
+       ) expected on true
+ where checkpoint.entity_type = $1`
+	dependencyDateFormat = "2006-01-02"
+)
+
+var requiredImportDependencyTypes = opendiscogsmanifest.RequiredLockEntityTypes
+
+type dependencyRequirement struct {
+	entityType       string
+	requiredBy       []string
+	horizonExclusive time.Time
+}
+
+type dependencyCheckpoint struct {
+	dumpDate       time.Time
+	checksumSHA256 string
+}
+
+func preflightImportDependencies(
+	ctx context.Context,
+	db *sql.DB,
+	dumps []*opendiscogsmodel.DiscogsDump,
+) error {
+	requirements, err := importDependencyRequirements(dumps)
+	if err != nil {
+		return err
+	}
+	if len(requirements) == 0 {
+		return nil
+	}
+	if db == nil {
+		return errors.New("preflight import dependencies: database connection is nil")
+	}
+
+	for _, requirement := range requirements {
+		checkpoint, expected, readErr := readDependencyCheckpoint(ctx, db, requirement)
+		if readErr != nil {
+			return readErr
+		}
+		if compatibilityErr := validateDependencyCheckpoint(
+			requirement,
+			checkpoint,
+			expected,
+		); compatibilityErr != nil {
+			return compatibilityErr
+		}
+	}
+	return nil
+}
+
+func importDependencyRequirements(
+	dumps []*opendiscogsmodel.DiscogsDump,
+) ([]dependencyRequirement, error) {
+	selected := make(map[string]*opendiscogsmodel.DiscogsDump, len(dumps))
+	for _, dump := range dumps {
+		if dump == nil {
+			return nil, errors.New("dependency preflight contains a nil dump")
+		}
+		entityTypes, err := opendiscogsmanifest.OrderedEntityTypes([]string{dump.EntityType})
+		if err != nil {
+			return nil, fmt.Errorf("resolve dependency preflight entity: %w", err)
+		}
+		entityType := entityTypes[0]
+		if _, duplicate := selected[entityType]; duplicate {
+			return nil, fmt.Errorf("dependency preflight contains duplicate entity type %q", entityType)
+		}
+		if dump.DumpDate.IsZero() {
+			return nil, fmt.Errorf("dependency preflight dump date is required for %q", entityType)
+		}
+		selected[entityType] = dump
+	}
+
+	requirementsByType := make(map[string]dependencyRequirement)
+	for entityType, dump := range selected {
+		dependencyTypes, err := requiredImportDependencyTypes([]string{entityType})
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s import dependencies: %w", entityType, err)
+		}
+		horizon := firstDayOfNextMonth(dump.DumpDate)
+		for _, dependencyType := range dependencyTypes {
+			if dependencyType == entityType {
+				continue
+			}
+			if _, included := selected[dependencyType]; included {
+				continue
+			}
+
+			requirement := requirementsByType[dependencyType]
+			requirement.entityType = dependencyType
+			if horizon.After(requirement.horizonExclusive) {
+				requirement.horizonExclusive = horizon
+			}
+			requirement.requiredBy = append(requirement.requiredBy, entityType)
+			requirementsByType[dependencyType] = requirement
+		}
+	}
+
+	entityTypes := make([]string, 0, len(requirementsByType))
+	for entityType := range requirementsByType {
+		entityTypes = append(entityTypes, entityType)
+	}
+	sort.Strings(entityTypes)
+	requirements := make([]dependencyRequirement, 0, len(entityTypes))
+	for _, entityType := range entityTypes {
+		requirement := requirementsByType[entityType]
+		sort.Strings(requirement.requiredBy)
+		requirements = append(requirements, requirement)
+	}
+	return requirements, nil
+}
+
+func firstDayOfNextMonth(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func readDependencyCheckpoint(
+	ctx context.Context,
+	db *sql.DB,
+	requirement dependencyRequirement,
+) (dependencyCheckpoint, *dependencyCheckpoint, error) {
+	var (
+		checkpoint       dependencyCheckpoint
+		expectedDate     sql.NullTime
+		expectedChecksum sql.NullString
+	)
+	err := db.QueryRowContext(
+		ctx,
+		dependencyCheckpointQuery,
+		requirement.entityType,
+		requirement.horizonExclusive,
+	).Scan(
+		&checkpoint.dumpDate,
+		&checkpoint.checksumSHA256,
+		&expectedDate,
+		&expectedChecksum,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return dependencyCheckpoint{}, nil, fmt.Errorf(
+			"partial import requires a successful %s checkpoint for %s",
+			requirement.entityType,
+			strings.Join(requirement.requiredBy, ","),
+		)
+	}
+	if err != nil {
+		return dependencyCheckpoint{}, nil, fmt.Errorf(
+			"read %s dependency checkpoint: %w",
+			requirement.entityType,
+			err,
+		)
+	}
+	if !expectedDate.Valid || !expectedChecksum.Valid {
+		return checkpoint, nil, nil
+	}
+	return checkpoint, &dependencyCheckpoint{
+		dumpDate:       expectedDate.Time,
+		checksumSHA256: expectedChecksum.String,
+	}, nil
+}
+
+func validateDependencyCheckpoint(
+	requirement dependencyRequirement,
+	checkpoint dependencyCheckpoint,
+	expected *dependencyCheckpoint,
+) error {
+	if !checkpoint.dumpDate.Before(requirement.horizonExclusive) {
+		return nil
+	}
+	if expected == nil {
+		return fmt.Errorf(
+			"%s checkpoint %s has no immutable catalog provenance before %s",
+			requirement.entityType,
+			checkpoint.dumpDate.Format(dependencyDateFormat),
+			requirement.horizonExclusive.Format(dependencyDateFormat),
+		)
+	}
+
+	checkpointDate := checkpoint.dumpDate.Format(dependencyDateFormat)
+	expectedDate := expected.dumpDate.Format(dependencyDateFormat)
+	staleDate := checkpointDate < expectedDate
+	reissued := checkpointDate == expectedDate && !strings.EqualFold(
+		strings.TrimSpace(checkpoint.checksumSHA256),
+		strings.TrimSpace(expected.checksumSHA256),
+	)
+	if !staleDate && !reissued {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s checkpoint %s is stale for %s; latest compatible catalog dump is %s",
+		requirement.entityType,
+		checkpointDate,
+		strings.Join(requirement.requiredBy, ","),
+		expectedDate,
+	)
+}

--- a/src/batch/dependency_preflight_test.go
+++ b/src/batch/dependency_preflight_test.go
@@ -1,0 +1,444 @@
+package batch
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const dependencyTestDateLayout = "2006-01-02"
+
+func TestImportDependencyRequirements(t *testing.T) {
+	t.Run("artist and label have no reference dependencies", func(t *testing.T) {
+		requirements, err := importDependencyRequirements([]*opendiscogsmodel.DiscogsDump{
+			importDump("artist", "2026-08-02", "1"),
+			importDump("label", "2026-08-03", "2"),
+		})
+		require.NoError(t, err)
+		require.Empty(t, requirements)
+	})
+
+	t.Run("master requires artist", func(t *testing.T) {
+		requirements, err := importDependencyRequirements([]*opendiscogsmodel.DiscogsDump{
+			importDump("master", "2026-08-04", "3"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []dependencyRequirement{{
+			entityType:       "artist",
+			requiredBy:       []string{"master"},
+			horizonExclusive: dependencyTestDate(t, "2026-09-01"),
+		}}, requirements)
+	})
+
+	t.Run("release requires artist label and master", func(t *testing.T) {
+		requirements, err := importDependencyRequirements([]*opendiscogsmodel.DiscogsDump{
+			importDump("release", "2026-08-05", "4"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []dependencyRequirement{
+			{
+				entityType:       "artist",
+				requiredBy:       []string{"release"},
+				horizonExclusive: dependencyTestDate(t, "2026-09-01"),
+			},
+			{
+				entityType:       "label",
+				requiredBy:       []string{"release"},
+				horizonExclusive: dependencyTestDate(t, "2026-09-01"),
+			},
+			{
+				entityType:       "master",
+				requiredBy:       []string{"release"},
+				horizonExclusive: dependencyTestDate(t, "2026-09-01"),
+			},
+		}, requirements)
+	})
+
+	t.Run("included dependencies satisfy the plan in execution order", func(t *testing.T) {
+		requirements, err := importDependencyRequirements([]*opendiscogsmodel.DiscogsDump{
+			importDump("release", "2026-08-05", "4"),
+			importDump("master", "2026-07-31", "3"),
+			importDump("label", "2026-08-03", "2"),
+			importDump("artist", "2026-08-02", "1"),
+		})
+		require.NoError(t, err)
+		require.Empty(t, requirements)
+	})
+
+	t.Run("shared dependency uses the latest required month", func(t *testing.T) {
+		requirements, err := importDependencyRequirements([]*opendiscogsmodel.DiscogsDump{
+			importDump("master", "2026-07-31", "3"),
+			importDump("release", "2026-08-05", "4"),
+			importDump("label", "2026-08-03", "2"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []dependencyRequirement{{
+			entityType:       "artist",
+			requiredBy:       []string{"master", "release"},
+			horizonExclusive: dependencyTestDate(t, "2026-09-01"),
+		}}, requirements)
+	})
+}
+
+func TestImportDependencyRequirementValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		dumps []*opendiscogsmodel.DiscogsDump
+		want  string
+	}{
+		{name: "nil dump", dumps: []*opendiscogsmodel.DiscogsDump{nil}, want: "nil dump"},
+		{
+			name: "unknown entity",
+			dumps: []*opendiscogsmodel.DiscogsDump{
+				importDump("release", "2026-08-05", "4"),
+				{EntityType: "unknown", DumpDate: dependencyTestDate(t, "2026-08-01")},
+			},
+			want: "unknown entity type",
+		},
+		{
+			name: "duplicate entity",
+			dumps: []*opendiscogsmodel.DiscogsDump{
+				importDump("artist", "2026-08-01", "1"),
+				importDump("ARTIST", "2026-08-02", "2"),
+			},
+			want: "duplicate entity type",
+		},
+		{
+			name:  "missing date",
+			dumps: []*opendiscogsmodel.DiscogsDump{{EntityType: "artist"}},
+			want:  "dump date is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := importDependencyRequirements(test.dumps)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+
+	t.Run("dependency graph errors are preserved", func(t *testing.T) {
+		expected := errors.New("fixture")
+		original := requiredImportDependencyTypes
+		requiredImportDependencyTypes = func([]string) ([]string, error) {
+			return nil, expected
+		}
+		t.Cleanup(func() { requiredImportDependencyTypes = original })
+
+		_, err := importDependencyRequirements([]*opendiscogsmodel.DiscogsDump{
+			importDump("master", "2026-08-04", "3"),
+		})
+
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "resolve master import dependencies")
+	})
+}
+
+func TestPreflightImportDependencies(t *testing.T) {
+	ctx := context.Background()
+	releaseDump := importDump("release", "2026-08-05", "4")
+	horizon := dependencyTestDate(t, "2026-09-01")
+
+	t.Run("independent entities and complete plans need no checkpoint query", func(t *testing.T) {
+		require.NoError(t, preflightImportDependencies(ctx, nil, []*opendiscogsmodel.DiscogsDump{
+			importDump("artist", "2026-08-02", "1"),
+			importDump("label", "2026-08-03", "2"),
+		}))
+		require.NoError(t, preflightImportDependencies(ctx, nil, []*opendiscogsmodel.DiscogsDump{
+			importDump("artist", "2026-08-02", "1"),
+			importDump("label", "2026-08-03", "2"),
+			importDump("master", "2026-07-31", "3"),
+			releaseDump,
+		}))
+	})
+
+	t.Run("required dependencies need a database", func(t *testing.T) {
+		err := preflightImportDependencies(ctx, nil, []*opendiscogsmodel.DiscogsDump{releaseDump})
+		require.ErrorContains(t, err, "database connection is nil")
+	})
+
+	t.Run("invalid plan is rejected before database access", func(t *testing.T) {
+		err := preflightImportDependencies(ctx, nil, []*opendiscogsmodel.DiscogsDump{nil})
+		require.ErrorContains(t, err, "nil dump")
+	})
+
+	t.Run("empty database rejects release-only import", func(t *testing.T) {
+		db, mock := dependencySQLMock(t)
+		expectDependencyCheckpoint(mock, "artist", horizon).
+			WillReturnRows(dependencyRows())
+
+		err := preflightImportDependencies(ctx, db, []*opendiscogsmodel.DiscogsDump{releaseDump})
+
+		require.ErrorContains(t, err, "successful artist checkpoint")
+	})
+
+	t.Run("incomplete checkpoint set rejects release-only import", func(t *testing.T) {
+		db, mock := dependencySQLMock(t)
+		artistDate := dependencyTestDate(t, "2026-07-29")
+		expectDependencyCheckpoint(mock, "artist", horizon).
+			WillReturnRows(dependencyRows().AddRow(artistDate, checksum("a"), artistDate, checksum("a")))
+		expectDependencyCheckpoint(mock, "label", horizon).
+			WillReturnRows(dependencyRows())
+
+		err := preflightImportDependencies(ctx, db, []*opendiscogsmodel.DiscogsDump{releaseDump})
+
+		require.ErrorContains(t, err, "successful label checkpoint")
+	})
+
+	t.Run("mixed publication dates are compatible", func(t *testing.T) {
+		db, mock := dependencySQLMock(t)
+		for _, dependency := range []struct {
+			entityType string
+			date       string
+			seed       string
+		}{
+			{entityType: "artist", date: "2026-07-29", seed: "a"},
+			{entityType: "label", date: "2026-08-02", seed: "b"},
+			{entityType: "master", date: "2026-07-31", seed: "c"},
+		} {
+			date := dependencyTestDate(t, dependency.date)
+			expectDependencyCheckpoint(mock, dependency.entityType, horizon).
+				WillReturnRows(dependencyRows().AddRow(
+					date,
+					checksum(dependency.seed),
+					date,
+					strings.ToUpper(checksum(dependency.seed)),
+				))
+		}
+
+		require.NoError(t, preflightImportDependencies(
+			ctx,
+			db,
+			[]*opendiscogsmodel.DiscogsDump{releaseDump},
+		))
+	})
+
+	t.Run("a newer checkpoint is compatible without an older catalog candidate", func(t *testing.T) {
+		db, mock := dependencySQLMock(t)
+		expectDependencyCheckpoint(mock, "artist", horizon).
+			WillReturnRows(dependencyRows().AddRow(
+				dependencyTestDate(t, "2026-09-02"),
+				checksum("a"),
+				nil,
+				nil,
+			))
+
+		require.NoError(t, preflightImportDependencies(
+			ctx,
+			db,
+			[]*opendiscogsmodel.DiscogsDump{importDump("master", "2026-08-04", "3")},
+		))
+	})
+
+	t.Run("known newer dependency dump makes checkpoint stale", func(t *testing.T) {
+		db, mock := dependencySQLMock(t)
+		expectDependencyCheckpoint(mock, "artist", horizon).
+			WillReturnRows(dependencyRows().AddRow(
+				dependencyTestDate(t, "2026-07-29"),
+				checksum("a"),
+				dependencyTestDate(t, "2026-08-04"),
+				checksum("d"),
+			))
+
+		err := preflightImportDependencies(ctx, db, []*opendiscogsmodel.DiscogsDump{releaseDump})
+
+		require.ErrorContains(t, err, "artist checkpoint 2026-07-29 is stale")
+	})
+
+	t.Run("query errors are explicit", func(t *testing.T) {
+		db, mock := dependencySQLMock(t)
+		expected := errors.New("fixture")
+		expectDependencyCheckpoint(mock, "artist", horizon).WillReturnError(expected)
+
+		err := preflightImportDependencies(ctx, db, []*opendiscogsmodel.DiscogsDump{releaseDump})
+
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "read artist dependency checkpoint")
+	})
+}
+
+func TestValidateDependencyCheckpoint(t *testing.T) {
+	requirement := dependencyRequirement{
+		entityType:       "artist",
+		requiredBy:       []string{"release"},
+		horizonExclusive: dependencyTestDate(t, "2026-09-01"),
+	}
+
+	t.Run("newer checkpoint is compatible without historical candidate", func(t *testing.T) {
+		err := validateDependencyCheckpoint(requirement, dependencyCheckpoint{
+			dumpDate:       dependencyTestDate(t, "2026-09-02"),
+			checksumSHA256: checksum("a"),
+		}, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing catalog provenance is rejected", func(t *testing.T) {
+		err := validateDependencyCheckpoint(requirement, dependencyCheckpoint{
+			dumpDate:       dependencyTestDate(t, "2026-07-29"),
+			checksumSHA256: checksum("a"),
+		}, nil)
+		require.ErrorContains(t, err, "no immutable catalog provenance")
+	})
+
+	t.Run("same-date reissue requires the current checksum", func(t *testing.T) {
+		date := dependencyTestDate(t, "2026-08-02")
+		err := validateDependencyCheckpoint(
+			requirement,
+			dependencyCheckpoint{dumpDate: date, checksumSHA256: checksum("a")},
+			&dependencyCheckpoint{dumpDate: date, checksumSHA256: checksum("b")},
+		)
+		require.ErrorContains(t, err, "is stale")
+	})
+
+	t.Run("checkpoint newer than the expected dump is compatible", func(t *testing.T) {
+		err := validateDependencyCheckpoint(
+			requirement,
+			dependencyCheckpoint{
+				dumpDate:       dependencyTestDate(t, "2026-08-03"),
+				checksumSHA256: checksum("a"),
+			},
+			&dependencyCheckpoint{
+				dumpDate:       dependencyTestDate(t, "2026-08-02"),
+				checksumSHA256: checksum("b"),
+			},
+		)
+		require.NoError(t, err)
+	})
+}
+
+func TestDependencyPreflightUsesCanonicalPostgreSQLCheckpoints(t *testing.T) {
+	ctx := context.Background()
+	pg := testutils.GetDatabase(t, testutils.Postgres)
+	dsn := testutils.GetDsn(testutils.Postgres, pg)
+	db, err := database.GetConnect(dsn)
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	db, err = database.GetConnect(dsn)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	masterDump := importDump("master", "2026-08-04", "3")
+	releaseDump := importDump("release", "2026-08-05", "4")
+	require.ErrorContains(t, preflightImportDependencies(
+		ctx,
+		sqlDB,
+		[]*opendiscogsmodel.DiscogsDump{masterDump},
+	), "successful artist checkpoint")
+	require.ErrorContains(t, preflightImportDependencies(
+		ctx,
+		sqlDB,
+		[]*opendiscogsmodel.DiscogsDump{releaseDump},
+	), "successful artist checkpoint")
+
+	require.NoError(t, preflightImportDependencies(ctx, sqlDB, []*opendiscogsmodel.DiscogsDump{
+		importDump("artist", "2026-08-02", "1"),
+		importDump("label", "2026-08-03", "2"),
+	}))
+	require.NoError(t, preflightImportDependencies(ctx, sqlDB, []*opendiscogsmodel.DiscogsDump{
+		importDump("artist", "2026-08-02", "1"),
+		importDump("label", "2026-08-03", "2"),
+		masterDump,
+		releaseDump,
+	}))
+
+	recordSuccessfulDependencyCheckpoint(t, db, importDump("artist", "2026-07-29", "a"))
+	require.ErrorContains(t, preflightImportDependencies(
+		ctx,
+		sqlDB,
+		[]*opendiscogsmodel.DiscogsDump{releaseDump},
+	), "successful label checkpoint")
+
+	recordSuccessfulDependencyCheckpoint(t, db, importDump("label", "2026-08-02", "b"))
+	recordSuccessfulDependencyCheckpoint(t, db, importDump("master", "2026-07-31", "c"))
+	require.NoError(t, preflightImportDependencies(
+		ctx,
+		sqlDB,
+		[]*opendiscogsmodel.DiscogsDump{releaseDump},
+	))
+
+	newerArtistDump := importDump("artist", "2026-08-04", "d")
+	require.NoError(t, db.Omit("ID", "CreatedAt", "LastModifiedAt").Create(newerArtistDump).Error)
+	require.ErrorContains(t, preflightImportDependencies(
+		ctx,
+		sqlDB,
+		[]*opendiscogsmodel.DiscogsDump{releaseDump},
+	), "artist checkpoint 2026-07-29 is stale")
+}
+
+func recordSuccessfulDependencyCheckpoint(
+	t *testing.T,
+	db *gorm.DB,
+	dump *opendiscogsmodel.DiscogsDump,
+) {
+	t.Helper()
+	require.NoError(t, db.Omit("ID", "CreatedAt", "LastModifiedAt").Create(dump).Error)
+	var runID int64
+	require.NoError(t, db.Raw(`
+		insert into discogs_import_run
+		       (manifest_sha256, status, completed_at, processor, processor_version)
+		values (?, 'success', now(), 'go-open-discogs-batch', 'dependency-preflight-test')
+		returning id`, dump.ChecksumSHA256).Scan(&runID).Error)
+	require.NoError(t, db.Exec(`
+		insert into discogs_import_run_dump
+		       (import_run_id, entity_type, dump_id, processed_items,
+		        last_progress_at, completed_at, chunk_size, total_items, total_chunks,
+		        import_contract_revision)
+		values (?, ?, ?, 0, now(), now(), 1, 0, 0, ?)`,
+		runID,
+		dump.EntityType,
+		dump.ID,
+		currentImportContractRevisions[dump.EntityType],
+	).Error)
+}
+
+func dependencySQLMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		require.NoError(t, db.Close())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+	return db, mock
+}
+
+func expectDependencyCheckpoint(
+	mock sqlmock.Sqlmock,
+	entityType string,
+	horizon time.Time,
+) *sqlmock.ExpectedQuery {
+	return mock.ExpectQuery(regexp.QuoteMeta(dependencyCheckpointQuery)).
+		WithArgs(entityType, horizon)
+}
+
+func dependencyRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"checkpoint_dump_date",
+		"checkpoint_checksum_sha256",
+		"expected_dump_date",
+		"expected_checksum_sha256",
+	})
+}
+
+func dependencyTestDate(t *testing.T, value string) time.Time {
+	t.Helper()
+	date, err := time.Parse(dependencyTestDateLayout, value)
+	require.NoError(t, err)
+	return date
+}
+
+func checksum(seed string) string {
+	return strings.Repeat(seed, 64)
+}

--- a/src/batch/execution.go
+++ b/src/batch/execution.go
@@ -10,13 +10,46 @@ import (
 
 	opendiscogsmanifest "github.com/dsub-io/open-discogs-model/manifest"
 	opendiscogsmodel "github.com/dsub-io/open-discogs-model/model"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-const processorName = "go-open-discogs-batch"
+type importContractRevision int32
+
+const (
+	processorName                         = "go-open-discogs-batch"
+	artistEntityType                      = "artist"
+	labelEntityType                       = "label"
+	masterEntityType                      = "master"
+	releaseEntityType                     = "release"
+	undefinedColumnSQLState               = "42703"
+	importContractRevisionMigration       = "V009"
+	importContractRevisionColumnReference = "discogs_import_run_dump.import_contract_revision"
+)
 
 var fingerprintImportManifest = opendiscogsmanifest.Fingerprint
 var orderImportEntityTypes = opendiscogsmanifest.OrderedEntityTypes
 var requiredImportLockTypes = opendiscogsmanifest.RequiredLockEntityTypes
+var currentImportContractRevisions = map[string]importContractRevision{
+	artistEntityType:  mustImportContractRevision(artistEntityType),
+	labelEntityType:   mustImportContractRevision(labelEntityType),
+	masterEntityType:  mustImportContractRevision(masterEntityType),
+	releaseEntityType: mustImportContractRevision(releaseEntityType),
+}
+
+func mustImportContractRevision(entityType string) importContractRevision {
+	revision, err := opendiscogsmanifest.ImportContractRevision(entityType)
+	if err != nil {
+		panic(fmt.Sprintf("load model import contract revision for %s: %v", entityType, err))
+	}
+	return importContractRevision(revision)
+}
+
+type importCheckpointCompatibility struct {
+	ExactRunID              int64
+	CompatibleEntityCount   int
+	SelectedEntityCount     int
+	IncompatibleEntityTypes []string
+}
 
 type ImportPreparation struct {
 	ManifestSHA256   string
@@ -90,6 +123,10 @@ func (c *ImportExecutionCoordinator) Prepare(
 	if err != nil {
 		return nil, err
 	}
+	revisions, err := resolveImportContractRevisions(entityTypes)
+	if err != nil {
+		return nil, err
+	}
 	lockTypes, err := requiredImportLockTypes(orderedTypes)
 	if err != nil {
 		return nil, err
@@ -128,13 +165,53 @@ func (c *ImportExecutionCoordinator) Prepare(
 		return nil, err
 	}
 
-	successfulRunID, err := findSuccessfulRun(ctx, tx, fingerprint)
+	dumpIDs := make([]int64, len(dumps))
+	for index, dump := range dumps {
+		dumpIDs[index], err = findOrInsertDump(ctx, tx, dump)
+		if err != nil {
+			_ = tx.Rollback()
+			c.release(ctx)
+			return nil, err
+		}
+	}
+
+	compatibility, err := findSuccessfulRun(
+		ctx,
+		tx,
+		fingerprint,
+	)
 	if err != nil {
 		_ = tx.Rollback()
 		c.release(ctx)
 		return nil, err
 	}
-	if successfulRunID != 0 && !force {
+	if !force && compatibility.SelectedEntityCount == len(dumps) &&
+		compatibility.CompatibleEntityCount > 0 &&
+		compatibility.CompatibleEntityCount < compatibility.SelectedEntityCount {
+		_ = tx.Rollback()
+		c.release(ctx)
+		return nil, fmt.Errorf(
+			"import plan is partially satisfied; preserve compatible checkpoints and rerun only --entities %s",
+			strings.Join(compatibility.IncompatibleEntityTypes, ","),
+		)
+	}
+	if !force && compatibility.SelectedEntityCount == len(dumps) &&
+		compatibility.CompatibleEntityCount == compatibility.SelectedEntityCount {
+		successfulRunID := compatibility.ExactRunID
+		if successfulRunID == 0 {
+			successfulRunID, err = consolidateSuccessfulImportRun(
+				ctx,
+				tx,
+				fingerprint,
+				c.processorVersion,
+				len(dumps),
+			)
+			if err != nil {
+				_ = tx.Rollback()
+				c.release(ctx)
+				return nil, err
+			}
+		}
 		if err := tx.Commit(); err != nil {
 			_ = tx.Rollback()
 			c.release(ctx)
@@ -147,16 +224,6 @@ func (c *ImportExecutionCoordinator) Prepare(
 			RunID:          successfulRunID,
 			Skipped:        true,
 		}, nil
-	}
-
-	dumpIDs := make([]int64, len(dumps))
-	for index, dump := range dumps {
-		dumpIDs[index], err = findOrInsertDump(ctx, tx, dump)
-		if err != nil {
-			_ = tx.Rollback()
-			c.release(ctx)
-			return nil, err
-		}
 	}
 
 	resumedFromRunID := int64(0)
@@ -191,19 +258,18 @@ func (c *ImportExecutionCoordinator) Prepare(
 		return nil, err
 	}
 	for index, dump := range dumps {
-		if _, err := tx.ExecContext(
+		if err := insertImportRunDump(
 			ctx,
-			`insert into discogs_import_run_dump
-			    (import_run_id, entity_type, dump_id, chunk_size)
-			 values ($1, $2, $3, $4)`,
+			tx,
 			runID,
 			dump.EntityType,
 			dumpIDs[index],
 			chunkSize,
+			revisions[index],
 		); err != nil {
 			_ = tx.Rollback()
 			c.release(ctx)
-			return nil, fmt.Errorf("record import run dump %s: %w", dump.EntityType, err)
+			return nil, err
 		}
 	}
 	if resumedFromRunID != 0 {
@@ -429,53 +495,218 @@ func assertNotDowngrade(
 	return nil
 }
 
+func resolveImportContractRevisions(
+	entityTypes []string,
+) ([]importContractRevision, error) {
+	revisions := make([]importContractRevision, len(entityTypes))
+	for index, entityType := range entityTypes {
+		revision, exists := currentImportContractRevisions[entityType]
+		if !exists || revision < 1 {
+			return nil, fmt.Errorf(
+				"import contract revision is unavailable for entity %s",
+				entityType,
+			)
+		}
+		revisions[index] = revision
+	}
+	return revisions, nil
+}
+
+func importContractRevisionSQL(entityTypeColumn string) string {
+	return fmt.Sprintf(
+		"case %s when '%s' then %d when '%s' then %d when '%s' then %d when '%s' then %d end",
+		entityTypeColumn,
+		artistEntityType,
+		currentImportContractRevisions[artistEntityType],
+		labelEntityType,
+		currentImportContractRevisions[labelEntityType],
+		masterEntityType,
+		currentImportContractRevisions[masterEntityType],
+		releaseEntityType,
+		currentImportContractRevisions[releaseEntityType],
+	)
+}
+
 func findSuccessfulRun(
 	ctx context.Context,
 	tx *sql.Tx,
 	fingerprint string,
-) (int64, error) {
-	var runID int64
+) (importCheckpointCompatibility, error) {
+	var exactRunID sql.NullInt64
+	var compatibleEntityCount int
+	var selectedEntityCount int
+	var incompatibleEntityTypes string
+	query := fmt.Sprintf(
+		`with candidate_run as (
+		    select candidate.id
+		      from discogs_import_run candidate
+		     where candidate.manifest_sha256 = $1
+		       and candidate.status = 'success'
+		     order by candidate.completed_at desc, candidate.id desc
+		     limit 1
+		), expected as (
+		    select candidate_dump.entity_type,
+		           candidate_dump.dump_id,
+		           candidate_dump.import_contract_revision as candidate_revision,
+		           %s as expected_revision
+		      from candidate_run
+		      join discogs_import_run_dump candidate_dump
+		        on candidate_dump.import_run_id = candidate_run.id
+		), compatibility as (
+		    select expected.entity_type,
+		           checkpoint.import_run_id,
+		           coalesce(
+		               current_dump.dump_id = expected.dump_id
+		               and current_dump.import_contract_revision = expected.expected_revision
+		               and not exists (
+		                   select 1
+		                     from discogs_import_run_dump failed_dump
+		                     join discogs_import_run failed_run
+		                       on failed_run.id = failed_dump.import_run_id
+		                    where failed_dump.entity_type = expected.entity_type
+		                      and failed_run.status = 'failed'
+		                      and (failed_run.completed_at > checkpoint.applied_at
+		                           or (failed_run.completed_at = checkpoint.applied_at
+		                               and failed_run.id > checkpoint.import_run_id))
+		               ),
+		               false
+		           ) as compatible
+		      from expected
+		      left join discogs_import_checkpoint checkpoint
+		        on checkpoint.entity_type = expected.entity_type
+		      left join discogs_import_run_dump current_dump
+		        on current_dump.import_run_id = checkpoint.import_run_id
+		       and current_dump.entity_type = checkpoint.entity_type
+		), exact_run as (
+		    select candidate_run.id
+		      from candidate_run
+		     where not exists (
+		         select 1
+		           from expected
+		          where candidate_revision is distinct from expected_revision
+		     )
+		)
+		select (select id from exact_run),
+		       count(*) filter (where compatible),
+		       count(*),
+		       coalesce(
+		           string_agg(entity_type, ',' order by entity_type)
+		               filter (where not compatible),
+		           ''
+		       )
+		  from compatibility`,
+		importContractRevisionSQL("candidate_dump.entity_type"),
+	)
 	err := tx.QueryRowContext(
 		ctx,
-		`select candidate_run.id
-		   from discogs_import_run candidate_run
-		  where candidate_run.manifest_sha256 = $1
-		    and candidate_run.status = 'success'
-		    and not exists (
-		        select 1
-		          from discogs_import_run_dump candidate_dump
-		          left join discogs_import_checkpoint checkpoint
-		            on checkpoint.entity_type = candidate_dump.entity_type
-		          left join discogs_import_run_dump current_dump
-		            on current_dump.import_run_id = checkpoint.import_run_id
-		           and current_dump.entity_type = checkpoint.entity_type
-		         where candidate_dump.import_run_id = candidate_run.id
-		           and current_dump.dump_id is distinct from candidate_dump.dump_id
-		    )
-		    and not exists (
-		        select 1
-		          from discogs_import_run_dump candidate_dump
-		          join discogs_import_checkpoint checkpoint
-		            on checkpoint.entity_type = candidate_dump.entity_type
-		          join discogs_import_run_dump failed_dump
-		            on failed_dump.entity_type = candidate_dump.entity_type
-		          join discogs_import_run failed_run
-		            on failed_run.id = failed_dump.import_run_id
-		         where candidate_dump.import_run_id = candidate_run.id
-		           and failed_run.status = 'failed'
-		           and (failed_run.completed_at > checkpoint.applied_at
-		                or (failed_run.completed_at = checkpoint.applied_at
-		                    and failed_run.id > checkpoint.import_run_id))
-		    )
-		  order by candidate_run.completed_at desc, candidate_run.id desc
-		  limit 1`,
+		query,
 		fingerprint,
-	).Scan(&runID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, nil
-	}
+	).Scan(
+		&exactRunID,
+		&compatibleEntityCount,
+		&selectedEntityCount,
+		&incompatibleEntityTypes,
+	)
 	if err != nil {
-		return 0, fmt.Errorf("find successful import manifest: %w", err)
+		return importCheckpointCompatibility{}, importContractRevisionQueryError(
+			"find successful import manifest",
+			err,
+		)
+	}
+	compatibility := importCheckpointCompatibility{
+		CompatibleEntityCount: compatibleEntityCount,
+		SelectedEntityCount:   selectedEntityCount,
+	}
+	if exactRunID.Valid {
+		compatibility.ExactRunID = exactRunID.Int64
+	}
+	if incompatibleEntityTypes != "" {
+		compatibility.IncompatibleEntityTypes = strings.Split(
+			incompatibleEntityTypes,
+			",",
+		)
+	}
+	return compatibility, nil
+}
+
+func consolidateSuccessfulImportRun(
+	ctx context.Context,
+	tx *sql.Tx,
+	fingerprint string,
+	processorVersion string,
+	expectedEntityCount int,
+) (int64, error) {
+	var runID int64
+	if err := tx.QueryRowContext(
+		ctx,
+		`insert into discogs_import_run
+		    (manifest_sha256, status, completed_at, force_requested,
+		     allow_downgrade_requested, processor, processor_version)
+		 values ($1, 'success', now(), false, false, $2, $3)
+		 returning id`,
+		fingerprint,
+		processorName,
+		processorVersion,
+	).Scan(&runID); err != nil {
+		return 0, fmt.Errorf("record consolidated successful import run: %w", err)
+	}
+	query := fmt.Sprintf(
+		`with candidate_run as (
+		    select candidate.id
+		      from discogs_import_run candidate
+		     where candidate.manifest_sha256 = $2
+		       and candidate.status = 'success'
+		       and candidate.id <> $1
+		     order by candidate.completed_at desc, candidate.id desc
+		     limit 1
+		), expected as (
+		    select candidate_dump.entity_type,
+		           candidate_dump.dump_id,
+		           %s as import_contract_revision
+		      from candidate_run
+		      join discogs_import_run_dump candidate_dump
+		        on candidate_dump.import_run_id = candidate_run.id
+		)
+		insert into discogs_import_run_dump
+		    (import_run_id, entity_type, dump_id, processed_items,
+		     last_progress_at, completed_at, chunk_size, total_items,
+		     total_chunks, import_contract_revision)
+		select $1, source.entity_type, source.dump_id, source.processed_items,
+		       source.last_progress_at, source.completed_at, source.chunk_size,
+		       source.total_items, source.total_chunks,
+		       expected.import_contract_revision
+		  from expected
+		  join discogs_import_checkpoint checkpoint
+		    on checkpoint.entity_type = expected.entity_type
+		  join discogs_import_run_dump source
+		    on source.import_run_id = checkpoint.import_run_id
+		   and source.entity_type = checkpoint.entity_type
+		   and source.dump_id = expected.dump_id
+		   and source.import_contract_revision = expected.import_contract_revision`,
+		importContractRevisionSQL("candidate_dump.entity_type"),
+	)
+	result, err := tx.ExecContext(
+		ctx,
+		query,
+		runID,
+		fingerprint,
+	)
+	if err != nil {
+		return 0, importContractRevisionQueryError(
+			"record consolidated successful import run dumps",
+			err,
+		)
+	}
+	recorded, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count consolidated successful import run dumps: %w", err)
+	}
+	if recorded != int64(expectedEntityCount) {
+		return 0, fmt.Errorf(
+			"record consolidated successful import run dumps: recorded %d of %d entities",
+			recorded,
+			expectedEntityCount,
+		)
 	}
 	return runID, nil
 }
@@ -489,8 +720,7 @@ func findResumableRun(
 	entityCount int,
 ) (int64, error) {
 	var runID int64
-	err := tx.QueryRowContext(
-		ctx,
+	query := fmt.Sprintf(
 		`select import_run.id
 		   from discogs_import_run import_run
 		  where import_run.manifest_sha256 = $1
@@ -501,6 +731,12 @@ func findResumableRun(
 		    and (select count(*)
 		           from discogs_import_run_dump run_dump
 		          where run_dump.import_run_id = import_run.id) = $4
+		    and not exists (
+		        select 1
+		          from discogs_import_run_dump run_dump
+		         where run_dump.import_run_id = import_run.id
+		           and run_dump.import_contract_revision is distinct from %s
+		    )
 		    and not exists (
 		        select 1
 		          from discogs_import_run_dump run_dump
@@ -541,13 +777,20 @@ func findResumableRun(
 		         where failed_dump.import_run_id = import_run.id
 		           and (current_dump.dump_id <> failed_dump.dump_id
 		                or current_run.processor <> import_run.processor
-		                or current_run.processor_version <> import_run.processor_version)
+		                or current_run.processor_version <> import_run.processor_version
+		                or current_dump.import_contract_revision <>
+		                   failed_dump.import_contract_revision)
 		           and (checkpoint.applied_at > import_run.completed_at
 		                or (checkpoint.applied_at = import_run.completed_at
 		                    and checkpoint.import_run_id > import_run.id))
 		    )
 		  order by import_run.completed_at desc, import_run.id desc
 		  limit 1`,
+		importContractRevisionSQL("run_dump.entity_type"),
+	)
+	err := tx.QueryRowContext(
+		ctx,
+		query,
 		fingerprint,
 		processorName,
 		processorVersion,
@@ -558,7 +801,10 @@ func findResumableRun(
 		return 0, nil
 	}
 	if err != nil {
-		return 0, fmt.Errorf("find resumable import run: %w", err)
+		return 0, importContractRevisionQueryError(
+			"find resumable import run",
+			err,
+		)
 	}
 	return runID, nil
 }
@@ -661,10 +907,12 @@ func pruneSupersededFailedProgress(ctx context.Context, tx *sql.Tx) error {
 		               left join discogs_import_run_dump current_dump
 		                 on current_dump.import_run_id = checkpoint.import_run_id
 		                and current_dump.entity_type = checkpoint.entity_type
-		              where failed_dump.import_run_id = failed_run.id
-		                and (current_dump.dump_id is distinct from failed_dump.dump_id
-		                     or current_run.processor is distinct from failed_run.processor
-		                     or current_run.processor_version is distinct from failed_run.processor_version)
+			              where failed_dump.import_run_id = failed_run.id
+			                and (current_dump.dump_id is distinct from failed_dump.dump_id
+			                     or current_run.processor is distinct from failed_run.processor
+			                     or current_run.processor_version is distinct from failed_run.processor_version
+			                     or current_dump.import_contract_revision is distinct from
+			                        failed_dump.import_contract_revision)
 		         )
 		  )`,
 	); err != nil {
@@ -716,6 +964,34 @@ func findOrInsertDump(
 	return dumpID, nil
 }
 
+func insertImportRunDump(
+	ctx context.Context,
+	tx *sql.Tx,
+	runID int64,
+	entityType string,
+	dumpID int64,
+	chunkSize int,
+	revision importContractRevision,
+) error {
+	if _, err := tx.ExecContext(
+		ctx,
+		`insert into discogs_import_run_dump
+		    (import_run_id, entity_type, dump_id, chunk_size, import_contract_revision)
+		 values ($1, $2, $3, $4, $5)`,
+		runID,
+		entityType,
+		dumpID,
+		chunkSize,
+		revision,
+	); err != nil {
+		return importContractRevisionQueryError(
+			"record import run dump "+entityType,
+			err,
+		)
+	}
+	return nil
+}
+
 func insertImportRun(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -734,7 +1010,8 @@ func insertImportRun(
 		ctx,
 		`insert into discogs_import_run
 		    (manifest_sha256, status, force_requested,
-		     allow_downgrade_requested, processor, processor_version, resumed_from_run_id)
+		     allow_downgrade_requested, processor, processor_version,
+		     resumed_from_run_id)
 		 values ($1, 'running', $2, $3, $4, $5, $6)
 		 returning id`,
 		fingerprint,
@@ -745,7 +1022,21 @@ func insertImportRun(
 		resumedFrom,
 	).Scan(&runID)
 	if err != nil {
-		return 0, fmt.Errorf("start import run: %w", err)
+		return 0, importContractRevisionQueryError("start import run", err)
 	}
 	return runID, nil
+}
+
+func importContractRevisionQueryError(operation string, err error) error {
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) && postgresError.Code == undefinedColumnSQLState {
+		return fmt.Errorf(
+			"%s: %s is unavailable; apply canonical model migration %s: %w",
+			operation,
+			importContractRevisionColumnReference,
+			importContractRevisionMigration,
+			err,
+		)
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }

--- a/src/batch/execution_contract_revision_test.go
+++ b/src/batch/execution_contract_revision_test.go
@@ -1,0 +1,430 @@
+package batch
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportContractRevisionDefinition(t *testing.T) {
+	revisions, err := resolveImportContractRevisions([]string{
+		artistEntityType,
+		labelEntityType,
+		masterEntityType,
+		releaseEntityType,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []importContractRevision{1, 1, 1, 2}, revisions)
+	require.Equal(
+		t,
+		"case relation.entity_type when 'artist' then 1 when 'label' then 1 when 'master' then 1 when 'release' then 2 end",
+		importContractRevisionSQL("relation.entity_type"),
+	)
+
+	_, err = resolveImportContractRevisions([]string{"unknown"})
+	require.ErrorContains(t, err, "unavailable for entity unknown")
+}
+
+func TestMustImportContractRevisionRejectsUnknownEntity(t *testing.T) {
+	require.Panics(t, func() {
+		mustImportContractRevision("unknown")
+	})
+}
+
+func TestFindSuccessfulRunContractCompatibility(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		row  *sqlmock.Rows
+		want importCheckpointCompatibility
+	}{
+		{
+			name: "exact current manifest",
+			row: sqlmock.NewRows([]string{
+				"exact_run_id",
+				"compatible_count",
+				"selected_count",
+				"incompatible_entities",
+			}).AddRow(11, 4, 4, ""),
+			want: importCheckpointCompatibility{
+				ExactRunID:            11,
+				CompatibleEntityCount: 4,
+				SelectedEntityCount:   4,
+			},
+		},
+		{
+			name: "mixed manifest requires only release",
+			row: sqlmock.NewRows([]string{
+				"exact_run_id",
+				"compatible_count",
+				"selected_count",
+				"incompatible_entities",
+			}).AddRow(nil, 3, 4, releaseEntityType),
+			want: importCheckpointCompatibility{
+				CompatibleEntityCount:   3,
+				SelectedEntityCount:     4,
+				IncompatibleEntityTypes: []string{releaseEntityType},
+			},
+		},
+		{
+			name: "no successful candidate",
+			row: sqlmock.NewRows([]string{
+				"exact_run_id",
+				"compatible_count",
+				"selected_count",
+				"incompatible_entities",
+			}).AddRow(nil, 0, 0, ""),
+			want: importCheckpointCompatibility{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			mock.ExpectQuery("select candidate.id").
+				WithArgs("fingerprint").
+				WillReturnRows(test.row)
+
+			actual, err := findSuccessfulRun(ctx, tx, "fingerprint")
+			require.NoError(t, err)
+			require.Equal(t, test.want, actual)
+		})
+	}
+}
+
+func TestFindResumableRunUsesEntityContractRevisions(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name string
+		rows *sqlmock.Rows
+		want int64
+	}{
+		{
+			name: "current revisions",
+			rows: sqlmock.NewRows([]string{"id"}).AddRow(12),
+			want: 12,
+		},
+		{
+			name: "no compatible run",
+			rows: sqlmock.NewRows([]string{"id"}),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			mock.ExpectQuery(regexp.QuoteMeta(
+				"run_dump.import_contract_revision is distinct from case run_dump.entity_type",
+			)).WithArgs(
+				"fingerprint",
+				processorName,
+				"version",
+				4,
+				5,
+			).WillReturnRows(test.rows)
+
+			runID, err := findResumableRun(ctx, tx, "fingerprint", "version", 5, 4)
+			require.NoError(t, err)
+			require.Equal(t, test.want, runID)
+		})
+	}
+}
+
+func TestConsolidateSuccessfulImportRun(t *testing.T) {
+	ctx := context.Background()
+	mock, tx := newMockTransaction(t)
+	mock.ExpectQuery("insert into discogs_import_run").WithArgs(
+		"fingerprint",
+		processorName,
+		"version",
+	).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(13))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"total_chunks, import_contract_revision)",
+	)).WithArgs(
+		int64(13),
+		"fingerprint",
+	).WillReturnResult(sqlmock.NewResult(0, 4))
+
+	runID, err := consolidateSuccessfulImportRun(
+		ctx,
+		tx,
+		"fingerprint",
+		"version",
+		4,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(13), runID)
+}
+
+func TestImportContractRevisionErrorBoundaries(t *testing.T) {
+	ctx := context.Background()
+	expected := errors.New("fixture")
+	missingColumn := &pgconn.PgError{
+		Code:    undefinedColumnSQLState,
+		Message: "column import_contract_revision does not exist",
+	}
+
+	t.Run("successful lookup missing V009", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("select candidate.id").
+			WithArgs("fingerprint").
+			WillReturnError(missingColumn)
+
+		_, err := findSuccessfulRun(ctx, tx, "fingerprint")
+		require.ErrorIs(t, err, missingColumn)
+		require.ErrorContains(t, err, importContractRevisionColumnReference)
+		require.ErrorContains(t, err, importContractRevisionMigration)
+	})
+
+	t.Run("resumable lookup", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("select import_run.id").WithArgs(
+			"fingerprint",
+			processorName,
+			"version",
+			1,
+			5,
+		).WillReturnError(expected)
+
+		_, err := findResumableRun(ctx, tx, "fingerprint", "version", 5, 1)
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "find resumable import run")
+	})
+
+	t.Run("consolidated run insert", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("insert into discogs_import_run").WithArgs(
+			"fingerprint",
+			processorName,
+			"version",
+		).WillReturnError(expected)
+
+		_, err := consolidateSuccessfulImportRun(
+			ctx,
+			tx,
+			"fingerprint",
+			"version",
+			1,
+		)
+		require.ErrorIs(t, err, expected)
+		require.ErrorContains(t, err, "record consolidated successful import run")
+	})
+
+	for _, test := range []struct {
+		name   string
+		result sql.Result
+		want   string
+	}{
+		{
+			name:   "consolidated run dump count",
+			result: sqlmock.NewErrorResult(expected),
+			want:   "count consolidated successful import run dumps",
+		},
+		{
+			name:   "consolidated run dump mismatch",
+			result: sqlmock.NewResult(0, 0),
+			want:   "recorded 0 of 1 entities",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			mock.ExpectQuery("insert into discogs_import_run").WithArgs(
+				"fingerprint",
+				processorName,
+				"version",
+			).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(13))
+			mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(
+				int64(13),
+				"fingerprint",
+			).WillReturnResult(test.result)
+
+			_, err := consolidateSuccessfulImportRun(
+				ctx,
+				tx,
+				"fingerprint",
+				"version",
+				1,
+			)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+
+	t.Run("consolidated run dump missing V009", func(t *testing.T) {
+		mock, tx := newMockTransaction(t)
+		mock.ExpectQuery("insert into discogs_import_run").WithArgs(
+			"fingerprint",
+			processorName,
+			"version",
+		).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(13))
+		mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(
+			int64(13),
+			"fingerprint",
+		).WillReturnError(missingColumn)
+
+		_, err := consolidateSuccessfulImportRun(
+			ctx,
+			tx,
+			"fingerprint",
+			"version",
+			1,
+		)
+		require.ErrorIs(t, err, missingColumn)
+		require.ErrorContains(t, err, importContractRevisionColumnReference)
+	})
+
+	actual := importContractRevisionQueryError("test operation", expected)
+	require.ErrorIs(t, actual, expected)
+	require.ErrorContains(t, actual, "test operation")
+}
+
+func TestInsertImportRunDoesNotUseProcessorRevision(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		resumedFromID int64
+		resumedFrom   sql.NullInt64
+	}{
+		{name: "new run"},
+		{
+			name:          "resumed run",
+			resumedFromID: 7,
+			resumedFrom:   sql.NullInt64{Int64: 7, Valid: true},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			mock.ExpectQuery("insert into discogs_import_run").WithArgs(
+				"fingerprint",
+				true,
+				true,
+				processorName,
+				"version",
+				test.resumedFrom,
+			).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(14))
+
+			runID, err := insertImportRun(
+				context.Background(),
+				tx,
+				"fingerprint",
+				true,
+				true,
+				"version",
+				test.resumedFromID,
+			)
+			require.NoError(t, err)
+			require.Equal(t, int64(14), runID)
+		})
+	}
+
+	expected := errors.New("fixture")
+	mock, tx := newMockTransaction(t)
+	mock.ExpectQuery("insert into discogs_import_run").WithArgs(
+		"fingerprint",
+		false,
+		false,
+		processorName,
+		"version",
+		sql.NullInt64{},
+	).WillReturnError(expected)
+	_, err := insertImportRun(
+		context.Background(),
+		tx,
+		"fingerprint",
+		false,
+		false,
+		"version",
+		0,
+	)
+	require.ErrorIs(t, err, expected)
+}
+
+func TestInsertImportRunDumpStoresEntityRevision(t *testing.T) {
+	ctx := context.Background()
+	for entityType, revision := range currentImportContractRevisions {
+		t.Run(entityType, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(
+				int64(11),
+				entityType,
+				int64(12),
+				5,
+				revision,
+			).WillReturnResult(sqlmock.NewResult(0, 1))
+
+			require.NoError(t, insertImportRunDump(
+				ctx,
+				tx,
+				11,
+				entityType,
+				12,
+				5,
+				revision,
+			))
+		})
+	}
+
+	missingColumn := &pgconn.PgError{
+		Code:    undefinedColumnSQLState,
+		Message: "column import_contract_revision does not exist",
+	}
+	mock, tx := newMockTransaction(t)
+	mock.ExpectExec("insert into discogs_import_run_dump").WithArgs(
+		int64(11),
+		releaseEntityType,
+		int64(12),
+		5,
+		currentImportContractRevisions[releaseEntityType],
+	).WillReturnError(missingColumn)
+
+	err := insertImportRunDump(
+		ctx,
+		tx,
+		11,
+		releaseEntityType,
+		12,
+		5,
+		currentImportContractRevisions[releaseEntityType],
+	)
+	require.ErrorIs(t, err, missingColumn)
+	require.ErrorContains(t, err, importContractRevisionColumnReference)
+}
+
+func TestPruneSupersededProgressUsesEntityContractRevision(t *testing.T) {
+	expected := errors.New("fixture")
+	for _, test := range []struct {
+		name    string
+		result  sql.Result
+		execErr error
+	}{
+		{
+			name:   "success",
+			result: sqlmock.NewResult(0, 1),
+		},
+		{
+			name:    "query failure",
+			execErr: expected,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock, tx := newMockTransaction(t)
+			expectation := mock.ExpectExec(regexp.QuoteMeta(
+				"current_dump.import_contract_revision is distinct from",
+			))
+			if test.execErr != nil {
+				expectation.WillReturnError(test.execErr)
+			} else {
+				expectation.WillReturnResult(test.result)
+			}
+
+			err := pruneSupersededFailedProgress(context.Background(), tx)
+			if test.execErr != nil {
+				require.ErrorIs(t, err, expected)
+				require.ErrorContains(t, err, "prune superseded failed import progress")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/batch/execution_test.go
+++ b/src/batch/execution_test.go
@@ -24,6 +24,7 @@ func TestImportExecutionCoordinator(t *testing.T) {
 	db, err := database.GetConnect(testutils.GetDsn(testutils.Postgres, pg))
 	require.NoError(t, err)
 	require.NoError(t, RunDDL(db))
+	installImportContractRevisionFixture(t, db)
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -57,6 +58,447 @@ func TestImportExecutionCoordinator(t *testing.T) {
 			require.NoError(t, completeEntityProgress(order, 0, 0))
 		}
 	}
+
+	t.Run("reprocesses successful runs from an older contract revision", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump(releaseEntityType, "2026-07-01", "0"),
+		}
+
+		legacy := NewImportExecutionCoordinator(sqlDB, "old-go-version")
+		legacyPreparation, err := legacy.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, legacyPreparation, dumps)
+		require.NoError(t, legacy.Complete(ctx, nil))
+		setImportContractRevision(
+			t,
+			db,
+			legacyPreparation.RunID,
+			legacyImportContractRevision,
+		)
+
+		current := NewImportExecutionCoordinator(sqlDB, "new-go-version")
+		currentPreparation, err := current.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.False(t, currentPreparation.Skipped)
+		require.Zero(t, currentPreparation.ResumedFromRunID)
+		requireImportContractRevision(
+			t,
+			db,
+			currentPreparation.RunID,
+			currentImportContractRevisions[releaseEntityType],
+		)
+		complete(t, currentPreparation, dumps)
+		require.NoError(t, current.Complete(ctx, nil))
+
+		repeated := NewImportExecutionCoordinator(sqlDB, "another-go-version")
+		repeatedPreparation, err := repeated.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.True(t, repeatedPreparation.Skipped)
+		require.Equal(t, currentPreparation.RunID, repeatedPreparation.RunID)
+	})
+
+	t.Run("narrows a mixed outdated manifest to release and preserves valid checkpoints", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump(artistEntityType, "2026-07-01", "1"),
+			importDump(labelEntityType, "2026-07-01", "2"),
+			importDump(masterEntityType, "2026-07-01", "3"),
+			importDump(releaseEntityType, "2026-07-01", "4"),
+		}
+		legacy := NewImportExecutionCoordinator(sqlDB, "legacy")
+		legacyPreparation, err := legacy.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, legacyPreparation, dumps)
+		require.NoError(t, legacy.Complete(ctx, nil))
+		setImportContractRevision(
+			t,
+			db,
+			legacyPreparation.RunID,
+			legacyImportContractRevision,
+		)
+		checkpointRunIDs := importCheckpointRunIDs(t, db)
+
+		mixed := NewImportExecutionCoordinator(sqlDB, "current")
+		_, err = mixed.Prepare(ctx, dumps, testChunkSize, false, false)
+		require.ErrorContains(t, err, "rerun only --entities release")
+		require.Equal(t, checkpointRunIDs, importCheckpointRunIDs(t, db))
+
+		releaseOnly := NewImportExecutionCoordinator(sqlDB, "current")
+		releasePreparation, err := releaseOnly.Prepare(
+			ctx,
+			dumps[3:],
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.False(t, releasePreparation.Skipped)
+		requireImportContractRevision(
+			t,
+			db,
+			releasePreparation.RunID,
+			currentImportContractRevisions[releaseEntityType],
+		)
+		complete(t, releasePreparation, dumps[3:])
+		require.NoError(t, releaseOnly.Complete(ctx, nil))
+
+		currentCheckpointRunIDs := importCheckpointRunIDs(t, db)
+		for _, entityType := range []string{
+			artistEntityType,
+			labelEntityType,
+			masterEntityType,
+		} {
+			require.Equal(
+				t,
+				checkpointRunIDs[entityType],
+				currentCheckpointRunIDs[entityType],
+			)
+		}
+		require.Equal(
+			t,
+			releasePreparation.RunID,
+			currentCheckpointRunIDs[releaseEntityType],
+		)
+
+		consolidated := NewImportExecutionCoordinator(sqlDB, "current")
+		consolidatedPreparation, err := consolidated.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.True(t, consolidatedPreparation.Skipped)
+		require.NotEqual(t, legacyPreparation.RunID, consolidatedPreparation.RunID)
+		requireRunDumpContractRevisions(
+			t,
+			db,
+			consolidatedPreparation.RunID,
+			currentImportContractRevisions,
+		)
+	})
+
+	t.Run("shares successful current-revision runs across processors", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("label", "2026-07-01", "0"),
+		}
+		javaRun := NewImportExecutionCoordinator(sqlDB, "go-fixture")
+		javaPreparation, err := javaRun.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, javaPreparation, dumps)
+		require.NoError(t, javaRun.Complete(ctx, nil))
+		require.NoError(t, db.Exec(
+			`update public.discogs_import_run
+			    set processor = ?, processor_version = ?
+			  where id = ?`,
+			"open-discogs-batch",
+			"java-fixture",
+			javaPreparation.RunID,
+		).Error)
+
+		goRun := NewImportExecutionCoordinator(sqlDB, "go-fixture")
+		goPreparation, err := goRun.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.True(t, goPreparation.Skipped)
+		require.Equal(t, javaPreparation.RunID, goPreparation.RunID)
+	})
+
+	t.Run("dirties current success after a failed older-revision attempt", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("release", "2026-07-01", "0"),
+		}
+		successful := NewImportExecutionCoordinator(sqlDB, "test")
+		successfulPreparation, err := successful.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, successfulPreparation, dumps)
+		require.NoError(t, successful.Complete(ctx, nil))
+
+		legacyFailure := NewImportExecutionCoordinator(sqlDB, "test")
+		legacyFailurePreparation, err := legacyFailure.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			true,
+			false,
+		)
+		require.NoError(t, err)
+		setImportContractRevision(
+			t,
+			db,
+			legacyFailurePreparation.RunID,
+			legacyImportContractRevision,
+		)
+		require.NoError(t, legacyFailure.Complete(ctx, errors.New("fixture failure")))
+
+		repeated := NewImportExecutionCoordinator(sqlDB, "test")
+		repeatedPreparation, err := repeated.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.False(t, repeatedPreparation.Skipped)
+		require.NotEqual(t, successfulPreparation.RunID, repeatedPreparation.RunID)
+		require.NoError(t, repeated.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("resumes abandoned and failed runs only at the current revision", func(t *testing.T) {
+		for _, test := range []struct {
+			name       string
+			revision   importContractRevision
+			abandoned  bool
+			wantResume bool
+		}{
+			{
+				name:       "current failed",
+				revision:   currentImportContractRevisions[masterEntityType],
+				wantResume: true,
+			},
+			{
+				name:      "incompatible failed",
+				revision:  incompatibleImportContractRevision,
+				abandoned: false,
+			},
+			{
+				name:       "current abandoned",
+				revision:   currentImportContractRevisions[masterEntityType],
+				abandoned:  true,
+				wantResume: true,
+			},
+			{
+				name:      "incompatible abandoned",
+				revision:  incompatibleImportContractRevision,
+				abandoned: true,
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				reset(t)
+				dumps := []*opendiscogsmodel.DiscogsDump{
+					importDump("master", "2026-07-01", "0"),
+				}
+				previous := NewImportExecutionCoordinator(sqlDB, "same-version")
+				previousPreparation, err := previous.Prepare(
+					ctx,
+					dumps,
+					testChunkSize,
+					false,
+					false,
+				)
+				require.NoError(t, err)
+				setImportContractRevision(
+					t,
+					db,
+					previousPreparation.RunID,
+					test.revision,
+				)
+				if test.abandoned {
+					previous.release(ctx)
+				} else {
+					require.NoError(t, previous.Complete(ctx, errors.New("fixture failure")))
+				}
+
+				retry := NewImportExecutionCoordinator(sqlDB, "same-version")
+				retryPreparation, err := retry.Prepare(
+					ctx,
+					dumps,
+					testChunkSize,
+					false,
+					false,
+				)
+				require.NoError(t, err)
+				if test.wantResume {
+					require.Equal(
+						t,
+						previousPreparation.RunID,
+						retryPreparation.ResumedFromRunID,
+					)
+				} else {
+					require.Zero(t, retryPreparation.ResumedFromRunID)
+				}
+				requireImportContractRevision(
+					t,
+					db,
+					retryPreparation.RunID,
+					currentImportContractRevisions[masterEntityType],
+				)
+				require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
+
+				var previousStatus string
+				require.NoError(t, db.Raw(
+					"select status from public.discogs_import_run where id = ?",
+					previousPreparation.RunID,
+				).Scan(&previousStatus).Error)
+				require.Equal(t, "failed", previousStatus)
+			})
+		}
+	})
+
+	t.Run("does not resume across a newer checkpoint from another revision", func(t *testing.T) {
+		reset(t)
+		dumps := []*opendiscogsmodel.DiscogsDump{
+			importDump("master", "2026-07-01", "0"),
+		}
+		failed := NewImportExecutionCoordinator(sqlDB, "same-version")
+		failedPreparation, err := failed.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.NoError(t, failed.Complete(ctx, errors.New("fixture failure")))
+
+		legacyCheckpoint := NewImportExecutionCoordinator(sqlDB, "same-version")
+		legacyCheckpointPreparation, err := legacyCheckpoint.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			true,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, legacyCheckpointPreparation, dumps)
+		require.NoError(t, legacyCheckpoint.Complete(ctx, nil))
+		setImportContractRevision(
+			t,
+			db,
+			legacyCheckpointPreparation.RunID,
+			incompatibleImportContractRevision,
+		)
+
+		retry := NewImportExecutionCoordinator(sqlDB, "same-version")
+		retryPreparation, err := retry.Prepare(
+			ctx,
+			dumps,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		require.False(t, retryPreparation.Skipped)
+		require.Zero(t, retryPreparation.ResumedFromRunID)
+		require.NotEqual(t, failedPreparation.RunID, retryPreparation.RunID)
+		require.NoError(t, retry.Complete(ctx, errors.New("fixture cleanup")))
+	})
+
+	t.Run("keeps force and downgrade authorization independent from revision", func(t *testing.T) {
+		reset(t)
+		julyDump := []*opendiscogsmodel.DiscogsDump{
+			importDump(releaseEntityType, "2026-07-01", "0"),
+		}
+		july := NewImportExecutionCoordinator(sqlDB, "test")
+		julyPreparation, err := july.Prepare(
+			ctx,
+			julyDump,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, julyPreparation, julyDump)
+		require.NoError(t, july.Complete(ctx, nil))
+		setImportContractRevision(
+			t,
+			db,
+			julyPreparation.RunID,
+			legacyImportContractRevision,
+		)
+
+		augustDump := []*opendiscogsmodel.DiscogsDump{
+			importDump(releaseEntityType, "2026-08-01", "1"),
+		}
+		august := NewImportExecutionCoordinator(sqlDB, "test")
+		augustPreparation, err := august.Prepare(
+			ctx,
+			augustDump,
+			testChunkSize,
+			false,
+			false,
+		)
+		require.NoError(t, err)
+		complete(t, augustPreparation, augustDump)
+		require.NoError(t, august.Complete(ctx, nil))
+
+		for _, force := range []bool{false, true} {
+			blocked := NewImportExecutionCoordinator(sqlDB, "test")
+			_, err = blocked.Prepare(
+				ctx,
+				julyDump,
+				testChunkSize,
+				force,
+				false,
+			)
+			require.ErrorContains(t, err, "predates checkpoint")
+		}
+
+		authorized := NewImportExecutionCoordinator(sqlDB, "test")
+		authorizedPreparation, err := authorized.Prepare(
+			ctx,
+			julyDump,
+			testChunkSize,
+			false,
+			true,
+		)
+		require.NoError(t, err)
+		require.False(t, authorizedPreparation.Skipped)
+		require.Zero(t, authorizedPreparation.ResumedFromRunID)
+		requireImportContractRevision(
+			t,
+			db,
+			authorizedPreparation.RunID,
+			currentImportContractRevisions[releaseEntityType],
+		)
+		require.NoError(t, authorized.Complete(ctx, errors.New("fixture cleanup")))
+	})
 
 	t.Run("skips a successful manifest unless forced", func(t *testing.T) {
 		reset(t)
@@ -867,5 +1309,96 @@ func importDump(entityType, date, checksumSeed string) *opendiscogsmodel.Discogs
 		ChecksumSHA256: checksum,
 		SizeBytes:      1,
 		URI:            fmt.Sprintf("data/%s/%s.xml.gz", date, entityType),
+	}
+}
+
+const (
+	legacyImportContractRevision       = importContractRevision(1)
+	incompatibleImportContractRevision = importContractRevision(99)
+)
+
+func installImportContractRevisionFixture(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		alter table public.discogs_import_run_dump
+		add column if not exists import_contract_revision integer not null default 1
+		check (import_contract_revision > 0);
+		alter table public.discogs_import_run_dump
+		alter column import_contract_revision drop default`).Error)
+}
+
+func setImportContractRevision(
+	t *testing.T,
+	db *gorm.DB,
+	runID int64,
+	revision importContractRevision,
+) {
+	t.Helper()
+	result := db.Exec(
+		`update public.discogs_import_run_dump
+		    set import_contract_revision = ?
+		  where import_run_id = ?`,
+		revision,
+		runID,
+	)
+	require.NoError(t, result.Error)
+	require.Positive(t, result.RowsAffected)
+}
+
+func requireImportContractRevision(
+	t *testing.T,
+	db *gorm.DB,
+	runID int64,
+	want importContractRevision,
+) {
+	t.Helper()
+	var actual importContractRevision
+	require.NoError(t, db.Raw(
+		`select import_contract_revision
+		   from public.discogs_import_run_dump
+		  where import_run_id = ?`,
+		runID,
+	).Scan(&actual).Error)
+	require.Equal(t, want, actual)
+}
+
+func importCheckpointRunIDs(t *testing.T, db *gorm.DB) map[string]int64 {
+	t.Helper()
+	type checkpoint struct {
+		EntityType  string
+		ImportRunID int64
+	}
+	var checkpoints []checkpoint
+	require.NoError(t, db.Raw(`
+		select entity_type, import_run_id
+		  from public.discogs_import_checkpoint
+		 order by entity_type`).Scan(&checkpoints).Error)
+	runIDs := make(map[string]int64, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		runIDs[checkpoint.EntityType] = checkpoint.ImportRunID
+	}
+	return runIDs
+}
+
+func requireRunDumpContractRevisions(
+	t *testing.T,
+	db *gorm.DB,
+	runID int64,
+	want map[string]importContractRevision,
+) {
+	t.Helper()
+	type runDumpRevision struct {
+		EntityType             string
+		ImportContractRevision importContractRevision
+	}
+	var revisions []runDumpRevision
+	require.NoError(t, db.Raw(`
+		select entity_type, import_contract_revision
+		  from public.discogs_import_run_dump
+		 where import_run_id = ?
+		 order by entity_type`, runID).Scan(&revisions).Error)
+	require.Len(t, revisions, len(want))
+	for _, revision := range revisions {
+		require.Equal(t, want[revision.EntityType], revision.ImportContractRevision)
 	}
 }

--- a/src/batch/extract.go
+++ b/src/batch/extract.go
@@ -48,11 +48,7 @@ func ExtractClause(item any) clause.OnConflict {
 			},
 		)
 	case *model.LabelReleaseItem:
-		return updateWhenChanged(
-			"label_release_item",
-			[]string{"release_item_id", "label_id"},
-			[]string{"category_notation"},
-		)
+		return doNothing("release_item_id", "label_id", "category_notation")
 	case *model.ReleaseItemFormat:
 		return updateWhenChanged(
 			"release_item_format",

--- a/src/batch/legacy_migration.go
+++ b/src/batch/legacy_migration.go
@@ -1,0 +1,320 @@
+package batch
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	opendiscogsschema "github.com/dsub-io/open-discogs-model/schema"
+	"gorm.io/gorm"
+)
+
+const (
+	liquibaseLockTable          = "databasechangeloglock"
+	liquibaseChangeLogTable     = "databasechangelog"
+	liquibaseLockID             = 1
+	liquibaseMigrationLockOwner = "go-open-discogs-batch canonical migrator"
+	legacyChangeSetIDPrefix     = "open-discogs-model-v"
+	postgresqlVersionMajorScale = 10_000
+)
+
+var liquibaseChecksumPattern = regexp.MustCompile(`^9:[0-9a-f]{32}$`)
+
+var (
+	loadLegacyLiquibaseCompatibility = opendiscogsschema.LegacyLiquibaseCompatibility
+	loadLegacyLiquibaseContract      = opendiscogsschema.LegacyLiquibaseContract
+)
+
+type liquibaseMigrationLock struct {
+	db       *gorm.DB
+	schema   database.Schema
+	acquired bool
+}
+
+type legacyLiquibaseRow struct {
+	ID            string
+	Author        string
+	Filename      string
+	ExecutionType string
+	Checksum      string
+}
+
+func acquireLiquibaseMigrationLock(
+	db *gorm.DB,
+	schema database.Schema,
+) (*liquibaseMigrationLock, error) {
+	lock := &liquibaseMigrationLock{db: db, schema: schema}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(fmt.Sprintf(`
+			create table if not exists %s
+			(
+			    id          integer not null primary key,
+			    locked      boolean not null,
+			    lockgranted timestamp,
+			    lockedby    varchar(255)
+			)`, schema.Qualify(liquibaseLockTable))).Error; err != nil {
+			return fmt.Errorf("create Liquibase migration lock table: %w", err)
+		}
+		if err := tx.Exec(
+			"insert into "+schema.Qualify(liquibaseLockTable)+
+				" (id, locked) values (?, false) on conflict (id) do nothing",
+			liquibaseLockID,
+		).Error; err != nil {
+			return fmt.Errorf("initialize Liquibase migration lock: %w", err)
+		}
+		var locked bool
+		result := tx.Raw(
+			"select locked from "+schema.Qualify(liquibaseLockTable)+
+				" where id = ? for update nowait",
+			liquibaseLockID,
+		).Scan(&locked)
+		if result.Error != nil {
+			return fmt.Errorf("reserve Liquibase migration lock: %w", result.Error)
+		}
+		if result.RowsAffected != 1 {
+			return fmt.Errorf("Liquibase migration lock row %d is missing", liquibaseLockID)
+		}
+		if locked {
+			return fmt.Errorf(
+				"Liquibase migration lock is already held in schema %s; stop the other migrator or verify and clear a stale lock",
+				schema.Name(),
+			)
+		}
+		result = tx.Exec(
+			"update "+schema.Qualify(liquibaseLockTable)+
+				" set locked = true, lockgranted = now(), lockedby = ? where id = ? and not locked",
+			liquibaseMigrationLockOwner,
+			liquibaseLockID,
+		)
+		if result.Error != nil {
+			return fmt.Errorf("acquire Liquibase migration lock: %w", result.Error)
+		}
+		if result.RowsAffected != 1 {
+			return fmt.Errorf("Liquibase migration lock changed while being acquired")
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	lock.acquired = true
+	return lock, nil
+}
+
+func (lock *liquibaseMigrationLock) release() error {
+	if lock == nil || !lock.acquired {
+		return nil
+	}
+	result := lock.db.Exec(
+		"update "+lock.schema.Qualify(liquibaseLockTable)+
+			" set locked = false, lockgranted = null, lockedby = null where id = ? and locked and lockedby = ?",
+		liquibaseLockID,
+		liquibaseMigrationLockOwner,
+	)
+	if result.Error != nil {
+		return fmt.Errorf("release Liquibase migration lock: %w", result.Error)
+	}
+	if result.RowsAffected != 1 {
+		return fmt.Errorf("Liquibase migration lock ownership changed before release")
+	}
+	lock.acquired = false
+	return nil
+}
+
+func adoptLegacyLiquibaseHistory(
+	db *gorm.DB,
+	schema database.Schema,
+	canonical []canonicalMigration,
+) error {
+	manifest, err := loadLegacyLiquibaseCompatibility()
+	if err != nil {
+		return fmt.Errorf("load legacy Liquibase compatibility contract: %w", err)
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(
+			"lock table " + schema.Qualify(migrationTable) + " in exclusive mode",
+		).Error; err != nil {
+			return fmt.Errorf("lock shared migration ledger for legacy adoption: %w", err)
+		}
+
+		var ledgerCount int64
+		if err := tx.Raw(
+			"select count(*) from " + schema.Qualify(migrationTable),
+		).Scan(&ledgerCount).Error; err != nil {
+			return fmt.Errorf("count shared migration ledger: %w", err)
+		}
+		rows, err := readLegacyLiquibaseRows(tx, schema)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		if ledgerCount > 0 {
+			if ledgerCount < int64(len(rows)) {
+				return fmt.Errorf(
+					"shared migration ledger has %d rows but legacy Liquibase history has %d; refusing partial adoption",
+					ledgerCount,
+					len(rows),
+				)
+			}
+			return nil
+		}
+
+		legacyMigrations, requiresSchemaProof, err := validateLegacyLiquibaseRows(
+			manifest,
+			schema,
+			canonical,
+			rows,
+		)
+		if err != nil {
+			return err
+		}
+		if requiresSchemaProof {
+			if err := verifyLegacySchemaContract(tx, schema, manifest, len(rows)); err != nil {
+				return err
+			}
+		}
+		for _, migration := range legacyMigrations {
+			if err := tx.Exec(
+				"insert into "+schema.Qualify(migrationTable)+" (version, checksum) values (?, ?)",
+				migration.CanonicalFilename,
+				migration.CanonicalSHA256,
+			).Error; err != nil {
+				return fmt.Errorf("adopt legacy migration %s: %w", migration.Version, err)
+			}
+		}
+		return nil
+	})
+}
+
+func readLegacyLiquibaseRows(
+	tx *gorm.DB,
+	schema database.Schema,
+) ([]legacyLiquibaseRow, error) {
+	var exists bool
+	if err := tx.Raw(
+		"select exists(select 1 from information_schema.tables where table_schema = ? and table_name = ?)",
+		schema.Name(),
+		liquibaseChangeLogTable,
+	).Scan(&exists).Error; err != nil {
+		return nil, fmt.Errorf("inspect legacy Liquibase history: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+	var rows []legacyLiquibaseRow
+	result := tx.Raw(
+		`select id, author, filename, exectype as execution_type, md5sum as checksum
+		   from `+schema.Qualify(liquibaseChangeLogTable)+`
+		  where id like ?
+		  order by id, author, filename`,
+		legacyChangeSetIDPrefix+"%",
+	).Scan(&rows)
+	if result.Error != nil {
+		return nil, fmt.Errorf("read legacy Liquibase history: %w", result.Error)
+	}
+	return rows, nil
+}
+
+func validateLegacyLiquibaseRows(
+	manifest opendiscogsschema.LegacyLiquibaseManifest,
+	schema database.Schema,
+	canonical []canonicalMigration,
+	rows []legacyLiquibaseRow,
+) ([]opendiscogsschema.LegacyLiquibaseMigration, bool, error) {
+	prefix, found := manifest.SchemaContract(fmt.Sprintf("V%03d", len(rows)))
+	if !found {
+		return nil, false, fmt.Errorf("legacy Liquibase history length %d is not a supported release prefix", len(rows))
+	}
+	if len(rows) > len(canonical) || len(prefix.MigrationVersions) != len(rows) {
+		return nil, false, fmt.Errorf("legacy Liquibase history is not a canonical artifact prefix")
+	}
+	wantedMode := opendiscogsschema.LegacySchemaModeCustom
+	if schema.Name() == database.DefaultSchemaName {
+		wantedMode = opendiscogsschema.LegacySchemaModePublic
+	}
+	requiresSchemaProof := false
+	validated := make([]opendiscogsschema.LegacyLiquibaseMigration, 0, len(rows))
+	for index, row := range rows {
+		migration := manifest.Migrations[index]
+		if migration.CanonicalFilename != canonical[index].version ||
+			migration.CanonicalSHA256 != canonical[index].checksum {
+			return nil, false, fmt.Errorf("legacy migration %s does not match the canonical artifact", migration.Version)
+		}
+		var expected *opendiscogsschema.LegacyChangeSet
+		for changeSetIndex := range migration.LegacyChangeSets {
+			candidate := &migration.LegacyChangeSets[changeSetIndex]
+			if candidate.SchemaMode == wantedMode {
+				expected = candidate
+				break
+			}
+		}
+		if expected == nil || row.ID != expected.ID || row.Author != expected.Author || row.Filename != expected.Filename {
+			return nil, false, fmt.Errorf("legacy migration %s has an untrusted Liquibase identity", migration.Version)
+		}
+		policy, permitted := expected.ExecutionPolicy(
+			opendiscogsschema.LegacyExecutionType(row.ExecutionType),
+		)
+		if !permitted {
+			return nil, false, fmt.Errorf("legacy migration %s has unsupported execution type %q", migration.Version, row.ExecutionType)
+		}
+		if expected.ChecksumPolicy == opendiscogsschema.LegacyChecksumPolicyExact {
+			if row.Checksum != expected.Checksum {
+				return nil, false, fmt.Errorf("legacy migration %s Liquibase checksum changed", migration.Version)
+			}
+		} else if !liquibaseChecksumPattern.MatchString(row.Checksum) {
+			return nil, false, fmt.Errorf("legacy migration %s has an invalid parameterized checksum", migration.Version)
+		}
+		if policy.AdoptionProof == opendiscogsschema.LegacyAdoptionProofSchemaContract {
+			requiresSchemaProof = true
+		}
+		validated = append(validated, migration)
+	}
+	return validated, requiresSchemaProof, nil
+}
+
+func verifyLegacySchemaContract(
+	tx *gorm.DB,
+	schema database.Schema,
+	manifest opendiscogsschema.LegacyLiquibaseManifest,
+	prefixLength int,
+) error {
+	contract, found := manifest.SchemaContract(fmt.Sprintf("V%03d", prefixLength))
+	if !found {
+		return fmt.Errorf("legacy schema contract for prefix V%03d is unavailable", prefixLength)
+	}
+	var serverVersionNumber int
+	if err := tx.Raw("show server_version_num").Scan(&serverVersionNumber).Error; err != nil {
+		return fmt.Errorf("read PostgreSQL version for legacy schema verification: %w", err)
+	}
+	postgresqlMajor := serverVersionNumber / postgresqlVersionMajorScale
+	expected, found := contract.ExpectedFingerprint(postgresqlMajor)
+	if !found {
+		return fmt.Errorf("legacy schema verification does not support PostgreSQL %d", postgresqlMajor)
+	}
+	verifier, err := loadLegacyLiquibaseContract(contract.Verifier.Name)
+	if err != nil {
+		return fmt.Errorf("load legacy schema verifier: %w", err)
+	}
+	if err := tx.Exec("set local search_path to " + schema.SearchPath()).Error; err != nil {
+		return fmt.Errorf("select legacy schema for verification: %w", err)
+	}
+	var fingerprintInput sql.NullString
+	if err := tx.Raw(string(verifier)).Scan(&fingerprintInput).Error; err != nil {
+		return fmt.Errorf("calculate legacy schema fingerprint: %w", err)
+	}
+	if !fingerprintInput.Valid {
+		return fmt.Errorf("legacy schema fingerprint query returned null")
+	}
+	digest := sha256.Sum256([]byte(fingerprintInput.String))
+	actual := hex.EncodeToString(digest[:])
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("legacy schema fingerprint mismatch: database=%s contract=%s", actual, expected)
+	}
+	return nil
+}

--- a/src/batch/release.go
+++ b/src/batch/release.go
@@ -11,8 +11,11 @@ import (
 )
 
 var (
-	labelReleaseItemRelation = integerRelation{
-		table: "label_release_item", parentColumn: "release_item_id", keyColumn: "label_id",
+	labelReleaseItemRelation = integerNullableTextKeyRelation{
+		table:             "label_release_item",
+		parentColumn:      "release_item_id",
+		integerKeyColumn:  "label_id",
+		nullableKeyColumn: "category_notation",
 	}
 	releaseArtistRelation = integerRelation{
 		table: "release_item_artist", parentColumn: "release_item_id", keyColumn: "artist_id",
@@ -194,7 +197,7 @@ func writeReleaseRelationChunk(
 				)
 			},
 			func() result.Result {
-				return reconcileIntegerRelation(
+				return reconcileIntegerNullableTextKeyRelation(
 					transactionOrder,
 					labelReleaseItemRelation,
 					deleteStale,
@@ -202,6 +205,7 @@ func writeReleaseRelationChunk(
 					labels,
 					func(item *model.LabelReleaseItem) int32 { return item.ReleaseItemID },
 					func(item *model.LabelReleaseItem) int32 { return item.LabelID },
+					func(item *model.LabelReleaseItem) *string { return item.CategoryNotation },
 				)
 			},
 			func() result.Result {

--- a/src/batch/release.go
+++ b/src/batch/release.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"time"
@@ -125,6 +126,42 @@ func writeReleaseRelationChunk(
 			tracks = append(tracks, item.GetTracks()...)
 			videos = append(videos, item.GetVideos()...)
 			creditedArtists = append(creditedArtists, item.GetCreditedArtists()...)
+		}
+		var (
+			artistError         error
+			creditedArtistError error
+			workError           error
+			styleError          error
+			genreError          error
+			labelError          error
+			formatError         error
+			identifierError     error
+			trackError          error
+			videoError          error
+		)
+		artists, artistError = deduplicateReleaseArtists(artists)
+		creditedArtists, creditedArtistError = deduplicateReleaseCreditedArtists(creditedArtists)
+		works, workError = deduplicateReleaseWorks(works)
+		releaseStyles, styleError = deduplicateReleaseStyles(releaseStyles)
+		releaseGenres, genreError = deduplicateReleaseGenres(releaseGenres)
+		labels, labelError = deduplicateLabelReleaseItems(labels)
+		formats, formatError = deduplicateReleaseFormats(formats)
+		identifiers, identifierError = deduplicateReleaseIdentifiers(identifiers)
+		tracks, trackError = deduplicateReleaseTracks(tracks)
+		videos, videoError = deduplicateReleaseVideos(videos)
+		if deduplicateError := errors.Join(
+			artistError,
+			creditedArtistError,
+			workError,
+			styleError,
+			genreError,
+			labelError,
+			formatError,
+			identifierError,
+			trackError,
+			videoError,
+		); deduplicateError != nil {
+			return result.NewResult(0, deduplicateError)
 		}
 		rootIDs = unique.Slice(rootIDs)
 		if referenceResult := writeReferenceEntities(

--- a/src/batch/release_dedupe.go
+++ b/src/batch/release_dedupe.go
@@ -1,0 +1,248 @@
+package batch
+
+import (
+	"fmt"
+
+	"github.com/dsub-io/open-discogs-model/model"
+)
+
+type releaseIntegerKey struct {
+	releaseItemID int32
+	relationKey   int32
+}
+
+type releaseTextKey struct {
+	releaseItemID int32
+	relationKey   string
+}
+
+type releaseTwoIntegerKey struct {
+	releaseItemID int32
+	firstKey      int32
+	secondKey     int32
+}
+
+type releaseLabelKey struct {
+	releaseItemID    int32
+	labelID          int32
+	categoryNotation nullableStringKey
+}
+
+type nullableStringKey struct {
+	value string
+	valid bool
+}
+
+func deduplicateReleaseArtists(
+	items []*model.ReleaseItemArtist,
+) ([]*model.ReleaseItemArtist, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemArtist{}.TableName(),
+		items,
+		func(row *model.ReleaseItemArtist) releaseIntegerKey {
+			return releaseIntegerKey{row.ReleaseItemID, row.ArtistID}
+		},
+		func(_, _ *model.ReleaseItemArtist) bool { return true },
+	)
+}
+
+func deduplicateReleaseCreditedArtists(
+	items []*model.ReleaseItemCreditedArtist,
+) ([]*model.ReleaseItemCreditedArtist, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemCreditedArtist{}.TableName(),
+		items,
+		func(row *model.ReleaseItemCreditedArtist) releaseTwoIntegerKey {
+			return releaseTwoIntegerKey{row.ReleaseItemID, row.ArtistID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemCreditedArtist) bool {
+			return equalOptionalValue(left.Role, right.Role)
+		},
+	)
+}
+
+func deduplicateReleaseWorks(
+	items []*model.ReleaseItemWork,
+) ([]*model.ReleaseItemWork, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemWork{}.TableName(),
+		items,
+		func(row *model.ReleaseItemWork) releaseTwoIntegerKey {
+			return releaseTwoIntegerKey{row.ReleaseItemID, row.LabelID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemWork) bool {
+			return equalOptionalValue(left.Work, right.Work)
+		},
+	)
+}
+
+func deduplicateReleaseStyles(
+	items []*model.ReleaseItemStyle,
+) ([]*model.ReleaseItemStyle, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemStyle{}.TableName(),
+		items,
+		func(row *model.ReleaseItemStyle) releaseTextKey {
+			return releaseTextKey{row.ReleaseItemID, row.Style}
+		},
+		func(_, _ *model.ReleaseItemStyle) bool { return true },
+	)
+}
+
+func deduplicateReleaseGenres(
+	items []*model.ReleaseItemGenre,
+) ([]*model.ReleaseItemGenre, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemGenre{}.TableName(),
+		items,
+		func(row *model.ReleaseItemGenre) releaseTextKey {
+			return releaseTextKey{row.ReleaseItemID, row.Genre}
+		},
+		func(_, _ *model.ReleaseItemGenre) bool { return true },
+	)
+}
+
+func deduplicateLabelReleaseItems(
+	items []*model.LabelReleaseItem,
+) ([]*model.LabelReleaseItem, error) {
+	return deduplicateCanonicalRows(
+		model.LabelReleaseItem{}.TableName(),
+		items,
+		func(row *model.LabelReleaseItem) releaseLabelKey {
+			return releaseLabelKey{
+				releaseItemID:    row.ReleaseItemID,
+				labelID:          row.LabelID,
+				categoryNotation: newNullableStringKey(row.CategoryNotation),
+			}
+		},
+		func(_, _ *model.LabelReleaseItem) bool { return true },
+	)
+}
+
+func deduplicateReleaseFormats(
+	items []*model.ReleaseItemFormat,
+) ([]*model.ReleaseItemFormat, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemFormat{}.TableName(),
+		items,
+		func(row *model.ReleaseItemFormat) releaseIntegerKey {
+			return releaseIntegerKey{row.ReleaseItemID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemFormat) bool {
+			return equalOptionalValue(left.Description, right.Description) &&
+				equalOptionalValue(left.Name, right.Name) &&
+				equalOptionalValue(left.Quantity, right.Quantity) &&
+				equalOptionalValue(left.Text, right.Text)
+		},
+	)
+}
+
+func deduplicateReleaseIdentifiers(
+	items []*model.ReleaseItemIdentifier,
+) ([]*model.ReleaseItemIdentifier, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemIdentifier{}.TableName(),
+		items,
+		func(row *model.ReleaseItemIdentifier) releaseIntegerKey {
+			return releaseIntegerKey{row.ReleaseItemID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemIdentifier) bool {
+			return equalOptionalValue(left.Description, right.Description) &&
+				equalOptionalValue(left.Type, right.Type) &&
+				equalOptionalValue(left.Value, right.Value)
+		},
+	)
+}
+
+func deduplicateReleaseImages(
+	items []*model.ReleaseItemImage,
+) ([]*model.ReleaseItemImage, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemImage{}.TableName(),
+		items,
+		func(row *model.ReleaseItemImage) releaseIntegerKey {
+			return releaseIntegerKey{row.ReleaseItemID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemImage) bool {
+			return equalOptionalValue(left.FileName, right.FileName)
+		},
+	)
+}
+
+func deduplicateReleaseTracks(
+	items []*model.ReleaseItemTrack,
+) ([]*model.ReleaseItemTrack, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemTrack{}.TableName(),
+		items,
+		func(row *model.ReleaseItemTrack) releaseIntegerKey {
+			return releaseIntegerKey{row.ReleaseItemID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemTrack) bool {
+			return equalOptionalValue(left.Duration, right.Duration) &&
+				equalOptionalValue(left.Position, right.Position) &&
+				equalOptionalValue(left.Title, right.Title)
+		},
+	)
+}
+
+func deduplicateReleaseVideos(
+	items []*model.ReleaseItemVideo,
+) ([]*model.ReleaseItemVideo, error) {
+	return deduplicateCanonicalRows(
+		model.ReleaseItemVideo{}.TableName(),
+		items,
+		func(row *model.ReleaseItemVideo) releaseIntegerKey {
+			return releaseIntegerKey{row.ReleaseItemID, row.Hash}
+		},
+		func(left, right *model.ReleaseItemVideo) bool {
+			return equalOptionalValue(left.Description, right.Description) &&
+				equalOptionalValue(left.Title, right.Title) &&
+				equalOptionalValue(left.URL, right.URL)
+		},
+	)
+}
+
+func deduplicateCanonicalRows[T comparable, K comparable](
+	table string,
+	items []*T,
+	key func(*T) K,
+	equalPayload func(*T, *T) bool,
+) ([]*T, error) {
+	seen := make(map[K]*T, len(items))
+	deduplicated := make([]*T, 0, len(items))
+	for index, item := range items {
+		if item == nil {
+			return nil, fmt.Errorf("nil %s row at batch index %d", table, index)
+		}
+		canonicalKey := key(item)
+		previous, exists := seen[canonicalKey]
+		if !exists {
+			seen[canonicalKey] = item
+			deduplicated = append(deduplicated, item)
+			continue
+		}
+		if !equalPayload(previous, item) {
+			return nil, fmt.Errorf(
+				"conflicting %s rows for canonical key %v",
+				table,
+				canonicalKey,
+			)
+		}
+	}
+	return deduplicated, nil
+}
+
+func newNullableStringKey(value *string) nullableStringKey {
+	if value == nil {
+		return nullableStringKey{}
+	}
+	return nullableStringKey{value: *value, valid: true}
+}
+
+func equalOptionalValue[T comparable](left, right *T) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}

--- a/src/batch/release_dedupe_integration_test.go
+++ b/src/batch/release_dedupe_integration_test.go
@@ -1,0 +1,167 @@
+package batch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dsub-io/go-open-discogs-batch/internal/testutils"
+	"github.com/dsub-io/go-open-discogs-batch/src/cache"
+	"github.com/dsub-io/go-open-discogs-batch/src/database"
+	"github.com/dsub-io/open-discogs-model/model"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestReleaseRelationWriterPreventsPostgresSQLState21000AndRetriesIdempotently(t *testing.T) {
+	postgres := testutils.GetDatabase(t, testutils.Postgres)
+	dsn := testutils.GetDsn(testutils.Postgres, postgres)
+	db, err := database.GetConnect(dsn)
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	db, err = database.GetConnect(dsn)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	const releaseItemID int32 = 2_000_000_001
+	require.NoError(t, db.Create(&model.ReleaseItem{
+		ID:             releaseItemID,
+		CreatedAt:      now,
+		LastModifiedAt: now,
+	}).Error)
+
+	name := "Vinyl"
+	quantityOne := int32(1)
+	quantityTwo := int32(2)
+	conflicting := []*model.ReleaseItemFormat{
+		{
+			ReleaseItemID:  releaseItemID,
+			Hash:           101,
+			Name:           &name,
+			Quantity:       &quantityOne,
+			CreatedAt:      now,
+			LastModifiedAt: now,
+		},
+		{
+			ReleaseItemID:  releaseItemID,
+			Hash:           101,
+			Name:           &name,
+			Quantity:       &quantityTwo,
+			CreatedAt:      now.Add(time.Second),
+			LastModifiedAt: now.Add(time.Second),
+		},
+	}
+
+	conflictResult := writeReleaseRelationBatch(
+		conflicting,
+		len(conflicting),
+		db,
+		deduplicateReleaseFormats,
+	)
+	require.ErrorContains(t, conflictResult.Err(), "conflicting release_item_format rows")
+	require.ErrorContains(t, conflictResult.Err(), "canonical key")
+	require.NotContains(t, conflictResult.Err().Error(), "SQLSTATE 21000")
+	requireRelationRowCount(t, db, &model.ReleaseItemFormat{}, releaseItemID, 0)
+
+	exactDuplicates := []*model.ReleaseItemFormat{
+		{
+			ReleaseItemID:  releaseItemID,
+			Hash:           101,
+			Name:           &name,
+			Quantity:       &quantityOne,
+			CreatedAt:      now,
+			LastModifiedAt: now,
+		},
+		{
+			ID:             99,
+			ReleaseItemID:  releaseItemID,
+			Hash:           101,
+			Name:           &name,
+			Quantity:       &quantityOne,
+			CreatedAt:      now.Add(time.Minute),
+			LastModifiedAt: now.Add(time.Minute),
+		},
+	}
+
+	firstWrite := writeReleaseRelationBatch(
+		exactDuplicates,
+		len(exactDuplicates),
+		db,
+		deduplicateReleaseFormats,
+	)
+	require.NoError(t, firstWrite.Err())
+	require.Equal(t, 1, firstWrite.Count())
+	requireRelationRowCount(t, db, &model.ReleaseItemFormat{}, releaseItemID, 1)
+
+	retry := writeReleaseRelationBatch(exactDuplicates, 1, db, deduplicateReleaseFormats)
+	require.NoError(t, retry.Err())
+	require.Zero(t, retry.Count())
+	requireRelationRowCount(t, db, &model.ReleaseItemFormat{}, releaseItemID, 1)
+
+	cache.ArtistIDs.Add(1)
+	cache.LabelIDs.Add(5)
+	t.Cleanup(cache.ResetIDs)
+	require.NoError(t, db.Create(&model.Artist{
+		ID:             1,
+		CreatedAt:      now,
+		LastModifiedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&model.Label{
+		ID:             5,
+		CreatedAt:      now,
+		LastModifiedAt: now,
+	}).Error)
+	fixture := readReleaseRelationDeduplicationFixture(t)
+	order := NewOrder(context.Background(), 100, 1, "unused", db)
+
+	fixtureWrite := writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{fixture}, false)
+	require.NoError(t, fixtureWrite.Err())
+	require.NotZero(t, fixtureWrite.Count())
+	requireReleaseFixtureRelationCounts(t, db, fixture.ID)
+
+	fixtureRetry := writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{fixture}, false)
+	require.NoError(t, fixtureRetry.Err())
+	require.Zero(t, fixtureRetry.Count())
+	requireReleaseFixtureRelationCounts(t, db, fixture.ID)
+}
+
+func requireRelationRowCount(
+	t *testing.T,
+	db *gorm.DB,
+	modelValue *model.ReleaseItemFormat,
+	releaseItemID int32,
+	expected int64,
+) {
+	t.Helper()
+	var count int64
+	require.NoError(t, db.Model(modelValue).
+		Where("release_item_id = ?", releaseItemID).
+		Count(&count).Error)
+	require.Equal(t, expected, count)
+}
+
+func requireReleaseFixtureRelationCounts(t *testing.T, db *gorm.DB, releaseItemID int32) {
+	t.Helper()
+	expected := []struct {
+		table string
+		count int64
+	}{
+		{model.ReleaseItemArtist{}.TableName(), 1},
+		{model.ReleaseItemCreditedArtist{}.TableName(), 1},
+		{model.ReleaseItemWork{}.TableName(), 1},
+		{model.ReleaseItemFormat{}.TableName(), 1},
+		{model.ReleaseItemGenre{}.TableName(), 1},
+		{model.ReleaseItemStyle{}.TableName(), 1},
+		{model.ReleaseItemIdentifier{}.TableName(), 1},
+		{model.ReleaseItemTrack{}.TableName(), 1},
+		{model.ReleaseItemVideo{}.TableName(), 1},
+		{model.LabelReleaseItem{}.TableName(), 3},
+	}
+	for _, relation := range expected {
+		var count int64
+		require.NoError(t, db.Table(relation.table).
+			Where("release_item_id = ?", releaseItemID).
+			Count(&count).Error)
+		require.Equal(t, relation.count, count, relation.table)
+	}
+}

--- a/src/batch/release_dedupe_test.go
+++ b/src/batch/release_dedupe_test.go
@@ -1,0 +1,263 @@
+package batch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dsub-io/open-discogs-model/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReleaseRelationChunkRejectsHashCollisionBeforeDatabaseStatements(t *testing.T) {
+	db, mock, _ := newMockGorm(t)
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+	left := "Aa"
+	right := "BB"
+	actual := writeReleaseRelationChunk(
+		NewOrder(context.Background(), 10, 1, "unused", db),
+		ChunkMetadata{},
+		[]*XmlReleaseRelation{{
+			ID: 1,
+			Formats: []XmlFormat{
+				{Name: &left},
+				{Name: &right},
+			},
+		}},
+		false,
+	)
+
+	require.ErrorContains(t, actual.Err(), "conflicting release_item_format rows")
+	require.ErrorContains(t, actual.Err(), "canonical key")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReleaseRelationBatchDeduplicatesCanonicalConflictKeys(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 12, 1, 0, 0, 0, time.UTC)
+	modifiedAt := createdAt.Add(time.Second)
+	role := "Producer"
+	work := "Recorded At"
+	description := "description"
+	name := "Vinyl"
+	quantity := int32(1)
+	text := "text"
+	identifierType := "Barcode"
+	value := "123"
+	fileName := "cover.jpg"
+	duration := "3:00"
+	position := "A1"
+	title := "Track"
+	url := "https://example.invalid/video"
+
+	t.Run("repeated artist", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseArtists,
+			&model.ReleaseItemArtist{ReleaseItemID: 1, ArtistID: 2, CreatedAt: createdAt},
+			&model.ReleaseItemArtist{ID: 99, ReleaseItemID: 1, ArtistID: 2, CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("credited artist hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseCreditedArtists,
+			&model.ReleaseItemCreditedArtist{ReleaseItemID: 1, ArtistID: 2, Hash: 3, Role: &role},
+			&model.ReleaseItemCreditedArtist{ID: 99, ReleaseItemID: 1, ArtistID: 2, Hash: 3, Role: &role, CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("work hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseWorks,
+			&model.ReleaseItemWork{ReleaseItemID: 1, LabelID: 2, Hash: 3, Work: &work},
+			&model.ReleaseItemWork{ID: 99, ReleaseItemID: 1, LabelID: 2, Hash: 3, Work: &work, LastModifiedAt: modifiedAt},
+		)
+	})
+	t.Run("style", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseStyles,
+			&model.ReleaseItemStyle{ReleaseItemID: 1, Style: "Techno", CreatedAt: createdAt},
+			&model.ReleaseItemStyle{ID: 99, ReleaseItemID: 1, Style: "Techno", CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("genre", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseGenres,
+			&model.ReleaseItemGenre{ReleaseItemID: 1, Genre: "Electronic", CreatedAt: createdAt},
+			&model.ReleaseItemGenre{ID: 99, ReleaseItemID: 1, Genre: "Electronic", CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("nullable catalog number and distinct spellings", func(t *testing.T) {
+		spacedCatalogNumber := "SK 026"
+		compactCatalogNumber := "SK026"
+		rows, err := deduplicateLabelReleaseItems([]*model.LabelReleaseItem{
+			{ReleaseItemID: 1, LabelID: 2, CategoryNotation: nil, CreatedAt: createdAt},
+			{ID: 99, ReleaseItemID: 1, LabelID: 2, CategoryNotation: nil, CreatedAt: modifiedAt},
+			{ReleaseItemID: 1, LabelID: 2, CategoryNotation: &spacedCatalogNumber},
+			{ReleaseItemID: 1, LabelID: 2, CategoryNotation: &compactCatalogNumber},
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 3)
+		require.Nil(t, rows[0].CategoryNotation)
+		require.Equal(t, spacedCatalogNumber, *rows[1].CategoryNotation)
+		require.Equal(t, compactCatalogNumber, *rows[2].CategoryNotation)
+	})
+	t.Run("format hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseFormats,
+			&model.ReleaseItemFormat{ReleaseItemID: 1, Hash: 2, Description: &description, Name: &name, Quantity: &quantity, Text: &text},
+			&model.ReleaseItemFormat{ID: 99, ReleaseItemID: 1, Hash: 2, Description: &description, Name: &name, Quantity: &quantity, Text: &text, CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("identifier hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseIdentifiers,
+			&model.ReleaseItemIdentifier{ReleaseItemID: 1, Hash: 2, Description: &description, Type: &identifierType, Value: &value},
+			&model.ReleaseItemIdentifier{ID: 99, ReleaseItemID: 1, Hash: 2, Description: &description, Type: &identifierType, Value: &value, LastModifiedAt: modifiedAt},
+		)
+	})
+	t.Run("image hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseImages,
+			&model.ReleaseItemImage{ReleaseItemID: 1, Hash: 2, FileName: &fileName},
+			&model.ReleaseItemImage{ID: 99, ReleaseItemID: 1, Hash: 2, FileName: &fileName, CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("track hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseTracks,
+			&model.ReleaseItemTrack{ReleaseItemID: 1, Hash: 2, Duration: &duration, Position: &position, Title: &title},
+			&model.ReleaseItemTrack{ID: 99, ReleaseItemID: 1, Hash: 2, Duration: &duration, Position: &position, Title: &title, CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("video hash", func(t *testing.T) {
+		assertExactReleaseRelationDeduplication(t,
+			deduplicateReleaseVideos,
+			&model.ReleaseItemVideo{ReleaseItemID: 1, Hash: 2, Description: &description, Title: &title, URL: &url},
+			&model.ReleaseItemVideo{ID: 99, ReleaseItemID: 1, Hash: 2, Description: &description, Title: &title, URL: &url, CreatedAt: modifiedAt},
+		)
+	})
+	t.Run("nil row", func(t *testing.T) {
+		rows, err := deduplicateReleaseArtists([]*model.ReleaseItemArtist{nil})
+		require.Nil(t, rows)
+		require.ErrorContains(t, err, "nil release_item_artist row at batch index 0")
+	})
+}
+
+func TestReleaseRelationBatchRejectsCanonicalHashCollisions(t *testing.T) {
+	producer := "Producer"
+	remixer := "Remixer"
+	recordedAt := "Recorded At"
+	pressedBy := "Pressed By"
+	description := "description"
+	otherDescription := "other description"
+	name := "Vinyl"
+	quantityOne := int32(1)
+	quantityTwo := int32(2)
+	text := "text"
+	identifierType := "Barcode"
+	value := "123"
+	otherValue := "456"
+	fileName := "cover.jpg"
+	duration := "3:00"
+	position := "A1"
+	title := "Track"
+	otherTitle := "Other Track"
+	url := "https://example.invalid/video"
+	otherURL := "https://example.invalid/other-video"
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "credited artist",
+			run: func() error {
+				_, err := deduplicateReleaseCreditedArtists([]*model.ReleaseItemCreditedArtist{
+					{ReleaseItemID: 1, ArtistID: 2, Hash: 3, Role: &producer},
+					{ReleaseItemID: 1, ArtistID: 2, Hash: 3, Role: &remixer},
+				})
+				return err
+			},
+		},
+		{
+			name: "work",
+			run: func() error {
+				_, err := deduplicateReleaseWorks([]*model.ReleaseItemWork{
+					{ReleaseItemID: 1, LabelID: 2, Hash: 3, Work: &recordedAt},
+					{ReleaseItemID: 1, LabelID: 2, Hash: 3, Work: &pressedBy},
+				})
+				return err
+			},
+		},
+		{
+			name: "format",
+			run: func() error {
+				_, err := deduplicateReleaseFormats([]*model.ReleaseItemFormat{
+					{ReleaseItemID: 1, Hash: 2, Description: &description, Name: &name, Quantity: &quantityOne, Text: &text},
+					{ReleaseItemID: 1, Hash: 2, Description: &description, Name: &name, Quantity: &quantityTwo, Text: &text},
+				})
+				return err
+			},
+		},
+		{
+			name: "identifier",
+			run: func() error {
+				_, err := deduplicateReleaseIdentifiers([]*model.ReleaseItemIdentifier{
+					{ReleaseItemID: 1, Hash: 2, Description: &description, Type: &identifierType, Value: &value},
+					{ReleaseItemID: 1, Hash: 2, Description: &otherDescription, Type: &identifierType, Value: &otherValue},
+				})
+				return err
+			},
+		},
+		{
+			name: "image",
+			run: func() error {
+				_, err := deduplicateReleaseImages([]*model.ReleaseItemImage{
+					{ReleaseItemID: 1, Hash: 2},
+					{ReleaseItemID: 1, Hash: 2, FileName: &fileName},
+				})
+				return err
+			},
+		},
+		{
+			name: "track",
+			run: func() error {
+				_, err := deduplicateReleaseTracks([]*model.ReleaseItemTrack{
+					{ReleaseItemID: 1, Hash: 2, Duration: &duration, Position: &position, Title: &title},
+					{ReleaseItemID: 1, Hash: 2, Duration: &duration, Position: &position, Title: &otherTitle},
+				})
+				return err
+			},
+		},
+		{
+			name: "video",
+			run: func() error {
+				_, err := deduplicateReleaseVideos([]*model.ReleaseItemVideo{
+					{ReleaseItemID: 1, Hash: 2, Description: &description, Title: &title, URL: &url},
+					{ReleaseItemID: 1, Hash: 2, Description: &description, Title: &title, URL: &otherURL},
+				})
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.run()
+			require.Error(t, err)
+			require.ErrorContains(t, err, "conflicting release_item_")
+			require.ErrorContains(t, err, "canonical key")
+		})
+	}
+}
+
+func assertExactReleaseRelationDeduplication[T comparable](
+	t *testing.T,
+	deduplicate func([]T) ([]T, error),
+	left T,
+	right T,
+) {
+	t.Helper()
+	rows, err := deduplicate([]T{left, right})
+	require.NoError(t, err)
+	require.Equal(t, []T{left}, rows)
+}

--- a/src/batch/release_test.go
+++ b/src/batch/release_test.go
@@ -2,11 +2,31 @@ package batch
 
 import (
 	"context"
+	"github.com/dsub-io/go-open-discogs-batch/src/cache"
 	"github.com/dsub-io/go-open-discogs-batch/src/reader"
 	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 )
+
+func TestReleaseLabelsPreserveDistinctCatalogNumbers(t *testing.T) {
+	cache.LabelIDs.Add(5)
+	t.Cleanup(cache.ResetIDs)
+	release := XmlReleaseRelation{
+		ID: 2,
+		Labels: []XmlLabelRelease{
+			{LabelID: 5, CategoryNotation: "SK 026"},
+			{LabelID: 5, CategoryNotation: "SK026"},
+			{LabelID: 5, CategoryNotation: " SK026 "},
+		},
+	}
+
+	labels := release.GetLabels()
+
+	require.Len(t, labels, 2)
+	require.Equal(t, "SK 026", *labels[0].CategoryNotation)
+	require.Equal(t, "SK026", *labels[1].CategoryNotation)
+}
 
 func TestReleaseRead(t *testing.T) {
 	c := context.Background()

--- a/src/batch/release_test.go
+++ b/src/batch/release_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/src/cache"
 	"github.com/dsub-io/go-open-discogs-batch/src/reader"
 	"github.com/stretchr/testify/require"
+	"os"
 	"strings"
 	"testing"
 )
@@ -26,6 +27,64 @@ func TestReleaseLabelsPreserveDistinctCatalogNumbers(t *testing.T) {
 	require.Len(t, labels, 2)
 	require.Equal(t, "SK 026", *labels[0].CategoryNotation)
 	require.Equal(t, "SK026", *labels[1].CategoryNotation)
+}
+
+func TestReleaseRelationDeduplicationFixture(t *testing.T) {
+	cache.ArtistIDs.Add(1)
+	cache.LabelIDs.Add(5)
+	t.Cleanup(cache.ResetIDs)
+
+	release := readReleaseRelationDeduplicationFixture(t)
+
+	assertReleaseRelationCount(t, deduplicateReleaseArtists, release.GetReleaseArtists(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseCreditedArtists, release.GetCreditedArtists(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseWorks, release.GetWorks(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseFormats, release.GetFormats(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseGenres, release.GetReleaseGenres(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseStyles, release.GetReleaseStyles(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseIdentifiers, release.GetIdentifiers(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseTracks, release.GetTracks(), 1)
+	assertReleaseRelationCount(t, deduplicateReleaseVideos, release.GetVideos(), 1)
+
+	labels, err := deduplicateLabelReleaseItems(release.GetLabels())
+	require.NoError(t, err)
+	require.Len(t, labels, 3)
+	require.Nil(t, labels[0].CategoryNotation)
+	require.Equal(t, "SK 026", *labels[1].CategoryNotation)
+	require.Equal(t, "SK026", *labels[2].CategoryNotation)
+}
+
+func readReleaseRelationDeduplicationFixture(t *testing.T) *XmlReleaseRelation {
+	t.Helper()
+	file, err := os.Open("testdata/release-relations-dedup.xml")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+	observable := reader.NewReader[XmlReleaseRelation](
+		context.Background(),
+		file,
+		"release",
+	)
+	var release *XmlReleaseRelation
+	for item := range observable.Observe() {
+		require.NoError(t, item.E)
+		require.NotNil(t, item.V)
+		require.Nil(t, release)
+		release = item.V.(*XmlReleaseRelation)
+	}
+	require.NotNil(t, release)
+	return release
+}
+
+func assertReleaseRelationCount[T comparable](
+	t *testing.T,
+	deduplicate func([]T) ([]T, error),
+	rows []T,
+	expected int,
+) {
+	t.Helper()
+	deduplicated, err := deduplicate(rows)
+	require.NoError(t, err)
+	require.Len(t, deduplicated, expected)
 }
 
 func TestReleaseRead(t *testing.T) {

--- a/src/batch/runner.go
+++ b/src/batch/runner.go
@@ -46,6 +46,7 @@ var openSQLDatabase = func(db *gorm.DB) (*sql.DB, error) { return db.DB() }
 var newExecutionCoordinator = func(db *sql.DB, version string) importExecutionCoordinator {
 	return NewImportExecutionCoordinator(db, version)
 }
+var validateImportDependencies = preflightImportDependencies
 var preloadImportReferenceIDs = preloadReferenceIDs
 var newImportBatch = New
 var closeIdentifierRows = func(rows *sql.Rows) error { return rows.Close() }
@@ -91,6 +92,9 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 	if err != nil {
 		return fmt.Errorf("open SQL connection pool: %w", err)
 	}
+	if err := validateImportDependencies(ctx, sqlDB, plan.Dumps); err != nil {
+		return err
+	}
 	coordinator := newExecutionCoordinator(sqlDB, runner.Version)
 	preparation, err := coordinator.Prepare(
 		ctx,
@@ -112,6 +116,9 @@ func (runner *Runner) Run(ctx context.Context, config *koanf.Koanf) error {
 			return cleanupImportFiles(plan)
 		}
 		return nil
+	}
+	if err := validateImportDependencies(ctx, sqlDB, plan.Dumps); err != nil {
+		return finalizeImport(ctx, coordinator, plan, false, err)
 	}
 	if err := fetchImportResources(ctx, plan); err != nil {
 		return finalizeImport(ctx, coordinator, plan, false, err)

--- a/src/batch/runner_error_test.go
+++ b/src/batch/runner_error_test.go
@@ -55,6 +55,7 @@ type runnerSeams struct {
 	resolve       func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error)
 	fetch         func(context.Context, *data.ImportPlan) error
 	open          func(*gorm.DB) (*sql.DB, error)
+	preflight     func(context.Context, *sql.DB, []*opendiscogsmodel.DiscogsDump) error
 	coordinator   func(*sql.DB, string) importExecutionCoordinator
 	preload       func(context.Context, *sql.DB, *koanf.Koanf) error
 	newBatch      func() Batch
@@ -71,6 +72,7 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 	originalResolve := resolveImportPlan
 	originalFetch := fetchImportResources
 	originalOpen := openSQLDatabase
+	originalPreflight := validateImportDependencies
 	originalCoordinator := newExecutionCoordinator
 	originalPreload := preloadImportReferenceIDs
 	originalBatch := newImportBatch
@@ -84,6 +86,7 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 		resolveImportPlan = originalResolve
 		fetchImportResources = originalFetch
 		openSQLDatabase = originalOpen
+		validateImportDependencies = originalPreflight
 		newExecutionCoordinator = originalCoordinator
 		preloadImportReferenceIDs = originalPreload
 		newImportBatch = originalBatch
@@ -97,6 +100,7 @@ func installRunnerSeams(t *testing.T, seams runnerSeams) {
 	resolveImportPlan = seams.resolve
 	fetchImportResources = seams.fetch
 	openSQLDatabase = seams.open
+	validateImportDependencies = seams.preflight
 	newExecutionCoordinator = seams.coordinator
 	preloadImportReferenceIDs = seams.preload
 	newImportBatch = seams.newBatch
@@ -119,8 +123,15 @@ func defaultRunnerSeams() runnerSeams {
 				Dumps:     []*opendiscogsmodel.DiscogsDump{importDump("artist", "2026-07-01", "a")},
 			}, nil
 		},
-		fetch:       func(context.Context, *data.ImportPlan) error { return nil },
-		open:        func(*gorm.DB) (*sql.DB, error) { return nil, nil },
+		fetch: func(context.Context, *data.ImportPlan) error { return nil },
+		open:  func(*gorm.DB) (*sql.DB, error) { return nil, nil },
+		preflight: func(
+			context.Context,
+			*sql.DB,
+			[]*opendiscogsmodel.DiscogsDump,
+		) error {
+			return nil
+		},
 		coordinator: func(*sql.DB, string) importExecutionCoordinator { return coordinator },
 		preload:     func(context.Context, *sql.DB, *koanf.Koanf) error { return nil },
 		newBatch: func() Batch {
@@ -161,6 +172,15 @@ func TestRunnerPropagatesEveryStageFailure(t *testing.T) {
 			s.resolve = func(*koanf.Koanf, data.Repository) (*data.ImportPlan, error) { return nil, expected }
 		}},
 		{"open SQL pool", func(s *runnerSeams) { s.open = func(*gorm.DB) (*sql.DB, error) { return nil, expected } }},
+		{"dependency preflight", func(s *runnerSeams) {
+			s.preflight = func(
+				context.Context,
+				*sql.DB,
+				[]*opendiscogsmodel.DiscogsDump,
+			) error {
+				return expected
+			}
+		}},
 		{"prepare", func(s *runnerSeams) {
 			s.coordinator = func(*sql.DB, string) importExecutionCoordinator {
 				return &executionCoordinatorStub{prepareErr: expected}
@@ -182,6 +202,35 @@ func TestRunnerPropagatesEveryStageFailure(t *testing.T) {
 			require.ErrorIs(t, (&Runner{Version: "test"}).Run(context.Background(), runnerConfig(t)), expected)
 		})
 	}
+}
+
+func TestRunnerRechecksDependenciesAfterAdmissionBeforeFetch(t *testing.T) {
+	expected := errors.New("dependency changed during admission")
+	seams := defaultRunnerSeams()
+	preflightCalls := 0
+	fetchCalled := false
+	seams.preflight = func(
+		context.Context,
+		*sql.DB,
+		[]*opendiscogsmodel.DiscogsDump,
+	) error {
+		preflightCalls++
+		if preflightCalls == 2 {
+			return expected
+		}
+		return nil
+	}
+	seams.fetch = func(context.Context, *data.ImportPlan) error {
+		fetchCalled = true
+		return nil
+	}
+	installRunnerSeams(t, seams)
+
+	err := (&Runner{Version: "test"}).Run(context.Background(), runnerConfig(t))
+
+	require.ErrorIs(t, err, expected)
+	require.Equal(t, 2, preflightCalls)
+	require.False(t, fetchCalled)
 }
 
 func TestRunnerRejectsInvalidDatabaseSchema(t *testing.T) {

--- a/src/batch/testdata/release-relations-dedup.xml
+++ b/src/batch/testdata/release-relations-dedup.xml
@@ -1,0 +1,48 @@
+<releases>
+  <release id="200000001" status="Accepted">
+    <artists>
+      <artist><id>1</id></artist>
+      <artist><id>1</id></artist>
+    </artists>
+    <title>Canonical relation deduplication</title>
+    <labels>
+      <label catno="" id="5"/>
+      <label catno=" " id="5"/>
+      <label catno="SK 026" id="5"/>
+      <label catno="SK026" id="5"/>
+      <label catno=" SK026 " id="5"/>
+    </labels>
+    <extraartists>
+      <artist><id>1</id><role>Producer</role></artist>
+      <artist><id>1</id><role> Producer </role></artist>
+    </extraartists>
+    <formats>
+      <format name="Vinyl" qty="1" text="Text"><descriptions><description>12 inch</description></descriptions></format>
+      <format name=" Vinyl " qty="1" text=" Text "><descriptions><description> 12 inch </description></descriptions></format>
+    </formats>
+    <genres>
+      <genre>Electronic</genre>
+      <genre> Electronic </genre>
+    </genres>
+    <styles>
+      <style>Techno</style>
+      <style> Techno </style>
+    </styles>
+    <tracklist>
+      <track><position>A1</position><title>Track</title><duration>3:00</duration></track>
+      <track><position> A1 </position><title> Track </title><duration> 3:00 </duration></track>
+    </tracklist>
+    <identifiers>
+      <identifier type="Barcode" description="Primary" value="123"/>
+      <identifier type=" Barcode " description=" Primary " value=" 123 "/>
+    </identifiers>
+    <videos>
+      <video src="https://example.invalid/video"><title>Video</title><description>Description</description></video>
+      <video src=" https://example.invalid/video "><title> Video </title><description> Description </description></video>
+    </videos>
+    <companies>
+      <company><id>5</id><entity_type_name>Recorded At</entity_type_name></company>
+      <company><id>5</id><entity_type_name> Recorded At </entity_type_name></company>
+    </companies>
+  </release>
+</releases>

--- a/src/batch/writer.go
+++ b/src/batch/writer.go
@@ -82,7 +82,7 @@ func (g gormWriter) Write(chunkSize int, slices ...interface{}) result.Result {
 		case []*model.LabelSubLabel:
 			r = doWrite[*model.LabelSubLabel](o, chunkSize, g.db)
 		case []*model.LabelReleaseItem:
-			r = doWrite[*model.LabelReleaseItem](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateLabelReleaseItems)
 		case []*model.Master:
 			r = doWrite[*model.Master](o, chunkSize, g.db)
 		case []*model.MasterArtist:
@@ -96,25 +96,25 @@ func (g gormWriter) Write(chunkSize int, slices ...interface{}) result.Result {
 		case []*model.ReleaseItem:
 			r = doWrite[*model.ReleaseItem](o, chunkSize, g.db)
 		case []*model.ReleaseItemArtist:
-			r = doWrite[*model.ReleaseItemArtist](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseArtists)
 		case []*model.ReleaseItemWork:
-			r = doWrite[*model.ReleaseItemWork](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseWorks)
 		case []*model.ReleaseItemFormat:
-			r = doWrite[*model.ReleaseItemFormat](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseFormats)
 		case []*model.ReleaseItemCreditedArtist:
-			r = doWrite[*model.ReleaseItemCreditedArtist](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseCreditedArtists)
 		case []*model.ReleaseItemGenre:
-			r = doWrite[*model.ReleaseItemGenre](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseGenres)
 		case []*model.ReleaseItemStyle:
-			r = doWrite[*model.ReleaseItemStyle](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseStyles)
 		case []*model.ReleaseItemIdentifier:
-			r = doWrite[*model.ReleaseItemIdentifier](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseIdentifiers)
 		case []*model.ReleaseItemImage:
-			r = doWrite[*model.ReleaseItemImage](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseImages)
 		case []*model.ReleaseItemTrack:
-			r = doWrite[*model.ReleaseItemTrack](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseTracks)
 		case []*model.ReleaseItemVideo:
-			r = doWrite[*model.ReleaseItemVideo](o, chunkSize, g.db)
+			r = writeReleaseRelationBatch(o, chunkSize, g.db, deduplicateReleaseVideos)
 		case []*model.Style:
 			r = doWrite[*model.Style](o, chunkSize, g.db)
 		case []*model.Genre:
@@ -127,6 +127,19 @@ func (g gormWriter) Write(chunkSize int, slices ...interface{}) result.Result {
 	}
 
 	return result.NewResult(updated, err)
+}
+
+func writeReleaseRelationBatch[T comparable](
+	items []T,
+	chunkSize int,
+	db *gorm.DB,
+	deduplicate func([]T) ([]T, error),
+) result.Result {
+	deduplicated, err := deduplicate(items)
+	if err != nil {
+		return result.NewResult(0, err)
+	}
+	return doWrite(deduplicated, chunkSize, db)
 }
 
 func doWrite[T comparable](items []T, chunkSize int, db *gorm.DB) result.Result {

--- a/src/batch/xml.go
+++ b/src/batch/xml.go
@@ -498,7 +498,7 @@ func (r *XmlReleaseRelation) GetWorks() []*opendiscogsmodel.ReleaseItemWork {
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetVideos() []*opendiscogsmodel.ReleaseItemVideo {
@@ -522,56 +522,64 @@ func (r *XmlReleaseRelation) GetVideos() []*opendiscogsmodel.ReleaseItemVideo {
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetIdentifiers() []*opendiscogsmodel.ReleaseItemIdentifier {
 	items := make([]*opendiscogsmodel.ReleaseItemIdentifier, 0, len(r.Identifiers))
 	for _, identifier := range r.Identifiers {
-		hashSource := identifier.Type + identifier.Description + identifier.Value
+		description := helper.FilterStr(&identifier.Description)
+		identifierType := helper.FilterStr(&identifier.Type)
+		value := helper.FilterStr(&identifier.Value)
+		hashSource := stringValue(identifierType) + stringValue(description) + stringValue(value)
 		if strings.TrimSpace(hashSource) == "" {
 			continue
 		}
 		now := time.Now().UTC()
 		items = append(items, &opendiscogsmodel.ReleaseItemIdentifier{
 			ReleaseItemID:  r.ID,
-			Description:    helper.FilterStr(&identifier.Description),
-			Type:           helper.FilterStr(&identifier.Type),
-			Value:          helper.FilterStr(&identifier.Value),
+			Description:    description,
+			Type:           identifierType,
+			Value:          value,
 			Hash:           helper.JavaStringHash(hashSource),
 			CreatedAt:      now,
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetTracks() []*opendiscogsmodel.ReleaseItemTrack {
 	items := make([]*opendiscogsmodel.ReleaseItemTrack, 0, len(r.Tracks))
 	for _, track := range r.Tracks {
-		hashSource := track.Position + track.Title + track.Duration
+		duration := helper.FilterStr(&track.Duration)
+		position := helper.FilterStr(&track.Position)
+		title := helper.FilterStr(&track.Title)
+		hashSource := stringValue(position) + stringValue(title) + stringValue(duration)
 		if strings.TrimSpace(hashSource) == "" {
 			continue
 		}
 		now := time.Now().UTC()
 		items = append(items, &opendiscogsmodel.ReleaseItemTrack{
 			ReleaseItemID:  r.ID,
-			Duration:       helper.FilterStr(&track.Duration),
-			Position:       helper.FilterStr(&track.Position),
-			Title:          helper.FilterStr(&track.Title),
+			Duration:       duration,
+			Position:       position,
+			Title:          title,
 			Hash:           helper.JavaStringHash(hashSource),
 			CreatedAt:      now,
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetFormats() []*opendiscogsmodel.ReleaseItemFormat {
 	items := make([]*opendiscogsmodel.ReleaseItemFormat, 0, len(r.Formats))
 	for _, format := range r.Formats {
 		description := reducedDescription(format.Descriptions)
-		hashSource := stringValue(format.Name) + stringValue(description) + stringValue(format.Text)
+		name := helper.FilterStr(format.Name)
+		text := helper.FilterStr(format.Text)
+		hashSource := stringValue(name) + stringValue(description) + stringValue(text)
 		if strings.TrimSpace(hashSource) == "" {
 			continue
 		}
@@ -579,15 +587,15 @@ func (r *XmlReleaseRelation) GetFormats() []*opendiscogsmodel.ReleaseItemFormat 
 		items = append(items, &opendiscogsmodel.ReleaseItemFormat{
 			ReleaseItemID:  r.ID,
 			Description:    description,
-			Name:           helper.FilterStr(format.Name),
+			Name:           name,
 			Quantity:       format.Quantity,
-			Text:           helper.FilterStr(format.Text),
+			Text:           text,
 			Hash:           helper.JavaStringHash(hashSource),
 			CreatedAt:      now,
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetCreditedArtists() []*opendiscogsmodel.ReleaseItemCreditedArtist {
@@ -610,7 +618,7 @@ func (r *XmlReleaseRelation) GetCreditedArtists() []*opendiscogsmodel.ReleaseIte
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetReleaseArtists() []*opendiscogsmodel.ReleaseItemArtist {
@@ -627,7 +635,7 @@ func (r *XmlReleaseRelation) GetReleaseArtists() []*opendiscogsmodel.ReleaseItem
 			LastModifiedAt: now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetLabels() []*opendiscogsmodel.LabelReleaseItem {
@@ -656,16 +664,21 @@ func (r *XmlReleaseRelation) GetLabels() []*opendiscogsmodel.LabelReleaseItem {
 			LastModifiedAt:   now,
 		})
 	}
-	return unique.Slice(items)
+	return items
 }
 
 func (r *XmlReleaseRelation) GetReleaseStyles() []*opendiscogsmodel.ReleaseItemStyle {
 	items := make([]*opendiscogsmodel.ReleaseItemStyle, 0, len(r.Styles))
-	for _, value := range unique.Slice(r.Styles) {
+	seen := make(map[string]struct{}, len(r.Styles))
+	for _, value := range r.Styles {
 		style := strings.TrimSpace(value)
 		if style == "" {
 			continue
 		}
+		if _, exists := seen[style]; exists {
+			continue
+		}
+		seen[style] = struct{}{}
 		now := time.Now().UTC()
 		items = append(items, &opendiscogsmodel.ReleaseItemStyle{
 			ReleaseItemID:  r.ID,
@@ -679,11 +692,16 @@ func (r *XmlReleaseRelation) GetReleaseStyles() []*opendiscogsmodel.ReleaseItemS
 
 func (r *XmlReleaseRelation) GetReleaseGenres() []*opendiscogsmodel.ReleaseItemGenre {
 	items := make([]*opendiscogsmodel.ReleaseItemGenre, 0, len(r.Genres))
-	for _, value := range unique.Slice(r.Genres) {
+	seen := make(map[string]struct{}, len(r.Genres))
+	for _, value := range r.Genres {
 		genre := strings.TrimSpace(value)
 		if genre == "" {
 			continue
 		}
+		if _, exists := seen[genre]; exists {
+			continue
+		}
+		seen[genre] = struct{}{}
 		now := time.Now().UTC()
 		items = append(items, &opendiscogsmodel.ReleaseItemGenre{
 			ReleaseItemID:  r.ID,

--- a/src/batch/xml.go
+++ b/src/batch/xml.go
@@ -632,11 +632,21 @@ func (r *XmlReleaseRelation) GetReleaseArtists() []*opendiscogsmodel.ReleaseItem
 
 func (r *XmlReleaseRelation) GetLabels() []*opendiscogsmodel.LabelReleaseItem {
 	items := make([]*opendiscogsmodel.LabelReleaseItem, 0, len(r.Labels))
+	type identity struct {
+		labelID          int32
+		categoryNotation string
+	}
+	seen := make(map[identity]struct{}, len(r.Labels))
 	for _, label := range r.Labels {
 		if !cache.LabelIDs.Contains(label.LabelID) {
 			continue
 		}
 		categoryNotation := strings.TrimSpace(label.CategoryNotation)
+		key := identity{labelID: label.LabelID, categoryNotation: categoryNotation}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
 		now := time.Now().UTC()
 		items = append(items, &opendiscogsmodel.LabelReleaseItem{
 			LabelID:          label.LabelID,

--- a/src/database/gorm.go
+++ b/src/database/gorm.go
@@ -58,6 +58,14 @@ func GetConnect(dsn string) (*gorm.DB, error) {
 
 // GetConnectInSchema creates a bounded-schema GORM connection without mutating the caller's DSN.
 func GetConnectInSchema(dsn, schemaName string) (*gorm.DB, error) {
+	return getConnectInSchema(dsn, schemaName, validatePostgreSQLServerVersion)
+}
+
+func getConnectInSchema(
+	dsn string,
+	schemaName string,
+	validateVersion postgreSQLServerVersionValidator,
+) (*gorm.DB, error) {
 	if len(dsn) == 0 {
 		return nil, errors.New("missing dsn")
 	}
@@ -83,6 +91,10 @@ func GetConnectInSchema(dsn, schemaName string) (*gorm.DB, error) {
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {
+		_ = sqlDB.Close()
+		return nil, err
+	}
+	if err := validateVersion(db); err != nil {
 		_ = sqlDB.Close()
 		return nil, err
 	}

--- a/src/database/gorm_test.go
+++ b/src/database/gorm_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -31,6 +32,15 @@ func TestConnect(t *testing.T) {
 		connectionPool, poolErr := connection.DB()
 		assert.NoError(t, poolErr)
 		assert.NoError(t, connectionPool.Close())
+
+		expected := errors.New("unsupported fixture version")
+		unsupportedConnection, unsupportedErr := getConnectInSchema(
+			dsn,
+			DefaultSchemaName,
+			func(*gorm.DB) error { return expected },
+		)
+		assert.Nil(t, unsupportedConnection)
+		assert.ErrorIs(t, unsupportedErr, expected)
 	})
 	t.Run("reject invalid pool limit", func(t *testing.T) {
 		assert.Error(t, ConfigurePool(DB, 0))

--- a/src/database/version.go
+++ b/src/database/version.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+const (
+	canonicalModelVersion             = "v0.2.3"
+	postgreSQLServerVersionQuery      = "select current_setting('server_version_num')::integer as server_version_num"
+	postgreSQLMajorVersionNumberScale = 10_000
+)
+
+type postgreSQLServerVersionNumber int
+
+type postgreSQLServerVersionValidator func(db *gorm.DB) error
+
+const minimumPostgreSQLServerVersion postgreSQLServerVersionNumber = 150_000
+
+type postgreSQLServerVersion struct {
+	Number postgreSQLServerVersionNumber `gorm:"column:server_version_num"`
+}
+
+func validatePostgreSQLServerVersion(db *gorm.DB) error {
+	var version postgreSQLServerVersion
+	if err := db.Raw(postgreSQLServerVersionQuery).Scan(&version).Error; err != nil {
+		return fmt.Errorf("read PostgreSQL server version: %w", err)
+	}
+	return requireSupportedPostgreSQLServerVersion(version.Number)
+}
+
+func requireSupportedPostgreSQLServerVersion(version postgreSQLServerVersionNumber) error {
+	if version >= minimumPostgreSQLServerVersion {
+		return nil
+	}
+	return fmt.Errorf(
+		"PostgreSQL %d is unsupported (server_version_num=%d): open-discogs-model %s requires PostgreSQL %d or newer; upgrade PostgreSQL before starting the import",
+		version.major(),
+		version,
+		canonicalModelVersion,
+		minimumPostgreSQLServerVersion.major(),
+	)
+}
+
+func (version postgreSQLServerVersionNumber) major() int {
+	return int(version) / postgreSQLMajorVersionNumberScale
+}

--- a/src/database/version_test.go
+++ b/src/database/version_test.go
@@ -1,0 +1,58 @@
+package database
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireSupportedPostgreSQLServerVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     postgreSQLServerVersionNumber
+		wantError   string
+		wantNoError bool
+	}{
+		{
+			name:      "reject PostgreSQL 14",
+			version:   140_012,
+			wantError: "PostgreSQL 14 is unsupported (server_version_num=140012): open-discogs-model v0.2.3 requires PostgreSQL 15 or newer; upgrade PostgreSQL before starting the import",
+		},
+		{name: "accept PostgreSQL 15", version: 150_000, wantNoError: true},
+		{name: "accept PostgreSQL 18", version: 180_001, wantNoError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := requireSupportedPostgreSQLServerVersion(test.version)
+			if test.wantNoError {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.wantError)
+		})
+	}
+}
+
+func TestValidatePostgreSQLServerVersion(t *testing.T) {
+	t.Run("accept supported server", func(t *testing.T) {
+		db, mock := newSchemaMock(t)
+		mock.ExpectQuery(regexp.QuoteMeta(postgreSQLServerVersionQuery)).
+			WillReturnRows(sqlmock.NewRows([]string{"server_version_num"}).AddRow(180_001))
+
+		require.NoError(t, validatePostgreSQLServerVersion(db))
+	})
+
+	t.Run("report version query failure", func(t *testing.T) {
+		db, mock := newSchemaMock(t)
+		expected := errors.New("version unavailable")
+		mock.ExpectQuery(regexp.QuoteMeta(postgreSQLServerVersionQuery)).WillReturnError(expected)
+
+		err := validatePostgreSQLServerVersion(db)
+		require.ErrorContains(t, err, "read PostgreSQL server version")
+		require.ErrorIs(t, err, expected)
+	})
+}


### PR DESCRIPTION
## Summary

- consume `open-discogs-model` v0.3.0 migration, lock, and import-revision contracts
- reject stale or missing dependencies before partial Master or Release imports
- deduplicate Release relations by canonical conflict keys and fail conflicting payloads
- harden signed Release Please commits, Docker cleanup, and multi-architecture release publishing

## Why

Consumer-owned migration state and permissive relation batching could diverge across Go and Java or silently select the wrong payload after interruption.

## Verification

- `go test -race -coverprofile=/tmp/open-discogs-go-final.cover ./...`
- total statement coverage: 100.0%
- `actionlint` and `shellcheck scripts/*.sh`
- verified no test-owned Docker resources remained

Production dump import remains blocked until the published Go and Java artifacts complete cross-language full-dump validation.
