### PR TITLE
perf: consume model 0.4.0 exact lookup indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Stream Discogs monthly public data dumps into PostgreSQL with bounded memory,
 durable progress, and idempotent recovery.
 
 This release consumes canonical
-[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.3.2.
+[`open-discogs-model`](https://github.com/dsub-io/open-discogs-model) v0.4.0.
 Go and Java therefore apply the same migration bytes and import contracts. This
 is an independent project and is not endorsed by Discogs.
 
 > [!CAUTION]
-> **Production import is not approved yet.** Publish both batch implementations
-> against model v0.3.1 and complete cross-language migration, recovery, and
-> full-dump validation before starting or resuming a production import.
+> Stop every Go and Java importer before applying model v0.4.0. Upgrade both
+> implementations before resuming imports; an older artifact rejects a database
+> whose canonical migration ledger is newer than its bundled model.
 
 - [Import safety and recovery](docs/import-safety.md)
 - [Performance measurements](docs/performance.md)
@@ -77,7 +77,7 @@ the importer never creates the database.
 | Existing schema | `USAGE` and `CREATE` on the schema, table writes, and migration DDL authority |
 | Restricted batch role | A DBA prepares the schema, extension, and grants first |
 
-Model v0.3.1 migrations are the only schema source of truth. Migration V007
+Model v0.4.0 migrations are the only schema source of truth. Migration V007
 uses `CREATE EXTENSION IF NOT EXISTS pg_trgm`; allow the migration role to
 install this trusted extension or have a DBA pre-install it in a stable schema
 visible to the migration role. Catalog tables are still created only in the

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dsub-io/open-discogs-model v0.3.2
+	github.com/dsub-io/open-discogs-model v0.4.0
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dsub-io/open-discogs-model v0.3.2 h1:2UtYWePwB3pACtSTUxIzPzDR8nHDri6oV2RHK9+DYFQ=
-github.com/dsub-io/open-discogs-model v0.3.2/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
+github.com/dsub-io/open-discogs-model v0.4.0 h1:1IQiZ5hT/zein3nPsSy5n3xErv50O8IYecEFzsRNYlI=
+github.com/dsub-io/open-discogs-model v0.4.0/go.mod h1:V5lT/YpZiw5TuUBcXSLor0TH4AisrCg5SRHHz7IcPE4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=


### PR DESCRIPTION
Updates the Go importer to the canonical model 0.4.0 migration inventory.

- applies V023 exact label/catalog and identifier lookup indexes through the shared migration ledger
- keeps Go and Java importers on the same canonical migration bytes
- documents that all importers must be stopped for migration and upgraded before imports resume

Validation:
- gofmt verification
- go mod tidy -diff
- go vet ./...
- go test -race -coverprofile=coverage.out -covermode=atomic ./... (100.0%)
- owned Docker cleanup: 0 containers, 0 networks, 0 volumes