### PR TITLE
fix: use patched Go 1.26.6 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Vet packages
         run: go vet ./...
 
+      - name: Scan known vulnerabilities
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+
       - name: Test with race detector and coverage
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23 AS build
+FROM golang:1.26.6-alpine3.23 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dsub-io/go-open-discogs-batch
 
-go 1.26
+go 1.26.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
Updates every Go batch build boundary to the patched Go 1.26.6 toolchain.

- pins the module toolchain so setup-go cannot select an older 1.26 patch
- updates the Docker builder from Go 1.26.4 to 1.26.6
- adds govulncheck to the required CI job so standard-library regressions are blocked

Validation:
- go version: go1.26.6
- go mod tidy -diff
- go vet ./...
- govulncheck: 0 reachable vulnerabilities
- go test -race with exact 100.0% coverage
- Docker image build from golang:1.26.6-alpine3.23
- owned Docker cleanup: 0 containers, 0 networks, 0 volumes