### PR TITLE
fix: prevent release master deadlocks

### DIFF
--- a/docs/import-safety.md
+++ b/docs/import-safety.md
@@ -63,6 +63,12 @@ Independent sets such as Artist and Label may run together; overlapping Go and
 Java imports cannot write concurrently. Schema migration takes the same shared
 lock family, so migration cannot race an active importer.
 
+Concurrent Release chunks may touch the same Master when a main release changes
+or when several releases for one Master cross chunk boundaries. Each chunk
+therefore locks every affected Master row in ascending ID order before writing
+Release roots or reconciling `main_release_id`. This database lock order is
+independent of XML and worker scheduling order.
+
 A partial Master or Release import is admitted only when each omitted reference
 entity has a compatible successful checkpoint. A missing checkpoint, a stale
 checkpoint, or a same-date dump reissued with a different checksum fails before

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -12,9 +12,28 @@ against canonical `open-discogs-model` v0.3.0.
 | Reference ID cache | 25.4× lower median time; 99.88% fewer allocated bytes | 1,000,000 sequential IDs |
 | Durable import contract | Higher fixed latency and allocation | 12-record PostgreSQL fixture |
 | Successful-manifest preflight | 95.4% lower p50; avoided 64 MiB file I/O | Cached sparse file |
+| Release Master lock order | Prevented deadlock in 10/10 concurrent regression runs | 4 writers × 4 overlapping Masters |
 
 Do not compare rows across these harnesses. Their inputs, paths, and units are
 different.
+
+## Release Master lock order
+
+A production-like 2026-08 import with `chunk-size=5000` and `max-workers=4`
+exposed a PostgreSQL deadlock after one Release chunk had committed. The server
+deadlock graph showed four workers waiting on `UPDATE master AS target`. Before
+that failure, Artist committed 10,163,318 roots in 110.797 seconds, Label
+2,405,196 in 21.982 seconds, Master 2,579,897 in 82.008 seconds, and Release
+5,000 roots before the run failed. Those figures describe the failed run and
+are not a successful full-import benchmark.
+
+The regression runs four concurrent Release chunk writers over the same four
+Master rows in different input orders. After adding ascending Master row locks,
+10/10 runs completed without deadlock. The pre-change production run failed;
+the small regression was not run against the old binary, so this is a
+correctness result rather than a latency or throughput improvement claim. A
+successful full-dump retry is required before reporting end-to-end throughput,
+latency distribution, or RSS.
 
 ## Reference ID cache
 
@@ -77,6 +96,9 @@ go test ./src/batch -run '^$' \
 go test ./src/cache -run '^$' \
   -bench '^(BenchmarkIDSetLoadMillion|BenchmarkSyncMapIDSetLoadMillion)$' \
   -benchtime=3x -count=5 -benchmem
