### PR TITLE
perf: consume model 0.3.2 query index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Stream Discogs monthly public data dumps into PostgreSQL with bounded memory,
 durable progress, and idempotent recovery.
 
 This release consumes canonical
-[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.1.
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.2.
 Go and Java therefore apply the same migration bytes and import contracts. This
 is an independent project and is not endorsed by Discogs.
 

--- a/docs/import-safety.md
+++ b/docs/import-safety.md
@@ -2,7 +2,7 @@
 
 This is the operational contract for dump discovery, admission, commits,
 recovery, and reader visibility. The schema contract is canonical
-[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.1,
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.2,
 shared with the Java importer.
 
 > [!CAUTION]

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -3,7 +3,7 @@
 These are bounded measurements of named changes, not forecasts for a full dump
 or different hardware. They also do not approve a production import: both
 batch implementations still require release and cross-language validation
-against canonical `open-discogs-model` v0.3.1.
+against canonical `open-discogs-model` v0.3.2.
 
 ## Results at a glance
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsub-io/open-discogs-model v0.3.1
+	github.com/dsub-io/open-discogs-model v0.3.2
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dsub-io/open-discogs-model v0.3.1 h1:mLmPg4cjV5sQTsLSSF/c9hjie9C6SCT/Z0Vz1r8Xe1U=
-github.com/dsub-io/open-discogs-model v0.3.1/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
+github.com/dsub-io/open-discogs-model v0.3.2 h1:2UtYWePwB3pACtSTUxIzPzDR8nHDri6oV2RHK9+DYFQ=
+github.com/dsub-io/open-discogs-model v0.3.2/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=


### PR DESCRIPTION
## What changed

- update the canonical model dependency from v0.3.1 to v0.3.2
- make the Go migrator apply V022 before import work starts
- align README and operational documentation with the consumed model release

## Why

V022 adds the canonical release combined-filter index required by the optimized API query path. Both batch implementations must consume the same model release so either migrator applies identical migration bytes.

## Measured impact

On the model-owned 1,000,000-release fixture, combined-filter SQL p99 decreased from 6.856 ms to 0.225 ms (-96.7%). The plan changed from 4,386 heap blocks plus a top-N sort to an ordered 53-buffer index scan. The index size was 31,522,816 bytes (+6.5% on the post-V007 test database). Importer throughput is unchanged because this PR changes only the canonical migration dependency.

## Validation

- `gofmt -l .`
- `go mod tidy -diff`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./...`
- 100.0% statement coverage with no uncovered statements
- Docker cleanup verified: 0 containers, 0 networks, 0 volumes