+go test ./src/batch \
+  -run '^TestConcurrentReleaseChunksLockOverlappingMastersInOneOrder$' \
+  -count=10
 ```
 
 Each command includes both comparison paths or implementations. The cache

--- a/src/batch/coverage_test.go
+++ b/src/batch/coverage_test.go
@@ -345,6 +345,18 @@ func TestWriteRelationChunkControlFlow(t *testing.T) {
 		actual := write(NewOrder(context.Background(), 1, 1, "unused", db))
 		require.Equal(t, wantError, actual.IsErr())
 	}
+	runRelease := func(t *testing.T, wantError bool, write func(Order) result.Result) {
+		db, mock, _ := newMockGorm(t)
+		mock.ExpectBegin()
+		expectReleaseMasterLock(mock)
+		if wantError {
+			mock.ExpectRollback()
+		} else {
+			mock.ExpectCommit()
+		}
+		actual := write(NewOrder(context.Background(), 1, 1, "unused", db))
+		require.Equal(t, wantError, actual.IsErr())
+	}
 
 	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, nil)} }
 	run(t, false, func(order Order) result.Result {
@@ -370,7 +382,7 @@ func TestWriteRelationChunkControlFlow(t *testing.T) {
 	run(t, true, func(order Order) result.Result {
 		return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{{ID: 1}}, false)
 	})
-	run(t, true, func(order Order) result.Result {
+	runRelease(t, true, func(order Order) result.Result {
 		return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{{ID: 1}}, false)
 	})
 
@@ -384,7 +396,7 @@ func TestWriteRelationChunkControlFlow(t *testing.T) {
 	run(t, true, func(order Order) result.Result {
 		return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{{ID: 1}}, true)
 	})
-	run(t, true, func(order Order) result.Result {
+	runRelease(t, true, func(order Order) result.Result {
 		return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{{ID: 1}}, true)
 	})
 }
@@ -428,9 +440,27 @@ func TestReferenceEntitiesUseDeterministicLockOrder(t *testing.T) {
 
 func TestReleaseUpdateAndReferenceFilters(t *testing.T) {
 	expected := errors.New("fixture")
-	db := poisonedGorm(t, expected)
+	poisonedDB := poisonedGorm(t, expected)
+	releaseID := int32(1)
+	require.ErrorIs(t, lockReleaseMasterRows(
+		NewOrder(context.Background(), 1, 1, "unused", poisonedDB),
+		[]int32{releaseID},
+		[]*XmlReleaseRelation{{ID: releaseID}, nil},
+	), expected)
+	mockDB, mock, _ := newMockGorm(t)
+	mock.ExpectBegin()
+	mock.ExpectQuery("select target.id").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(expected)
+	mock.ExpectRollback()
+	require.ErrorIs(t, writeReleaseRelationChunk(
+		NewOrder(context.Background(), 1, 1, "unused", mockDB),
+		ChunkMetadata{},
+		[]*XmlReleaseRelation{{ID: releaseID}},
+		false,
+	).Err(), expected)
 	actual := updateMasterMainReleases(
-		NewOrder(context.Background(), 1, 1, "unused", db),
+		NewOrder(context.Background(), 1, 1, "unused", poisonedDB),
 		[]*XmlReleaseRelation{nil},
 	)
 	require.ErrorIs(t, actual.Err(), expected)
@@ -459,26 +489,37 @@ func TestReferenceWriteFailuresInRelationChunks(t *testing.T) {
 	NewWriter = func(*gorm.DB) Writer { return writerStub{result: result.NewResult(0, nil)} }
 	expected := errors.New("fixture")
 
-	for _, write := range []func(Order) result.Result{
-		func(order Order) result.Result {
+	writes := []struct {
+		prepare func(sqlmock.Sqlmock)
+		write   func(Order) result.Result
+	}{
+		{write: func(order Order) result.Result {
 			return writeMasterRelationChunk(order, ChunkMetadata{}, []*XmlMasterRelation{{
-				ID:     1,
-				Genres: []string{"genre"},
+				ID: 1, Genres: []string{"genre"},
 			}}, false)
-		},
-		func(order Order) result.Result {
+		}},
+		{prepare: expectReleaseMasterLock, write: func(order Order) result.Result {
 			return writeReleaseRelationChunk(order, ChunkMetadata{}, []*XmlReleaseRelation{{
-				ID:     1,
-				Genres: []string{"genre"},
+				ID: 1, Genres: []string{"genre"},
 			}}, false)
-		},
-	} {
+		}},
+	}
+	for _, fixture := range writes {
 		db, mock, _ := newMockGorm(t)
 		mock.ExpectBegin()
+		if fixture.prepare != nil {
+			fixture.prepare(mock)
+		}
 		mock.ExpectExec(`INSERT INTO .*genre`).WithArgs("genre").WillReturnError(expected)
 		mock.ExpectRollback()
-		require.ErrorIs(t, write(NewOrder(context.Background(), 1, 1, "unused", db)).Err(), expected)
+		require.ErrorIs(t, fixture.write(NewOrder(context.Background(), 1, 1, "unused", db)).Err(), expected)
 	}
+}
+
+func expectReleaseMasterLock(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("select target.id").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 }
 
 func TestLabelSubLabelReconcileAccessors(t *testing.T) {

--- a/src/batch/release.go
+++ b/src/batch/release.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -10,6 +11,19 @@ import (
 	"github.com/dsub-io/go-open-discogs-batch/src/unique"
 	"github.com/dsub-io/open-discogs-model/model"
 )
+
+const releaseMasterLockSQL = `select target.id
+	from master as target
+	where target.id = any(?::integer[])
+	   or target.main_release_id = any(?::integer[])
+	   or exists (
+	       select 1
+	       from release_item as existing
+	       where existing.id = any(?::integer[])
+	         and existing.master_id = target.id
+	   )
+	order by target.id
+	for update`
 
 var (
 	labelReleaseItemRelation = integerNullableTextKeyRelation{
@@ -164,6 +178,9 @@ func writeReleaseRelationChunk(
 			return result.NewResult(0, deduplicateError)
 		}
 		rootIDs = unique.Slice(rootIDs)
+		if lockError := lockReleaseMasterRows(transactionOrder, rootIDs, items); lockError != nil {
+			return result.NewResult(0, lockError)
+		}
 		if referenceResult := writeReferenceEntities(
 			transactionOrder,
 			filterGenres(genres),
@@ -298,6 +315,40 @@ func writeReleaseRelationChunk(
 		}
 		return written.Sum(updateMasterMainReleases(transactionOrder, items))
 	})
+}
+
+func lockReleaseMasterRows(
+	order Order,
+	releaseIDs []int32,
+	releases []*XmlReleaseRelation,
+) error {
+	if len(releaseIDs) == 0 {
+		return nil
+	}
+	masterIDs := make([]int32, 0, len(releases))
+	for _, release := range releases {
+		if release == nil || release.MasterInfo.MasterID == nil {
+			continue
+		}
+		masterIDs = append(masterIDs, *release.MasterInfo.MasterID)
+	}
+	masterIDs = unique.Slice(masterIDs)
+	sort.Slice(masterIDs, func(left, right int) bool { return masterIDs[left] < masterIDs[right] })
+
+	type lockedMaster struct {
+		ID int32
+	}
+	locked := make([]lockedMaster, 0, len(masterIDs))
+	query := order.getDB().Raw(
+		releaseMasterLockSQL,
+		postgresArray(masterIDs),
+		postgresArray(releaseIDs),
+		postgresArray(releaseIDs),
+	).Scan(&locked)
+	if query.Error != nil {
+		return fmt.Errorf("lock release master rows: %w", query.Error)
+	}
+	return nil
 }
 
 func updateMasterMainReleases(order Order, releases []*XmlReleaseRelation) result.Result {

--- a/src/batch/release_dedupe_integration_test.go
+++ b/src/batch/release_dedupe_integration_test.go
@@ -2,6 +2,8 @@ package batch
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +14,72 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
+
+func TestConcurrentReleaseChunksLockOverlappingMastersInOneOrder(t *testing.T) {
+	postgres := testutils.GetDatabase(t, testutils.Postgres)
+	dsn := testutils.GetDsn(testutils.Postgres, postgres)
+	db, err := database.GetConnect(dsn)
+	require.NoError(t, err)
+	require.NoError(t, RunDDL(db))
+	db, err = database.GetConnect(dsn)
+	require.NoError(t, err)
+
+	const (
+		firstMasterID int32 = 2_000_000_100
+		masterCount         = 4
+		workerCount         = 4
+	)
+	now := time.Now().UTC()
+	for offset := int32(0); offset < masterCount; offset++ {
+		masterID := firstMasterID + offset
+		cache.MasterIDs.Add(masterID)
+		require.NoError(t, db.Create(&model.Master{
+			ID: masterID, CreatedAt: now, LastModifiedAt: now,
+		}).Error)
+	}
+	t.Cleanup(cache.ResetIDs)
+
+	start := make(chan struct{})
+	errorsByWorker := make(chan error, workerCount)
+	var workers sync.WaitGroup
+	for worker := int32(0); worker < workerCount; worker++ {
+		workers.Add(1)
+		go func(workerID int32) {
+			defer workers.Done()
+			items := make([]*XmlReleaseRelation, 0, masterCount)
+			for index := int32(0); index < masterCount; index++ {
+				masterOffset := (index + workerID) % masterCount
+				masterID := firstMasterID + masterOffset
+				releaseID := int32(2_000_001_000) + workerID*masterCount + masterOffset
+				title := fmt.Sprintf("worker-%d-master-%d", workerID, masterOffset)
+				items = append(items, &XmlReleaseRelation{
+					ID: releaseID, Title: &title,
+					MasterInfo: XmlReleaseMasterInfo{MasterID: &masterID, IsMaster: true},
+				})
+			}
+			<-start
+			written := writeReleaseRelationChunk(
+				NewOrder(context.Background(), masterCount, 1, "unused", db),
+				ChunkMetadata{Index: int64(workerID), ItemCount: masterCount},
+				items,
+				false,
+			)
+			errorsByWorker <- written.Err()
+		}(worker)
+	}
+	close(start)
+	workers.Wait()
+	close(errorsByWorker)
+	for writeError := range errorsByWorker {
+		require.NoError(t, writeError)
+	}
+
+	var linkedMasters int64
+	require.NoError(t, db.Model(&model.Master{}).
+		Where("id >= ? and id < ? and main_release_id is not null", firstMasterID, firstMasterID+masterCount).
+		Count(&linkedMasters).Error)
+	require.Equal(t, int64(masterCount), linkedMasters)
+}
 
 func TestReleaseRelationWriterPreventsPostgresSQLState21000AndRetriesIdempotently(t *testing.T) {
 	postgres := testutils.GetDatabase(t, testutils.Postgres)


### PR DESCRIPTION
## What changed

Release chunks now lock every affected Master row in ascending ID order before writing Release roots and reconciling `main_release_id`.

A PostgreSQL integration regression runs four concurrent writers against the same four Masters in different input orders.

## Why

The v2.3.6 production-like import reached Release and exposed a deadlock between concurrent `UPDATE master AS target` statements. The failed run remained durable: Artist, Label, and Master completed, one 5,000-item Release chunk committed, and the run was recorded as failed.

## Validation

- 10/10 concurrent PostgreSQL regression runs passed
- `go test -race -covermode=atomic ./...`
- 100.0% statement coverage with zero uncovered statements
- Dump-to-PostgreSQL E2E passed
- Docker cleanup verified: 0 containers, 0 networks, 0 volumes

No full-import performance improvement is claimed. The failed-run measurements and regression scope are recorded in `docs/performance.md`.
